### PR TITLE
Status_Monitoring: Encode RRD errors returned in JSON. Fixes #9601

### DIFF
--- a/sysutils/pfSense-Status_Monitoring/Makefile
+++ b/sysutils/pfSense-Status_Monitoring/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-Status_Monitoring
-PORTVERSION=	1.7.7
+PORTVERSION=	1.7.8
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/sysutils/pfSense-Status_Monitoring/files/usr/local/www/rrd_fetch_json.php
+++ b/sysutils/pfSense-Status_Monitoring/files/usr/local/www/rrd_fetch_json.php
@@ -167,7 +167,7 @@ foreach ($side as $settings) {
 
 	$rrd_array = rrd_fetch($settings['rrd_file'], $rrd_options);
 	if (!($rrd_array)) {
-		die ('{ "error" : "' . rrd_error() . '" }');
+		die ('{ "error" : ' . json_encode(rrd_error()) . ' }');
 	}
 
 	$ds_list = array_keys ($rrd_array['data']);


### PR DESCRIPTION
(cherry picked from commit c52e39222c61f5fa98cf384fcd86020e8fe53a49)