### PR TITLE
OpenVPN export: Only add tun-ipv6 for legacy clients. Fixes #11217

### DIFF
--- a/security/pfSense-pkg-openvpn-client-export/Makefile
+++ b/security/pfSense-pkg-openvpn-client-export/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	pfSense-pkg-openvpn-client-export
 PORTVERSION=	1.5
-PORTREVISION=	4
+PORTREVISION=	5
 CATEGORIES=	security
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/security/pfSense-pkg-openvpn-client-export/files/usr/local/pkg/openvpn-client-export.inc
+++ b/security/pfSense-pkg-openvpn-client-export/files/usr/local/pkg/openvpn-client-export.inc
@@ -193,8 +193,11 @@ EOF;
 		$conf .= "dev {$devmode}{$nl}";
 	}
 
-	/* TODO: This has been deprecated in OpenVPN 2.4 but does not yet cause a fatal error. */
-	if (!empty($settings['tunnel_networkv6']) && ($expformat != "inlinedroid") && ($expformat != "inlineios")) {
+	/* This has been deprecated in OpenVPN 2.4 and removed from OpenVPN 2.5. */
+	if ($legacy &&
+	    (!empty($settings['tunnel_networkv6']) &&
+	    ($expformat != "inlinedroid") &&
+	    ($expformat != "inlineios"))) {
 		$conf .= "tun-ipv6{$nl}";
 	}
 	$conf .= "persist-tun{$nl}";
@@ -852,10 +855,6 @@ function openvpn_client_export_sharedkey_config($srvid, $useaddr, $proxy, $nokey
 	// add basic settings
 	$conf = "dev tun\n";
 
-	/* TODO: This has been deprecated in OpenVPN 2.4 but does not yet cause a fatal error. */
-	if(! empty($settings['tunnel_networkv6'])) {
-		$conf .= "tun-ipv6\n";
-	}
 	$conf .= "persist-tun\n";
 	$conf .= "persist-key\n";
 	$conf .= "cipher {$cipher}\n";


### PR DESCRIPTION
(cherry picked from commit 1c53b446dbf4b06057d33c6ecbee5f963b2df955)