### PR TITLE
Set up the certificate authentication for the pkg repo when necessary.

### DIFF
--- a/sysutils/pfSense-upgrade/Makefile
+++ b/sysutils/pfSense-upgrade/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-upgrade
-PORTVERSION=	0.98
+PORTVERSION=	0.99
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/sysutils/pfSense-upgrade/files/pfSense-upgrade
+++ b/sysutils/pfSense-upgrade/files/pfSense-upgrade
@@ -294,6 +294,19 @@ abi_setup() {
 	echo "ABI=${ABI}" > /usr/local/etc/pkg.conf
 	echo "ALTABI=${ALTABI}" >> /usr/local/etc/pkg.conf
 
+	AUTH_CA="/etc/ssl/netgate-ca.pem"
+	AUTH_CERT="/etc/ssl/pfSense-repo-custom.cert"
+	AUTH_KEY="/etc/ssl/pfSense-repo-custom.key"
+	if [ -f "${AUTH_CA}" -a -f "${AUTH_CERT}" -a -f "${AUTH_KEY}" ]; then
+		cat << EOF >> /usr/local/etc/pkg.conf
+PKG_ENV {
+	SSL_CA_CERT_FILE=${AUTH_CA}
+	SSL_CLIENT_CERT_FILE=${AUTH_CERT}
+	SSL_CLIENT_KEY_FILE=${AUTH_KEY}
+}
+EOF
+	fi
+
 	# XXX Replace it by a function that detect thoth hardware
 	if [ "${arch}" = "aarch64" ]; then
 		cat << EOF >> /usr/local/etc/pkg.conf


### PR DESCRIPTION
Note that this change do not interfere with the normal operations when the
certificates files are not present.

(cherry picked from commit 971df7fc333c4cf0ebf1f27d1d02a98e01abd633)