### PR TITLE
www/e2guardian: refresh configure.ac patch for 5.3.8

### DIFF
--- a/www/e2guardian/files/patch-configure.ac
+++ b/www/e2guardian/files/patch-configure.ac
@@ -1,18 +1,19 @@
---- configure.ac.orig	2020-01-27 08:24:39 UTC
+--- configure.ac.orig   2023-11-25 14:07:26 UTC
 +++ configure.ac
 @@ -6,7 +6,6 @@ AC_DEFINE([FD_SETSIZE_OVERIDE],[""],[Define to allow D
  
  AC_PREREQ(2.57)
- AC_INIT(e2guardian, 5.3.4)
+-AC_INIT(e2guardian, 5.3.8)
 -AM_INIT_AUTOMAKE
++AC_INIT(e2guardian, 5.3.8)
  AC_CONFIG_HEADERS([dgconfig.h])
  AC_CONFIG_MACRO_DIR([m4])
  AM_INIT_AUTOMAKE([subdir-objects])
-@@ -617,7 +616,6 @@ else
- 	AC_MSG_RESULT(yes)
- 	dnsauth=true
- 	DNSAUTHSUPPORT=""
--	LIBS="${LIBS} -lresolv"
- 	AC_DEFINE([PRT_DNSAUTH],[],[Define to enable DNS auth plugin])
+@@ -619,7 +618,6 @@ else
+         AC_MSG_RESULT(yes)
+         dnsauth=true
+         DNSAUTHSUPPORT=""
+-        LIBS="${LIBS} -lresolv"
+         AC_DEFINE([PRT_DNSAUTH],[],[Define to enable DNS auth plugin])
  fi],
  [


### PR DESCRIPTION
## Summary
- update the configure.ac patch context to match the 5.3.8 release
- keep the FreeBSD-specific removals of the redundant AM_INIT_AUTOMAKE and the libresolv addition

## Testing
- make patch *(fails: GNU make cannot parse the BSD-style Makefile in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d08c276e14832e80af9a2ded0bd9ef