### PR TITLE
www/e2guardian: ensure consistent OpenSSL libs

### DIFF
--- a/www/e2guardian/Makefile
+++ b/www/e2guardian/Makefile
@@ -60,8 +60,8 @@ DEBUG_CONFIGURE_OFF=		--with-dgdebug=off --with-newdebug=off
 DEBUG_CONFIGURE_ON=		--with-dgdebug=on --with-newdebug=on
 SSL_MITM_USES=			ssl
 SSL_MITM_CONFIGURE_ENABLE=	sslmitm
-SSL_MITM_CONFIGURE_ENV=		OPENSSL_LIBS="-lssl -lcrypto" \
-				OPENSSL_CFLAGS="-I${OPENSSLINC} -L${OPENSSLLIB}"
+SSL_MITM_CONFIGURE_ENV=		OPENSSL_LIBS="-L${OPENSSLLIB} -lssl -lcrypto" \
+				OPENSSL_CFLAGS="-I${OPENSSLINC}"
 
 .include <bsd.port.options.mk>
 


### PR DESCRIPTION
## Summary
- ensure the SSL MITM plugin links both OpenSSL libraries from the same provider by adding the library path to OPENSSL_LIBS
- limit OPENSSL_CFLAGS to header search paths so it no longer overrides the library path

## Testing
- `make -C www/e2guardian clean` *(fails in this Linux environment because GNU make does not understand the FreeBSD-specific .include directive; bmake is unavailable)*
- `make -C www/e2guardian` *(same as above)*
- `make -C www/e2guardian clean DEFAULT_VERSIONS+=ssl=openssl` *(same as above)*
- `make -C www/e2guardian DEFAULT_VERSIONS+=ssl=openssl` *(same as above)*

------
https://chatgpt.com/codex/tasks/task_e_68d0952c5a88832ebe846c03d001f527