### PR TITLE
www/e2guardian: use explicit OpenSSL library paths

### DIFF
--- a/www/e2guardian/Makefile
+++ b/www/e2guardian/Makefile
@@ -60,7 +60,7 @@ DEBUG_CONFIGURE_OFF=		--with-dgdebug=off --with-newdebug=off
 DEBUG_CONFIGURE_ON=		--with-dgdebug=on --with-newdebug=on
 SSL_MITM_USES=			ssl
 SSL_MITM_CONFIGURE_ENABLE=	sslmitm
-SSL_MITM_CONFIGURE_ENV=		OPENSSL_LIBS="-L${OPENSSLLIB} -lssl -lcrypto" \
+SSL_MITM_CONFIGURE_ENV=		OPENSSL_LIBS="${OPENSSLLIB}/libssl.so ${OPENSSLLIB}/libcrypto.so" \
 				OPENSSL_CFLAGS="-I${OPENSSLINC}"
 
 .include <bsd.port.options.mk>


### PR DESCRIPTION
## Summary
- set the SSL_MITM OPENSSL_LIBS configure environment to point at libssl.so and libcrypto.so within ${OPENSSLLIB}

## Testing
- make -C www/e2guardian clean *(fails: missing separator because GNU make is being used instead of FreeBSD make)*
- make -C www/e2guardian *(fails: missing separator because GNU make is being used instead of FreeBSD make)*
- env DEFAULT_VERSIONS="ssl=openssl" make -C www/e2guardian *(fails: missing separator because GNU make is being used instead of FreeBSD make)*
- env DEFAULT_VERSIONS="ssl=openssl30" make -C www/e2guardian *(fails: missing separator because GNU make is being used instead of FreeBSD make)*

------
https://chatgpt.com/codex/tasks/task_e_68d09d8aa98c832ea92b98f1f628e492