### PR TITLE
www/e2guardian: pass OPENSSL_LDFLAGS to configure

### DIFF
--- a/www/e2guardian/Makefile
+++ b/www/e2guardian/Makefile
@@ -61,7 +61,8 @@ DEBUG_CONFIGURE_ON=		--with-dgdebug=on --with-newdebug=on
 SSL_MITM_USES=			ssl
 SSL_MITM_CONFIGURE_ENABLE=	sslmitm
 SSL_MITM_CONFIGURE_ENV=		OPENSSL_LIBS="${OPENSSLLIB}/libssl.so ${OPENSSLLIB}/libcrypto.so" \
-				OPENSSL_CFLAGS="-I${OPENSSLINC}"
+				OPENSSL_CFLAGS="-I${OPENSSLINC}" \
+				OPENSSL_LDFLAGS="-L${OPENSSLLIB}"
 
 .include <bsd.port.options.mk>
 


### PR DESCRIPTION
## Summary
- ensure the SSL MITM option forwards OPENSSL_LDFLAGS alongside the existing OPENSSL_LIBS and OPENSSL_CFLAGS

## Testing
- make -C www/e2guardian clean  # fails: GNU make in container does not understand .include from bsd.port.mk


------
https://chatgpt.com/codex/tasks/task_e_68d0a24b2f34832e9f7c0ebefef8ab43