### PR TITLE
Fix CONFLICTS_WITH typo in Kontrol-pkg-E2guardian5

### DIFF
--- a/www/Kontrol-pkg-E2guardian5/Makefile
+++ b/www/Kontrol-pkg-E2guardian5/Makefile
@@ -19,7 +19,7 @@ RUN_DEPENDS=	${LOCALBASE}/sbin/e2guardian:www/e2guardian \
 		e2guardian>=0:www/e2guardian
 
 
-CONFLITS_WITH=	www/e2guardian5
+CONFLICTS_WITH=	www/e2guardian5
 
 NO_BUILD=	yes
 NO_MTREE=	yes


### PR DESCRIPTION
## Summary
- fix the CONFLICTS_WITH variable name typo in the Kontrol-pkg-E2guardian5 port Makefile

## Testing
- make check-plist *(fails: GNU make in this environment does not understand the .include directive required by FreeBSD ports makefiles)*

------
https://chatgpt.com/codex/tasks/task_e_68d15c940808832e9d3cbc9e26a4cb91