### PR TITLE
net/kea: build from public distfiles

### DIFF
--- a/net/kea/Makefile
+++ b/net/kea/Makefile
@@ -4,9 +4,6 @@ PORTREVISION=	1
 CATEGORIES=	net
 MASTER_SITES=	ISC/kea/${DISTVERSION}
 
-PATCHFILES+=	netgate.diff:-p1
-MASTER_SITE_BACKUP=
-FETCH_DEPENDS=	curl:ftp/curl
 
 MAINTAINER=	apevnev@me.com
 COMMENT=	Alternative DHCP implementation by ISC
@@ -67,10 +64,5 @@ post-install:
 	${CP} *.8 ${STAGEDIR}${PREFIX}/share/man/man8
 	@cd ${WRKSRC}/_build/src/bin/keactrl; \
 	for i in *.conf; do ${CP} $$i ${STAGEDIR}${PREFIX}/etc/kea/$$i.sample; done
-
-pre-fetch:
-	if [ ! -f "${DISTDIR}/${DIST_SUBDIR}/netgate.diff" ] || [ "$$( awk '$$1 == "SHA256" && $$2 == "(netgate.diff)" {print $$4}' "${DISTINFO_FILE}" )" != "$$( sha256 -q "${DISTDIR}/${DIST_SUBDIR}/netgate.diff" )" ]; then \
-		curl -vv --header 'PRIVATE-TOKEN: ${GITLAB_TOKEN}' -o "${DISTDIR}/${DIST_SUBDIR}/netgate.diff" "https://gitlab.netgate.com/api/v4/projects/8/repository/files/net%2Fkea%2Ffiles%2Fnetgate.diff/raw?ref=plus-devel"; \
-	fi
 
 .include <bsd.port.mk>

--- a/net/kea/distinfo
+++ b/net/kea/distinfo
@@ -1,5 +1,3 @@
 TIMESTAMP = 1756327795
 SHA256 (kea-3.0.1.tar.xz) = ec84fec4bb7f6b9d15a82e755a571e9348eb4d6fbc62bb3f6f1296cd7a24c566
 SIZE (kea-3.0.1.tar.xz) = 6632284
-SHA256 (netgate.diff) = 69252e564b4f0619f962007113690cdba63975f7f938a10d92a807c01f04a93b
-SIZE (netgate.diff) = 8074


### PR DESCRIPTION
## Summary
- remove the netgate-specific patch fetch that depended on an internal GitLab host
- update distinfo so the port only references the public ISC distfile

## Testing
- not run (requires FreeBSD make for ports framework)

------
https://chatgpt.com/codex/tasks/task_e_68f96b8f2000832ea84503a1a6ef7e6c