### PR TITLE
Fix Kontrol-upgrade staging of repo setup script

### DIFF
--- a/sysutils/pfSense-upgrade/Makefile
+++ b/sysutils/pfSense-upgrade/Makefile
@@ -1,4 +1,4 @@
-PORTNAME=	pfSense-upgrade
+PORTNAME=	Kontrol-upgrade
 PORTVERSION=	1.3.15
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty
@@ -6,18 +6,20 @@ DISTFILES=	# empty
 EXTRACT_ONLY=	# empty
 
 MAINTAINER=	coreteam@pfsense.org
-COMMENT=	pfSense upgrade script
+COMMENT=	Kontrol upgrade script
 
 LICENSE=	APACHE20
 
 NO_MTREE=	yes
 NO_BUILD=	yes
 
+PRODUCT_NAME=	${PORTNAME:S/-upgrade//}
+
 PLIST_FILES=	libexec/install-boot.sh \
-		libexec/pfSense-upgrade \
+		libexec/${PRODUCT_NAME}-upgrade \
 		sbin/install-boot \
-		sbin/pfSense-repo-setup \
-		sbin/pfSense-upgrade
+		sbin/${PRODUCT_NAME}-repo-setup \
+		sbin/${PRODUCT_NAME}-upgrade
 
 do-extract:
 	@${MKDIR} ${WRKSRC}
@@ -26,14 +28,16 @@ do-extract:
 do-install:
 	${MKDIR} ${STAGEDIR}${PREFIX}/sbin
 	${MKDIR} ${STAGEDIR}${PREFIX}/libexec
-	${MKDIR} ${STAGEDIR}${PREFIX}/share/pfSense
-	${INSTALL_SCRIPT} ${WRKSRC}/pfSense-upgrade \
+	${MKDIR} ${STAGEDIR}${PREFIX}/share/${PRODUCT_NAME}
+	${INSTALL_SCRIPT} ${WRKSRC}/${PRODUCT_NAME}-upgrade \
 		${STAGEDIR}${PREFIX}/libexec
-	${INSTALL_SCRIPT} ${WRKSRC}/pfSense-upgrade.wrapper \
-		${STAGEDIR}${PREFIX}/sbin/pfSense-upgrade
+	${INSTALL_SCRIPT} ${WRKSRC}/${PRODUCT_NAME}-upgrade.wrapper \
+		${STAGEDIR}${PREFIX}/sbin/${PRODUCT_NAME}-upgrade
 	${INSTALL_SCRIPT} ${WRKSRC}/install-boot \
 		${STAGEDIR}${PREFIX}/sbin
 	${INSTALL_SCRIPT} ${WRKSRC}/install-boot.sh \
 		${STAGEDIR}${PREFIX}/libexec
+	${INSTALL_SCRIPT} ${WRKSRC}/${PRODUCT_NAME}-repo-setup \
+		${STAGEDIR}${PREFIX}/sbin/${PRODUCT_NAME}-repo-setup
 
 .include <bsd.port.mk>

--- a/sysutils/pfSense-upgrade/pkg-descr
+++ b/sysutils/pfSense-upgrade/pkg-descr
@@ -1,3 +1,3 @@
-pfSense upgrade script
+Kontrol upgrade script
 
 WWW: https://www.pfsense.org/


### PR DESCRIPTION
## Summary
- rename the port metadata to Kontrol and derive the product name from the port name
- install the Kontrol repo setup helper so it is present in the staging directory
- update the package description to reflect the Kontrol branding

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f97ce92890832eb9b480bb5837b91f