### PR TITLE
www/squid-legacy: force C++14 standard

### DIFF
--- a/www/squid-legacy/Makefile
+++ b/www/squid-legacy/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	squid
 DISTVERSION=	4.15
+PORTREVISION=	1
 CATEGORIES=	www
 MASTER_SITES=	http://www2.pl.squid-cache.org/Versions/v4/ \
 		http://ca.squid-cache.org/Versions/v4/ \
@@ -25,6 +26,7 @@ LICENSE=	GPLv2
 LICENSE_FILE=	${WRKSRC}/COPYING
 
 USES=		compiler:c++11-lib cpe perl5 shebangfix tar:xz
+USE_CXXSTD=	c++14
 
 CONFLICTS=	squid3 squid-devel
 CPE_VENDOR=	squid-cache


### PR DESCRIPTION
## Summary
- force www/squid-legacy to build with the C++14 standard to retain removed libstdc++ adapters
- bump PORTREVISION for the rebuild

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fa69302d58832e903e9897818a8a17