### PR TITLE
www/squid-legacy: restore build with modern toolchains

### DIFF
--- a/www/squid-legacy/Makefile
+++ b/www/squid-legacy/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	squid
 DISTVERSION=	4.15
+PORTREVISION=	2
 CATEGORIES=	www
 MASTER_SITES=	http://www2.pl.squid-cache.org/Versions/v4/ \
 		http://ca.squid-cache.org/Versions/v4/ \
@@ -25,6 +26,7 @@ LICENSE=	GPLv2
 LICENSE_FILE=	${WRKSRC}/COPYING
 
 USES=		compiler:c++11-lib cpe perl5 shebangfix tar:xz
+USE_CXXSTD=	c++14
 
 CONFLICTS=	squid3 squid-devel
 CPE_VENDOR=	squid-cache

--- a/www/squid-legacy/files/patch-src_ssl_support.cc
+++ b/www/squid-legacy/files/patch-src_ssl_support.cc
@@ -1,0 +1,23 @@
+--- src/ssl/support.cc.orig	2021-05-30 20:00:00 UTC
++++ src/ssl/support.cc
+@@
+-    ssl_ex_index_cert_error_check = SSL_get_ex_new_index(0, (void *) "cert_error_check", NULL, &ssl_dupAclChecklist, &ssl_freeAclChecklist);
++#if OPENSSL_VERSION_NUMBER >= 0x30000000L
++    ssl_ex_index_cert_error_check = SSL_get_ex_new_index(0, (void *) "cert_error_check", NULL, &ssl_dupAclChecklist_ossl3, &ssl_freeAclChecklist);
++#else
++    ssl_ex_index_cert_error_check = SSL_get_ex_new_index(0, (void *) "cert_error_check", NULL, &ssl_dupAclChecklist, &ssl_freeAclChecklist);
++#endif
+@@
+     CRYPTO_set_ex_data(to, idx, dupChecklist);
+     return 1;
+ }
+
++#if OPENSSL_VERSION_NUMBER >= 0x30000000L
++static int
++ssl_dupAclChecklist_ossl3(CRYPTO_EX_DATA *to, const CRYPTO_EX_DATA *from,
++    void **from_d, int idx, long argl, void *argp)
++{
++    void *data = from_d ? *from_d : NULL;
++    return ssl_dupAclChecklist(to, const_cast<CRYPTO_EX_DATA *>(from), data, idx, argl, argp);
++}
++#endif


### PR DESCRIPTION
## Summary
- force the www/squid-legacy port to compile with the C++14 standard to retain removed libc++ adaptors
- add an OpenSSL 3 compatibility shim for ssl_dupAclChecklist and bump PORTREVISION for the rebuild

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fa69302d58832e903e9897818a8a17