### PR TITLE
Improve interface handling for e2guardian listen interfaces

### DIFF
--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc
@@ -502,11 +502,27 @@ EOF;
 }
 
 function dg_get_real_interface_address($iface) {
-	global $config;
-	$iface = convert_friendly_interface_to_real_interface_name($iface);
-	$line = trim(shell_exec("ifconfig $iface | grep inet | grep -v inet6"));
-	list($dummy, $ip, $dummy2, $netmask) = explode(" ", $line);
-	return array($ip, long2ip(hexdec($netmask)));
+        global $config;
+        $iface = convert_friendly_interface_to_real_interface_name($iface);
+        $line = trim(shell_exec("ifconfig $iface | grep inet | grep -v inet6"));
+        list($dummy, $ip, $dummy2, $netmask) = explode(" ", $line);
+        return array($ip, long2ip(hexdec($netmask)));
+}
+
+function dg_normalize_interface_list($iface_value)
+{
+        if (is_array($iface_value)) {
+                $iface_list = $iface_value;
+        } else {
+                $iface_list = explode(",", (string)$iface_value);
+        }
+
+        $iface_list = array_map('trim', $iface_list);
+        $iface_list = array_filter($iface_list, function ($value) {
+                return ($value !== '');
+        });
+
+        return array_values($iface_list);
 }
 
 function check_ca_hashes() {
@@ -562,35 +578,36 @@ function e2g_generate_rules($type) {
 		return;
 	}
 
-	// Proxy Interface(s)
-	$proxy_ifaces_friendly = explode(",", $e2g_conf['interface']);
-	$proxy_ifaces = array_map('convert_friendly_interface_to_real_interface_name', $proxy_ifaces_friendly);
-	$proxy_iface_ips = array();
-	foreach ($proxy_ifaces_friendly as $idx => $iface_friendly) {
-		$iface_real = $proxy_ifaces[$idx];
-		if (empty($iface_real)) {
-			continue;
-		}
-		$iface_details = dg_get_real_interface_address($iface_friendly);
-		if (!empty($iface_details[0])) {
-			$proxy_iface_ips[$iface_real] = $iface_details[0];
-		}
-	}
-	$default_redirect_ip = (!empty($proxy_iface_ips) ? reset($proxy_iface_ips) : '127.0.0.1');
+        // Proxy Interface(s)
+        $proxy_ifaces_friendly = dg_normalize_interface_list($e2g_conf['interface']);
+        $proxy_ifaces = array_map('convert_friendly_interface_to_real_interface_name', $proxy_ifaces_friendly);
 	// Transparent Proxy Interface(s)
 	if ($e2g_conf['transparent_proxy'] == "on") {
-		if (! bp_in_array('lo0',$proxy_ifaces)) {
-			$proxy_ifaces[] = 'lo0';
-		}
+                if (! bp_in_array('lo0',$proxy_ifaces)) {
+                        $proxy_ifaces[] = 'lo0';
+                        $proxy_ifaces_friendly[] = 'lo0';
+                }
                 $transparent_ifaces = explode(",", $e2g_conf['transparent_active_interface']);
                 $transparent_ifaces = array_map('trim', $transparent_ifaces);
                 $transparent_ifaces = array_map('convert_friendly_interface_to_real_interface_name', $transparent_ifaces);
                 // Trailing commas or empty interface slots break pf rule generation ("no rdr on  proto ...")
                 // which disables the transparent NAT rules entirely.
                 $transparent_ifaces = array_filter($transparent_ifaces);
-	} else {
-		$transparent_ifaces = array();
-	}
+        } else {
+                $transparent_ifaces = array();
+        }
+        $proxy_iface_ips = array();
+        foreach ($proxy_ifaces_friendly as $idx => $iface_friendly) {
+                $iface_real = $proxy_ifaces[$idx];
+                if (empty($iface_real)) {
+                        continue;
+                }
+                $iface_details = dg_get_real_interface_address($iface_friendly);
+                if (!empty($iface_details[0])) {
+                        $proxy_iface_ips[$iface_real] = $iface_details[0];
+                }
+        }
+        $default_redirect_ip = (!empty($proxy_iface_ips) ? reset($proxy_iface_ips) : '127.0.0.1');
         // SSL Intercept Interface(s)
         $ssl_intercept_enabled = e2g_ssl_intercept_is_enabled($e2g_conf);
 
@@ -2093,15 +2110,15 @@ EOF;
 	$filtergroups = ($count > 1?($count -1):1);
 	$filterip = "";
 	$filterports = "";
-	foreach (explode(",", $e2guardian['interface']) as $i => $iface) {
-		$real_ifaces[] = dg_get_real_interface_address($iface);
-		if ($real_ifaces[$i][0]) {
-			$filterip .= "filterip = " . $real_ifaces[$i][0] . "\n";
-		}
-		$filterports .= "filterports = " . $filterport . "\n";
-	}
-	$filterip = ($filterip == "" ? "filterip = " : $filterip);
-	$filterports = ($filterports == "" ? "filterports = $filterport" : $filterports);
+        foreach (dg_normalize_interface_list($e2guardian['interface']) as $i => $iface) {
+                $real_ifaces[] = dg_get_real_interface_address($iface);
+                if (!empty($real_ifaces[$i][0])) {
+                        $filterip .= "filterip = " . $real_ifaces[$i][0] . "\n";
+                        $filterports .= "filterports = " . $filterport . "\n";
+                }
+        }
+        $filterip = ($filterip == "" ? "filterip = " : $filterip);
+        $filterports = ($filterports == "" ? "filterports = $filterport" : $filterports);
 	$ssl_proxy_port = $e2guardian['ssl_proxy_port'] ? $e2guardian['ssl_proxy_port'] : "8081";
 	include(E2GUARDIAN_PKGDIR . "/e2guardian.conf.template");
 


### PR DESCRIPTION
## Summary
- normalize the interface list to handle multiple selections reliably
- rebuild proxy interface IP mapping after adding loopback for transparent mode
- generate filterip/filterports entries only for interfaces with valid addresses

## Testing
- Not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c4e1bd764832e99aa588667e2b597)