### PR TITLE
Preserve bypass proxy IP bypass entries when toggling transparent mode

### DIFF
--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.xml
@@ -217,7 +217,7 @@
 				]]>
 			</sethelp>
 			<type>checkbox</type>
-			<enablefields>transparent_active_interface,private_subnet_proxy_off,defined_ip_proxy_off,defined_ip_proxy_off_dest</enablefields>
+                        <enablefields>transparent_active_interface,private_subnet_proxy_off</enablefields>
 		</field>
 		<field>
 			<fielddescr>Transparent Proxy Interface(s)</fielddescr>


### PR DESCRIPTION
## Summary
- keep bypass proxy source/destination IP fields enabled so their values persist when transparent proxy is toggled

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69405cdd6a40832e99196b12031c80e2)