### PR TITLE
www/e2guardian54: desativar build da página man

### DIFF
--- a/www/e2guardian54/Makefile
+++ b/www/e2guardian54/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	e2guardian
 PORTVERSION=	5.4.9
-PORTREVISION=	03
+PORTREVISION=	04
 DISTVERSIONPREFIX=	v
 CATEGORIES=	www
 GH_ACCOUNT=    kontrol-br
@@ -14,7 +14,6 @@ WWW=		https://e2guardian.org
 
 LICENSE=	GPLv2
 
-BUILD_DEPENDS=	rst2man:textproc/py-docutils@${PY_FLAVOR}
 RUN_DEPENDS+=   openssl111>=1.1.1w_2:security/openssl111
 
 LIB_DEPENDS=	libpcre.so:devel/pcre

--- a/www/e2guardian54/pkg-descr
+++ b/www/e2guardian54/pkg-descr
@@ -1,6 +1,6 @@
 e2guardian is a content filtering proxy that works in conjunction with another
 caching proxy such as Squid or Oops. More information can be found in the
-e2guardian man page, the "doc" subdirectory and the in the configuration files.
+"doc" subdirectory and in the configuration files.
 
 e2guardian is a fork of DansGuardian and the maintainers fully acknowledge the
 work carried out by and the copyright of Daniel Baron and other contributors to

--- a/www/e2guardian54/pkg-plist
+++ b/www/e2guardian54/pkg-plist
@@ -241,7 +241,6 @@
 @sample %%ETCDIR%%/lists/urlredirectregexplist.sample
 @sample %%ETCDIR%%/lists/urlregexplist.sample
 @sample %%ETCDIR%%/lists/weightedphraselist.sample
-man/man8/e2guardian.8.gz
 sbin/e2guardian
 %%PORTDOCS%%%%DOCSDIR%%/AuthPlugins
 %%PORTDOCS%%%%DOCSDIR%%/ContentScanners


### PR DESCRIPTION
### Motivation
- Corrigir falha no empacotamento causada pela ausência do manpage que fazia o `package` falhar (arquivo `man/man8/e2guardian.8.gz` não encontrado). 
- A documentação em formato man não é usada no ambiente alvo, portanto desativar a sua compilação reduz dependências desnecessárias.

### Description
- Removida a dependência de build `rst2man:textproc/py-docutils@${PY_FLAVOR}` no arquivo `www/e2guardian54/Makefile` e incrementado `PORTREVISION` para `04`.
- Removida a entrada `man/man8/e2guardian.8.gz` do `www/e2guardian54/pkg-plist` para não exigir a instalação do manpage no estágio de empacotamento.
- Ajustado o `www/e2guardian54/pkg-descr` para remover a referência ao manpage e refletir que a documentação manual não será instalada.

### Testing
- Nenhum teste automatizado foi executado.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696658cd93dc832eb368c71976d84034)