### PR TITLE
Garantir descrição padrão ao salvar configurações do E2guardian

### DIFF
--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc
@@ -799,6 +799,10 @@ function e2g_generate_rules($type) {
 function sync_package_e2guardian($via_rpc = "no", $install_process = false) {
 	global $config, $g, $savemsg, $e2g_sched_in_use;
 
+	if (empty($savemsg)) {
+		$savemsg = gettext("E2guardian configuration updated.");
+	}
+
 	// detect boot process
 	if (is_array($_POST)) {
 		if (preg_match("/\w+/", $_POST['__csrf_magic'])) {


### PR DESCRIPTION
### Motivation
- Corrigir o alerta "write_config() was called without description" observado após atualizações de ambiente (ex.: PHP 8.3) quando o fluxo não define `$savemsg` antes de executar operações de escrita de configuração.
- Evitar chamadas a `write_config()` sem uma descrição explícita para melhorar a clareza dos logs e prevenir avisos/erros em tempo de execução.

### Description
- Define uma mensagem padrão em `sync_package_e2guardian()` quando `$savemsg` estiver vazio, atribuindo `gettext("E2guardian configuration updated.")` antes de continuar o processo de sincronização; alteração aplicada no arquivo `www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc`.
- A mudança é pequena e preventiva, garantindo que operações subsequentes de gravação de configuração sempre tenham uma descrição associada.

### Testing
- Nenhum teste automático foi executado durante esta alteração; apenas validação de sintaxe e commit foram realizados com sucesso.
- O patch contém 4 inserções no arquivo indicado e foi commitado sem conflitos.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966a140bd4c832eb1243d5ac194907a)