### PR TITLE
Compatibilidade pfSense-repo com pkg do FreeBSD 15 (ABI/OSVERSION e SRV)

### DIFF
--- a/sysutils/pfSense-repo/Makefile
+++ b/sysutils/pfSense-repo/Makefile
@@ -29,7 +29,7 @@ PFSENSE_PKG_SET_VERSION?=	${DISTVERSION}
 
 .include <bsd.port.pre.mk>
 
-MIRROR_TYPE?=	srv
+MIRROR_TYPE?=	none
 PFSENSE_REPOS?=	pfSense-repo pfSense-repo-previous pfSense-repo-devel
 PFSENSE_REPOS_${ARCH}?=	${PFSENSE_REPOS}
 PFSENSE_DEFAULT_REPO?=	pfSense-repo-devel
@@ -38,36 +38,17 @@ SIGNATURE_TYPE?=	fingerprints
 DEFAULT_REPO=	${DATADIR}/pkg/repos/${PFSENSE_DEFAULT_REPO_${ARCH}}.conf
 TMP_PLIST_FILES=${PFSENSE_REPOS_${ARCH}:C/$/.conf/} \
 		${PFSENSE_REPOS_${ARCH}:C/$/.descr/} \
-		${PFSENSE_REPOS_${ARCH}:C/$/.abi/} \
-		${PFSENSE_REPOS_${ARCH}:C/$/.altabi/}
+		${PFSENSE_REPOS_${ARCH}:C/$/.abi/}
 PLIST_FILES=	${TMP_PLIST_FILES:C/^/%%DATADIR%%\/pkg\/repos\//} \
 		${DEFAULT_REPO}.default \
 		${DATADIR}/next_pkg_set_version
 DEFAULT_ABI=	${OPSYS}:${OSREL:C/\..*//}:${ARCH}
 
-.if ${ARCH} == "aarch64"
-ALTABI_ARCH=	aarch64:64
-.elif ${ARCH} == "amd64"
-ALTABI_ARCH=	x86:64
-.elif ${ARCH} == "i386"
-ALTABI_ARCH=	x86:32
-.elif ${ARCH} == "armv6"
-ALTABI_ARCH=	32:el:eabi:hardfp
-.elif ${ARCH} == "armv7"
-ALTABI_ARCH=	32:el:eabi:softfp
-.else
-.error "Invalid arch: ${ARCH}"
-.endif
-
 .if ${ARCH} == "armv7"
 ARCH_OLD=	armv6
-ALTABI_ARCH_OLD=32:el:eabi:hardfp
 .else
 ARCH_OLD=	${ARCH}
-ALTABI_ARCH_OLD=${ALTABI_ARCH}
 .endif
-
-DEFAULT_ALTABI=	${OPSYS:tl}:${OSREL:C/\..*//}:${ALTABI_ARCH}
 
 .if defined(PKG_REPO_BRANCH_DEVEL_${ARCH}) && !empty(PKG_REPO_BRANCH_DEVEL_${ARCH})
 PKG_REPO_BRANCH_DEVEL=${PKG_REPO_BRANCH_DEVEL_${ARCH}}
@@ -107,12 +88,6 @@ do-build:
 			-e "s,%%ARCH_OLD%%,${ARCH_OLD},g" \
 			${WRKSRC}/${f}.abi; \
 	fi
-	@if [ -f ${WRKSRC}/${f}.altabi ]; then \
-		${REINPLACE_CMD} -i '' \
-			-e "s,%%ARCH%%,${ALTABI_ARCH},g" \
-			-e "s,%%ARCH_OLD%%,${ALTABI_ARCH_OLD},g" \
-			${WRKSRC}/${f}.altabi; \
-	fi
 .endfor
 
 do-install:
@@ -125,11 +100,6 @@ do-install:
 		${INSTALL_DATA} ${WRKSRC}/${f}.abi ${STAGEDIR}${DATADIR}/pkg/repos; \
 	else \
 		${ECHO_CMD} ${DEFAULT_ABI} > ${STAGEDIR}${DATADIR}/pkg/repos/${f}.abi; \
-	fi
-	if [ -f ${WRKSRC}/${f}.altabi ]; then \
-		${INSTALL_DATA} ${WRKSRC}/${f}.altabi ${STAGEDIR}${DATADIR}/pkg/repos; \
-	else \
-		${ECHO_CMD} ${DEFAULT_ALTABI} > ${STAGEDIR}${DATADIR}/pkg/repos/${f}.altabi; \
 	fi
 .endfor
 	${ECHO_CMD} ${PFSENSE_PKG_SET_VERSION} \

--- a/sysutils/pfSense-repo/files/Kontrol-repo-devel.conf
+++ b/sysutils/pfSense-repo/files/Kontrol-repo-devel.conf
@@ -2,16 +2,16 @@ FreeBSD: { enabled: no }
 
 %%PRODUCT_NAME%%-core: {
   url: "%%PKG_REPO_SERVER_DEVEL%%/%%PRODUCT_NAME%%_%%PKG_REPO_BRANCH_DEVEL%%_%%ARCH%%-core",
-  mirror_type: "srv",
-  signature_type: "fingerprints",
+  mirror_type: "%%MIRROR_TYPE%%",
+  signature_type: "%%SIGNATURE_TYPE%%",
   fingerprints: "/usr/local/share/%%PRODUCT_NAME%%/keys/pkg",
   enabled: yes
 }
 
 %%PRODUCT_NAME%%: {
   url: "%%PKG_REPO_SERVER_DEVEL%%/%%PRODUCT_NAME%%_%%PKG_REPO_BRANCH_DEVEL%%_%%ARCH%%-%%POUDRIERE_PORTS_NAME%%",
-  mirror_type: "srv",
-  signature_type: "fingerprints",
+  mirror_type: "%%MIRROR_TYPE%%",
+  signature_type: "%%SIGNATURE_TYPE%%",
   fingerprints: "/usr/local/share/%%PRODUCT_NAME%%/keys/pkg",
   enabled: yes
 }

--- a/sysutils/pfSense-repo/files/pkg-install.in
+++ b/sysutils/pfSense-repo/files/pkg-install.in
@@ -37,11 +37,11 @@ fi
 PKG_CONF="/usr/local/etc/pkg.conf"
 REAL_CONF=$(readlink ${REPO_CONF})
 
-ABI=$(cat ${REAL_CONF%%.conf}.abi)
-ALTABI=$(cat ${REAL_CONF%%.conf}.altabi)
+ABI_FILE="${REAL_CONF%%.conf}.abi"
+OSVERSION=$(/sbin/sysctl -n kern.osreldate)
 
-echo "ABI=${ABI}" > ${PKG_CONF}
-echo "ALTABI=${ALTABI}" >> ${PKG_CONF}
+echo "ABI_FILE=${ABI_FILE}" > ${PKG_CONF}
+echo "OSVERSION=${OSVERSION}" >> ${PKG_CONF}
 
 # Help users to fix fstab before risk moving to FreeBSD 11
 if /usr/bin/grep -q -E '/dev/ad[[:digit:]]' /etc/fstab; then


### PR DESCRIPTION
### Motivation
- O `pkg` do FreeBSD 15 passou a rejeitar `ALTABI` e exige agora `ABI` e `OSVERSION` ou `ABI_FILE`, provocando mensagens de aviso/erro durante `pkg update`.
- Repositórios estavam configurados com `mirror_type` igual a `srv` por padrão, causando mensagens "No SRV record found" quando não há registro SRV.
- É necessário gerar os ficheiros de configuração dos repositórios e o `pkg.conf` de forma compatível com o novo comportamento do `pkg`.

### Description
- Alterado `MIRROR_TYPE` padrão para `none` para evitar o uso de SRV por defeito e removida a enumeração de `.altabi` no `PLIST` e na instalação em `sysutils/pfSense-repo/Makefile`.
- Removida a lógica de geração/instalação de arquivos `.altabi` e as variáveis relacionadas a `ALTABI` no `Makefile` para não expor artefatos obsoletos.
- Atualizado o template `Kontrol-repo-devel.conf` para usar as variáveis `%%MIRROR_TYPE%%` e `%%SIGNATURE_TYPE%%` em vez de valores hardcoded, permitindo controlar o tipo de mirror a partir do `Makefile`.
- Modificado `sysutils/pfSense-repo/files/pkg-install.in` para gravar `ABI_FILE=<caminho_do_arquivo_abi>` e `OSVERSION=<kern.osreldate>` em `/usr/local/etc/pkg.conf` usando `readlink` e `/sbin/sysctl -n kern.osreldate`, substituindo a escrita direta de `ABI` e `ALTABI`.

### Testing
- Nenhum teste automatizado foi executado.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966e7ebd6a8832eb6d8d5a3d54b79ae)