### PR TITLE
Incluir `OSVERSION` em `pkg.conf` no setup/upgrade do pfSense

### DIFF
--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -306,9 +306,11 @@ abi_setup() {
 		ALTABI=${CUR_ALTABI}
 	fi
 
+	OSVERSION=$(/sbin/sysctl -n kern.osreldate)
+
 	# Make sure pkg.conf is set properly so GUI can work
 	echo "ABI=${ABI}" > /usr/local/etc/pkg.conf
-	echo "ALTABI=${ALTABI}" >> /usr/local/etc/pkg.conf
+	echo "OSVERSION=${OSVERSION}" >> /usr/local/etc/pkg.conf
 
 	AUTH_CA="/etc/ssl/netgate-ca.pem"
 	AUTH_CERT="/etc/ssl/pfSense-repo-custom.cert"

--- a/sysutils/pfSense-upgrade/files/pfSense-repo-setup
+++ b/sysutils/pfSense-upgrade/files/pfSense-repo-setup
@@ -128,10 +128,12 @@ abi_setup() {
 		ALTABI=${CUR_ALTABI}
 	fi
 
+	OSVERSION=$(/sbin/sysctl -n kern.osreldate)
+
 	# Make sure pkg.conf is set properly so GUI can work
 	cat << EOF > "${PKG_CONF}"
 ABI=${ABI}
-ALTABI=${ALTABI}
+OSVERSION=${OSVERSION}
 EOF
 	if [ -n "${dbdir}" ] && [ -n "${reposdir}" ]; then
 			cat << EOF >> ${PKG_CONF}""


### PR DESCRIPTION
### Motivation
- Corrigir a criação de `/usr/local/etc/pkg.conf` para gravar `OSVERSION` em vez de deixar `ALTABI` ser escrito, evitando que o arquivo seja instalado com a chave errada para a nova lógica de repositório.

### Description
- Atualiza `sysutils/pfSense-upgrade/files/pfSense-repo-setup` para calcular `OSVERSION` com `$(/sbin/sysctl -n kern.osreldate)` e escrever `OSVERSION` no `PKG_CONF` em vez de `ALTABI`.
- Atualiza `sysutils/pfSense-upgrade/files/Kontrol-upgrade` para calcular `OSVERSION` e escrever `OSVERSION` em `/usr/local/etc/pkg.conf` após definir `ABI`, mantendo a lógica de cálculo de `ABI`/`ALTABI` para uso interno.

### Testing
- Não foram executados testes automatizados nesta mudança.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967aadbbaa0832ea00c9f0fd23cadbc)