### PR TITLE
Corrige valores padrão de SSL para e2guardian (evita config incompleta)

### DIFF
--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc
@@ -1129,6 +1129,20 @@ function sync_package_e2guardian($via_rpc = "no", $install_process = false) {
 	}
 
         $enablessl = (e2g_ssl_intercept_is_enabled($e2guardian) ? "on" : "off");
+	$ca_pem = "";
+	$ca_pk = "";
+	$generatedcertpath = "";
+	$cert_key = "";
+	$certprivatekeypath = '/etc/ssl/demoCA/private/serverkey.pem';
+	if ($enablessl === "on") {
+		$ca_pem = "cacertificatepath = '/etc/ssl/demoCA/cacert.pem'";
+		$ca_pk = "caprivatekeypath = '/etc/ssl/demoCA/private/cakey.pem'";
+		$generatedcertpath = "generatedcertpath = '" . $e2guardian_dir . "/ssl/generatedcerts'";
+		if (! file_exists($certprivatekeypath)) {
+			system("openssl genrsa 4096 > $certprivatekeypath");
+		}
+		$cert_key = "certprivatekeypath = '{$certprivatekeypath}' ";
+	}
 	$ca_cert = lookup_ca($e2guardian["dca"]);
 	if ($ca_cert != false) {
 		if (base64_decode($ca_cert['prv'])) {
@@ -1141,13 +1155,8 @@ function sync_package_e2guardian($via_rpc = "no", $install_process = false) {
 			exec("/usr/bin/openssl x509 -hash -noout -in /etc/ssl/demoCA/cacert.pem", $cert_hash);
 			file_put_contents(E2GUARDIAN_CERTSDIR . "/" . $cert_hash[0] . ".0", base64_decode($ca_cert['crt']));
 			$ca_pem = "cacertificatepath = '/etc/ssl/demoCA/cacert.pem'";
-			$generatedcertpath= "generatedcertpath = '" . $e2guardian_dir . "/ssl/generatedcerts'";
+			$generatedcertpath = "generatedcertpath = '" . $e2guardian_dir . "/ssl/generatedcerts'";
 		}
-		$certprivatekeypath='/etc/ssl/demoCA/private/serverkey.pem';
-		if (! file_exists($certprivatekeypath)) {
-			system("openssl genrsa 4096 > $certprivatekeypath");
-		}
-		$cert_key = "certprivatekeypath = '{$certprivatekeypath}' ";
 		/*
 		$svr_cert = lookup_cert($e2guardian_config["dcert"]);
 		if ($svr_cert != false) {


### PR DESCRIPTION
### Motivation
- Ativar `Enable SSL support` deixava o arquivo de configuração incompleto e gerava erros como `cacertificatepath is required when ssl is enabled` porque variáveis de caminho não eram inicializadas.
- É necessário garantir valores padrão mínimos para CA, chave e diretório de certificados quando a interceptação SSL está ativa para que o `e2guardian` inicie corretamente.

### Description
- Inicializa as variáveis de configuração SSL (`$ca_pem`, `$ca_pk`, `$generatedcertpath`, `$cert_key`) antes de montar o template de configuração quando `enablessl` está `on` no arquivo `files/usr/local/pkg/e2guardian.inc`.
- Define valores padrão apontando para `/etc/ssl/demoCA` e para o diretório de certificados gerados em `$e2guardian_dir . "/ssl/generatedcerts"` quando `enablessl === "on"`.
- Gera uma chave de servidor em `/etc/ssl/demoCA/private/serverkey.pem` via `openssl` caso não exista, para preencher `certprivatekeypath` e evitar campos vazios.
- Preserva a lógica existente de `lookup_ca` para sobrescrever os valores padrão se uma CA estiver configurada no sistema.

### Testing
- Nenhum teste automatizado foi executado.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967cc457734832ea41a4bc65ff254ed)