### PR TITLE
Add CA fallback and generation for SSL MITM in Kontrol-pkg-E2guardian54

### DIFF
--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc
@@ -1134,9 +1134,11 @@ function sync_package_e2guardian($via_rpc = "no", $install_process = false) {
 	$generatedcertpath = "";
 	$cert_key = "";
 	$certprivatekeypath = '/etc/ssl/demoCA/private/serverkey.pem';
+	$ca_pem_path = '/etc/ssl/demoCA/cacert.pem';
+	$ca_key_path = '/etc/ssl/demoCA/private/cakey.pem';
 	if ($enablessl === "on") {
-		$ca_pem = "cacertificatepath = '/etc/ssl/demoCA/cacert.pem'";
-		$ca_pk = "caprivatekeypath = '/etc/ssl/demoCA/private/cakey.pem'";
+		$ca_pem = "cacertificatepath = '{$ca_pem_path}'";
+		$ca_pk = "caprivatekeypath = '{$ca_key_path}'";
 		$generatedcertpath = "generatedcertpath = '" . $e2guardian_dir . "/ssl/generatedcerts'";
 		if (! file_exists($certprivatekeypath)) {
 			system("openssl genrsa 4096 > $certprivatekeypath");
@@ -1146,15 +1148,15 @@ function sync_package_e2guardian($via_rpc = "no", $install_process = false) {
 	$ca_cert = lookup_ca($e2guardian["dca"]);
 	if ($ca_cert != false) {
 		if (base64_decode($ca_cert['prv'])) {
-			file_put_contents("/etc/ssl/demoCA/private/cakey.pem", base64_decode($ca_cert['prv']));
-			$ca_pk = "caprivatekeypath = '/etc/ssl/demoCA/private/cakey.pem'";
+			file_put_contents($ca_key_path, base64_decode($ca_cert['prv']));
+			$ca_pk = "caprivatekeypath = '{$ca_key_path}'";
 		}
 		if (base64_decode($ca_cert['crt'])) {
 			$cert_hash = array();
-			file_put_contents("/etc/ssl/demoCA/cacert.pem", base64_decode($ca_cert['crt']));
-			exec("/usr/bin/openssl x509 -hash -noout -in /etc/ssl/demoCA/cacert.pem", $cert_hash);
+			file_put_contents($ca_pem_path, base64_decode($ca_cert['crt']));
+			exec("/usr/bin/openssl x509 -hash -noout -in {$ca_pem_path}", $cert_hash);
 			file_put_contents(E2GUARDIAN_CERTSDIR . "/" . $cert_hash[0] . ".0", base64_decode($ca_cert['crt']));
-			$ca_pem = "cacertificatepath = '/etc/ssl/demoCA/cacert.pem'";
+			$ca_pem = "cacertificatepath = '{$ca_pem_path}'";
 			$generatedcertpath = "generatedcertpath = '" . $e2guardian_dir . "/ssl/generatedcerts'";
 		}
 		/*
@@ -1166,6 +1168,39 @@ function sync_package_e2guardian($via_rpc = "no", $install_process = false) {
 			}
 		}
 		*/
+	}
+	if ($enablessl === "on") {
+		$ca_found = (file_exists($ca_pem_path) && file_exists($ca_key_path));
+		if (!$ca_found && is_array($config['ca'])) {
+			foreach ($config['ca'] as $ca) {
+				if (stripos($ca['descr'], 'e2guardian') !== false && !empty($ca['crt']) && !empty($ca['prv'])) {
+					file_put_contents($ca_pem_path, base64_decode($ca['crt']));
+					file_put_contents($ca_key_path, base64_decode($ca['prv']));
+					$ca_found = true;
+					break;
+				}
+			}
+			if (!$ca_found) {
+				foreach ($config['ca'] as $ca) {
+					if (!empty($ca['crt']) && !empty($ca['prv'])) {
+						file_put_contents($ca_pem_path, base64_decode($ca['crt']));
+						file_put_contents($ca_key_path, base64_decode($ca['prv']));
+						$ca_found = true;
+						break;
+					}
+				}
+			}
+		}
+		if (!$ca_found) {
+			$subj = '/C=US/ST=State/L=Locality/O=e2guardian/CN=e2guardianCA';
+			exec("/usr/bin/openssl req -new -newkey rsa:2048 -days 3650 -nodes -x509 -keyout {$ca_key_path} -out {$ca_pem_path} -subj \"{$subj}\"");
+			$ca_found = (file_exists($ca_pem_path) && file_exists($ca_key_path));
+		}
+		if ($ca_found) {
+			$ca_pem = "cacertificatepath = '{$ca_pem_path}'";
+			$ca_pk = "caprivatekeypath = '{$ca_key_path}'";
+			$generatedcertpath = "generatedcertpath = '" . $e2guardian_dir . "/ssl/generatedcerts'";
+		}
 	}
 
 	//contentscanners preg_replace patterns

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_antivirus.inc
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_antivirus.inc
@@ -577,7 +577,7 @@ function e2guardian_antivirus_get_raw_config() {
 		}
 	}
 	if ($loaded) {
-		write_config("Squid - Loaded raw configuration files", false);
+		write_config('Squid - Loaded raw configuration files', false);
 		log_error("[squid] Successfully loaded raw configuration files");
 	}
 }

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_sync.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_sync.xml
@@ -185,6 +185,6 @@
 		e2guardian_validate_input($_POST, $input_errors);
 	</custom_php_validation_command>
 	<custom_php_resync_config_command>
-		write_config("E2guardian sync settings.");
+		write_config('E2guardian sync settings.');
 	</custom_php_resync_config_command>
 </packagegui>

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/www/e2guardian.php
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/www/e2guardian.php
@@ -239,7 +239,7 @@ function read_lists($log_notice=true, $uw="") {
                 file_put_contents(E2GUARDIAN_PKGDIR . "/e2guardian_" . $edit_xml . "_acl.xml", $edit_file, LOCK_EX);
         }
 
-        write_config("Saving...");
+        write_config('E2guardian - saved blacklist metadata.');
         if ($log_notice == true && $uw == "") {
                 file_notice("E2guardian", "E2Guardian Blacklist applied, check site and URL access lists for categories", "E2guardian BlackList Updated.");
         } else {
@@ -248,11 +248,11 @@ function read_lists($log_notice=true, $uw="") {
         }
 }
 
-if ($argv[1] == "update_lists") {
+if (isset($argv[1]) && $argv[1] == "update_lists") {
 	extract_black_list();
 }
 
-if ($argv[1] == "fetch_blacklist") {
+if (isset($argv[1]) && $argv[1] == "fetch_blacklist") {
 	fetch_blacklist();
 }
 


### PR DESCRIPTION
### Motivation
- Prevent SSL MITM failures when CA files are missing by reusing an existing configured CA or generating a fallback self-signed CA and centralize CA path handling for MITM certificate generation.

### Description
- Introduce ` $ca_pem_path` and `$ca_key_path` and replace hardcoded `/etc/ssl/demoCA/...` paths with these variables in `www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc`.
- When SSL interception is enabled the code now prefers `lookup_ca($e2guardian['dca'])`, then searches `$config['ca']` for a CA whose `descr` contains `e2guardian`, then any CA with both `crt` and `prv`, and finally generates a self-signed CA via `openssl` if none are found, and sets `cacertificatepath`, `caprivatekeypath` and `generatedcertpath` accordingly.
- Persist CA files to disk and run `openssl x509 -hash -noout` against the new PEM path to populate `E2GUARDIAN_CERTSDIR` as before, but using the new path variables.
- Apply small related cleanups: normalize `write_config` quoting in `www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_antivirus.inc` and `www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_sync.xml`, and make `argv` checks in `www/Kontrol-pkg-E2guardian54/files/usr/local/www/e2guardian.php` safer by using `isset($argv[1])`.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69681269ebf8832eb805affe7d502646)