### PR TITLE
Add thread stack size setting and English description to E2guardian GUI

### DIFF
--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.conf.template
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.conf.template
@@ -572,6 +572,11 @@ logconnectionhandlingerrors = {$logconnectionhandlingerrors}
 # On large site you might want to try 5000 (max value 20000)
 httpworkers = {$httpworkers}
 
+# Stack size (in KiB) for each worker/listener/logger thread created by E2guardian.
+# Use this to mitigate stack overflows on systems with small default thread stacks.
+# Set to 0 to use the built-in default (currently 2048 KiB).
+threadstacksize = {$threadstacksize}
+
 
 # Process options
 # (Change these only if you really know what you are doing).

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc
@@ -829,6 +829,7 @@ function sync_package_e2guardian($via_rpc = "no", $install_process = false) {
 			'watchdog'   => 'on',
 			'applyaction' => '-Q',
 			'httpworkers' => '256',
+			'threadstacksize' => '0',
 			'daemon_options' => 'softrestart');
 	}
 	$e2guardian = $config['installedpackages']['e2guardian']['config'][0];
@@ -874,6 +875,9 @@ function sync_package_e2guardian($via_rpc = "no", $install_process = false) {
 	$softrestart = (preg_match('/softrestart/', $e2guardian['daemon_options']) ? "on" : "off");
 	$nodaemon = (preg_match('/nodaemon/', $e2guardian['daemon_options']) ? "yes" : "off");
 	$httpworkers=($e2guardian['httpworkers'] ? $e2guardian['httpworkers'] : "100");
+	$threadstacksize = (isset($e2guardian['threadstacksize']) && $e2guardian['threadstacksize'] !== "")
+		? $e2guardian['threadstacksize']
+		: "0";
 	$preforkchildren = ($e2guardian['preforkchildren']? $e2guardian['preforkchildren'] : "10");
 	switch ($e2guardian['parentmode']) {
 		case "remote":

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.xml
@@ -199,6 +199,15 @@
                                On large site you might want to try 2500 (max value 20000)<br>
 				]]></description>
 		</field>
+		<field>
+			<fielddescr>Thread stack size (KiB)</fielddescr>
+			<fieldname>threadstacksize</fieldname>
+			<type>input</type>
+			<size>10</size>
+			<description><![CDATA[Default: <strong>0</strong> (uses the built-in value of 2048 KiB).<br>
+				Sets the stack size (in KiB) for each worker/listener/logger thread created by E2guardian.<br>
+				Use this to mitigate stack overflows on systems with small default thread stacks.]]></description>
+		</field>
 <field>
 			<name>Transparent Proxy Settings</name>
 			<type>listtopic</type>


### PR DESCRIPTION
### Motivation
- Expose a `threadstacksize` option in the GUI so administrators can adjust per-thread stack size to mitigate stack overflows on systems with small default thread stacks. 
- Provide an English user-facing description for the new field so the GUI text is consistent and clear.

### Description
- Added the `threadstacksize` input field to `www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.xml` with an English description explaining units (KiB), default `0`, and usage. 
- Plumbed `threadstacksize` into the package defaults in `www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc` by adding the default `'threadstacksize' => '0'` and assigning the runtime variable `$threadstacksize`. 
- Inserted the `threadstacksize = {$threadstacksize}` directive and explanatory comments into `www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.conf.template` so the generated configuration contains the setting.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e7c857178832e9e6740db1bb5d371)