### PR TITLE
Adicionar opção Max header line length ao GUI do E2guardian54

### DIFF
--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.conf.template
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.conf.template
@@ -718,6 +718,11 @@ searchsitelistforip = on
 # Minimum 10 max 2000
 # default 40
 # maxheaderlines = 40
+# Limit maximum length of any individual HTTP/ICAP header line (including the request line).
+# Increase this if very long URLs cause truncated header reads.
+# Minimum 4096 max 16777216
+# default 32768
+maxheaderlinelength = {$maxheaderlinelength}
 
 EOF;
 ?>

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc
@@ -841,6 +841,7 @@ function sync_package_e2guardian($via_rpc = "no", $install_process = false) {
 			'weightedphrasemode' => '2',
 			'preservecase' => '0',
 			'phrasefiltermode' => '2',
+			'maxheaderlinelength' => '32768',
 			'cron' => 'day');
 	}
 	$e2guardian_config= $config['installedpackages']['e2guardianconfig']['config'][0];
@@ -910,6 +911,7 @@ function sync_package_e2guardian($via_rpc = "no", $install_process = false) {
 	$weightedphrasemode = ($e2guardian_config['weightedphrasemode'] ? $e2guardian_config['weightedphrasemode'] : "2");
 	$phrasefiltermode = ($e2guardian_config['phrasefiltermode'] ? $e2guardian_config['phrasefiltermode'] : "2");
 	$preservecase = ($e2guardian_config['preservecase'] ? $e2guardian_config['preservecase'] : "0");
+	$maxheaderlinelength = ($e2guardian_config['maxheaderlinelength'] ? $e2guardian_config['maxheaderlinelength'] : "32768");
 	$clamdscan = (preg_match('/clamdscan/', $e2guardian_config['content_scanners']) ? "on" : "off");
 	$icapscan = (preg_match('/icapscan/', $e2guardian_config['content_scanners']) ? "on" : "off");
 	$contentscannertimeout = ($e2guardian_config['contentscannertimeout'] ? $e2guardian_config['contentscannertimeout'] : "60");

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_config.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_config.xml
@@ -276,6 +276,16 @@
 				Default value: 300 (5 mins).]]></description>
 		</field>
 		<field>
+			<fielddescr>Max header line length</fielddescr>
+			<fieldname>maxheaderlinelength</fieldname>
+			<type>input</type>
+			<size>10</size>
+			<description><![CDATA[Limit maximum length of any individual HTTP/ICAP header line (including the request line).<br>
+				Increase this if very long URLs cause truncated header reads.<br>
+				Minimum 4096 max 16777216<br>
+				<strong>Default is 32768</strong>]]></description>
+		</field>
+		<field>
 			<fielddescr>Misc Options</fielddescr>
 			<fieldname>misc_options</fieldname>
 			<description><![CDATA[Misc options. Default values are in ( )]]></description>


### PR DESCRIPTION
### Motivation
- Expor na interface de configuração inicial a opção `maxheaderlinelength` que já existe no `e2guardian.conf` para permitir ajustar o limite de comprimento de linhas de header via GUI.

### Description
- Adiciona campo de entrada `maxheaderlinelength` na tela "General" em `www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_config.xml` com descrição e valor padrão 32768.
- Define o valor padrão em `sync_package_e2guardian` adicionando `'maxheaderlinelength' => '32768'` e lê a configuração em `$maxheaderlinelength` em `www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc`.
- Emite a linha `maxheaderlinelength = {$maxheaderlinelength}` no template de configuração `www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.conf.template` para inclusão no `e2guardian.conf` gerado.
- As alterações foram gravadas e commitadas nos três arquivos acima.

### Testing
- Nenhum teste automatizado foi executado.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ea9afd2e8832ea3d646938cd0165e)