### PR TITLE
Corrige erro no post-install por arquivos de lista ausentes em www/e2guardian55

### DIFF
--- a/www/e2guardian55/Makefile
+++ b/www/e2guardian55/Makefile
@@ -90,22 +90,30 @@ post-install:
 	@${FIND} ${STAGEDIR}${ETCDIR} -type f \
 		\( -name '*.conf' -or -name '*list' -or -name '*.story' \) \
 		-exec ${MV} {} {}.sample \;
-	@${MV} ${STAGEDIR}${ETCDIR}/lists/authplugins/ipgroups \
-		${STAGEDIR}${ETCDIR}/lists/authplugins/ipgroups.sample
-	@${MV} ${STAGEDIR}${ETCDIR}/lists/authplugins/portgroups \
-		${STAGEDIR}${ETCDIR}/lists/authplugins/portgroups.sample
-	@${MV} ${STAGEDIR}${ETCDIR}/lists/bannedrooms/default \
-		${STAGEDIR}${ETCDIR}/lists/bannedrooms/default.sample
-	@${MV} ${STAGEDIR}${ETCDIR}/lists/domainsnobypass \
-		${STAGEDIR}${ETCDIR}/lists/domainsnobypass.sample
-	@${MV} ${STAGEDIR}${ETCDIR}/lists/ipnobypass \
-		${STAGEDIR}${ETCDIR}/lists/ipnobypass.sample
-	@${MV} ${STAGEDIR}${ETCDIR}/lists/urlnobypass \
-		${STAGEDIR}${ETCDIR}/lists/urlnobypass.sample
+	@for file in lists/authplugins/ipgroups \
+		lists/authplugins/portgroups \
+		lists/bannedrooms/default \
+		lists/domainsnobypass \
+		lists/ipnobypass \
+		lists/urlnobypass; do \
+		if [ -f ${STAGEDIR}${ETCDIR}/$$file ]; then \
+			${MV} ${STAGEDIR}${ETCDIR}/$$file \
+				${STAGEDIR}${ETCDIR}/$$file.sample; \
+		else \
+			${INSTALL_DATA} /dev/null \
+				${STAGEDIR}${ETCDIR}/$$file.sample; \
+		fi; \
+	done
 	@${MKDIR} ${STAGEDIR}${ETCDIR}/lists/contentscanners
-	@${MV} ${STAGEDIR}${ETCDIR}/lists/exceptionvirusextensionlist.sample \
-		${STAGEDIR}${ETCDIR}/lists/contentscanners/
-	@${MV} ${STAGEDIR}${ETCDIR}/lists/exceptionvirussiteiplist.sample \
-		${STAGEDIR}${ETCDIR}/lists/contentscanners/
+	@for file in exceptionvirusextensionlist \
+		exceptionvirussiteiplist; do \
+		if [ -f ${STAGEDIR}${ETCDIR}/lists/$$file.sample ]; then \
+			${MV} ${STAGEDIR}${ETCDIR}/lists/$$file.sample \
+				${STAGEDIR}${ETCDIR}/lists/contentscanners/; \
+		else \
+			${INSTALL_DATA} /dev/null \
+				${STAGEDIR}${ETCDIR}/lists/contentscanners/$$file.sample; \
+		fi; \
+	done
 
 .include <bsd.port.mk>


### PR DESCRIPTION
### Motivation
- O `post-install` falhava ao renomear `lists/bannedrooms/default` para `.sample` quando o ficheiro não existia, causando erro de `mv` e interrompendo o `stage`.
- É necessário garantir que todos os ficheiros `.sample` listados no `pkg-plist` existam no `stagedir` para evitar falhas de empacotamento.

### Description
- Substituídas várias chamadas `mv` diretas no `post-install` por um loop `for` que verifica a existência de cada ficheiro em `${STAGEDIR}${ETCDIR}` antes de mover, e cria um ficheiro `.sample` vazio com `INSTALL_DATA /dev/null` quando o original está ausente.
- Adicionada lógica equivalente para `lists/contentscanners` para mover `exceptionvirusextensionlist.sample` e `exceptionvirussiteiplist.sample` só se existirem, ou criar amostras vazias caso contrário.
- Alteração aplicada no `www/e2guardian55/Makefile` dentro da seção `post-install` para robustez no processo de staging.

### Testing
- Nenhum teste automatizado foi executado.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972cb9fedf0832e953283be4a4be2bc)