### PR TITLE
Fix install staging for e2guardian55 lists

### DIFF
--- a/www/e2guardian55/Makefile
+++ b/www/e2guardian55/Makefile
@@ -86,26 +86,37 @@ PLIST_SUB+=	SCANNERS="@comment "
 
 SUB_FILES=	pkg-message
 
+pre-install:
+	@${MKDIR} ${STAGEDIR}${ETCDIR}/lists/bannedrooms
+
 post-install:
 	@${FIND} ${STAGEDIR}${ETCDIR} -type f \
 		\( -name '*.conf' -or -name '*list' -or -name '*.story' \) \
 		-exec ${MV} {} {}.sample \;
-	@${MV} ${STAGEDIR}${ETCDIR}/lists/authplugins/ipgroups \
-		${STAGEDIR}${ETCDIR}/lists/authplugins/ipgroups.sample
-	@${MV} ${STAGEDIR}${ETCDIR}/lists/authplugins/portgroups \
-		${STAGEDIR}${ETCDIR}/lists/authplugins/portgroups.sample
-	@${MV} ${STAGEDIR}${ETCDIR}/lists/bannedrooms/default \
-		${STAGEDIR}${ETCDIR}/lists/bannedrooms/default.sample
-	@${MV} ${STAGEDIR}${ETCDIR}/lists/domainsnobypass \
-		${STAGEDIR}${ETCDIR}/lists/domainsnobypass.sample
-	@${MV} ${STAGEDIR}${ETCDIR}/lists/ipnobypass \
-		${STAGEDIR}${ETCDIR}/lists/ipnobypass.sample
-	@${MV} ${STAGEDIR}${ETCDIR}/lists/urlnobypass \
-		${STAGEDIR}${ETCDIR}/lists/urlnobypass.sample
+	@for file in lists/authplugins/ipgroups \
+		lists/authplugins/portgroups \
+		lists/bannedrooms/default \
+		lists/domainsnobypass \
+		lists/ipnobypass \
+		lists/urlnobypass; do \
+		if [ -f ${STAGEDIR}${ETCDIR}/$$file ]; then \
+			${MV} ${STAGEDIR}${ETCDIR}/$$file \
+				${STAGEDIR}${ETCDIR}/$$file.sample; \
+		else \
+			${INSTALL_DATA} /dev/null \
+				${STAGEDIR}${ETCDIR}/$$file.sample; \
+		fi; \
+	done
 	@${MKDIR} ${STAGEDIR}${ETCDIR}/lists/contentscanners
-	@${MV} ${STAGEDIR}${ETCDIR}/lists/exceptionvirusextensionlist.sample \
-		${STAGEDIR}${ETCDIR}/lists/contentscanners/
-	@${MV} ${STAGEDIR}${ETCDIR}/lists/exceptionvirussiteiplist.sample \
-		${STAGEDIR}${ETCDIR}/lists/contentscanners/
+	@for file in exceptionvirusextensionlist \
+		exceptionvirussiteiplist; do \
+		if [ -f ${STAGEDIR}${ETCDIR}/lists/$$file.sample ]; then \
+			${MV} ${STAGEDIR}${ETCDIR}/lists/$$file.sample \
+				${STAGEDIR}${ETCDIR}/lists/contentscanners/; \
+		else \
+			${INSTALL_DATA} /dev/null \
+				${STAGEDIR}${ETCDIR}/lists/contentscanners/$$file.sample; \
+		fi; \
+	done
 
 .include <bsd.port.mk>


### PR DESCRIPTION
### Motivation
- Avoid staging failures during `make install` caused by a missing `lists/bannedrooms` directory which produced errors like `install: .../lists/bannedrooms: No such file or directory`.
- Ensure that all expected `.sample` files referenced by the port exist in the `${STAGEDIR}${ETCDIR}` so packaging does not fail when upstream omits those files.

### Description
- Added a `pre-install` target that creates the directory `${STAGEDIR}${ETCDIR}/lists/bannedrooms` before installation.
- Replaced multiple direct `mv` calls in `post-install` with a `for` loop that checks for each file in `lists/...` and either moves it to `*.sample` or creates an empty `.sample` with `INSTALL_DATA /dev/null` when the source is missing.
- Added a `for` loop to populate `lists/contentscanners` by moving existing `*sample` files or creating empty `$$file.sample` files when absent.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972cb9fedf0832e953283be4a4be2bc)