### PR TITLE
www/e2guardian55: copiar diretórios de dados para staging para gerar arquivos .sample

### DIFF
--- a/www/e2guardian55/Makefile
+++ b/www/e2guardian55/Makefile
@@ -90,6 +90,21 @@ pre-install:
 	@${MKDIR} ${STAGEDIR}${ETCDIR}/lists/bannedrooms
 
 post-install:
+	@${MKDIR} ${STAGEDIR}${ETCDIR}/authplugins
+	@if [ -d ${WRKSRC}/data/authplugins ]; then \
+		${COPYTREE_SHARE} ${WRKSRC}/data/authplugins \
+			${STAGEDIR}${ETCDIR}/authplugins; \
+	fi
+	@${MKDIR} ${STAGEDIR}${ETCDIR}/contentscanners
+	@if [ -d ${WRKSRC}/data/contentscanners ]; then \
+		${COPYTREE_SHARE} ${WRKSRC}/data/contentscanners \
+			${STAGEDIR}${ETCDIR}/contentscanners; \
+	fi
+	@${MKDIR} ${STAGEDIR}${ETCDIR}/lists
+	@if [ -d ${WRKSRC}/data/lists ]; then \
+		${COPYTREE_SHARE} ${WRKSRC}/data/lists \
+			${STAGEDIR}${ETCDIR}/lists; \
+	fi
 	@${FIND} ${STAGEDIR}${ETCDIR} -type f \
 		\( -name '*.conf' -or -name '*list' -or -name '*.story' \) \
 		-exec ${MV} {} {}.sample \;


### PR DESCRIPTION
### Motivation
- Corrigir erros do `pkg-static` durante a criação do pacote onde muitos arquivos `*.sample` referenciados no `pkg-plist` não existiam no diretório de stage. 
- Garantir que os arquivos de configuração e listas fornecidos pelo upstream em `data/` sejam instalados no `STAGEDIR` antes do processo que renomeia arquivos para `.sample`.

### Description
- Adicionada cópia condicional das árvores `data/authplugins`, `data/contentscanners` e `data/lists` para `$(STAGEDIR)$(ETCDIR)` no bloco `post-install` usando `$(COPYTREE_SHARE)` quando presentes em `$(WRKSRC)`. 
- Criadas previamente as pastas `authplugins`, `contentscanners` e `lists` em `$(STAGEDIR)$(ETCDIR)` para receber os arquivos copiados. 
- Mantida a lógica existente que renomeia `*.conf`, `*list` e `*.story` para `*.sample` e que garante a presença de arquivos `.sample` nulos quando necessário.

### Testing
- Nenhum teste automatizado foi executado.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972d1407ffc832e92f829d6e7cef5b6)