### PR TITLE
Switch Kontrol-pkg-E2guardian55 to e2guardian55 and update package metadata

### DIFF
--- a/www/Kontrol-pkg-E2guardian55/Makefile
+++ b/www/Kontrol-pkg-E2guardian55/Makefile
@@ -1,6 +1,6 @@
 # $FreeBSD$
 
-PORTNAME=	Kontrol-pkg-E2guardian54
+PORTNAME=	Kontrol-pkg-E2guardian55
 PORTVERSION=	0.7.5.1
 PORTREVISION=
 CATEGORIES=	www

--- a/www/Kontrol-pkg-E2guardian55/files/usr/local/share/Kontrol-pkg-E2guardian55/info.xml
+++ b/www/Kontrol-pkg-E2guardian55/files/usr/local/share/Kontrol-pkg-E2guardian55/info.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <pfsensepkgs>
         <package>
-                <name>E2guardian54</name>
-                <descr><![CDATA[Full featured content filtering for e2guardian 5.4 with MITM, domain, URL and body filtering.]]></descr>
+                <name>E2guardian55</name>
+                <descr><![CDATA[Full featured content filtering for e2guardian 5.5 with MITM, domain, URL and body filtering.]]></descr>
                 <pkginfolink/>
                 <version>%%PKGVERSION%%</version>
                 <configurationfile>e2guardian.xml</configurationfile>

--- a/www/Kontrol-pkg-E2guardian55/pkg-descr
+++ b/www/Kontrol-pkg-E2guardian55/pkg-descr
@@ -1,4 +1,4 @@
-E2guardian 5.4 is an Open Source web content filter. It filters the actual
+E2guardian 5.5 is an Open Source web content filter. It filters the actual
 content of pages based on many methods including phrase matching, request
 header and URL filtering, etc. It does not purely filter based on a banned list
 of sites


### PR DESCRIPTION
### Motivation
- The port was cloned from the 5.4 package and still contained 5.4 names and data files, so it must be aligned to the 5.5 package and dependency naming. 
- Ensure the port metadata and datadir reflect `e2guardian55` so package tooling and `RUN_DEPENDS` are consistent.

### Description
- Update `PORTNAME` in `www/Kontrol-pkg-E2guardian55/Makefile` to `Kontrol-pkg-E2guardian55` so the port name matches the 5.5 package. 
- Rename the data directory from `files/usr/local/share/Kontrol-pkg-E2guardian54` to `files/usr/local/share/Kontrol-pkg-E2guardian55` and update `info.xml` to set `<name>E2guardian55</name>` and the 5.5 description. 
- Update the package description in `pkg-descr` to reference E2guardian 5.5.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972d9f7f91c832ea141ac661d167145)