### PR TITLE
Remover flags de debug do Makefile de e2guardian54

### DIFF
--- a/www/e2guardian54/Makefile
+++ b/www/e2guardian54/Makefile
@@ -61,12 +61,6 @@ EMAIL_CONFIGURE_ENABLE=		email
 DEBUG_CONFIGURE_OFF=		--with-e2debug=off --with-newdebug=off
 DEBUG_CONFIGURE_ON=		--with-e2debug=on --with-newdebug=on
 
-# >>>> FLAGS DE DEBUG (ADICIONADO)
-DEBUG_CFLAGS=		-g -O0 -fno-omit-frame-pointer
-DEBUG_CXXFLAGS=		-g -O0 -fno-omit-frame-pointer
-DEBUG_VARS=		STRIP=
-# <<<< FLAGS DE DEBUG
-
 #SSL_MITM_USES=                 ssl
 SSL_MITM_CONFIGURE_ENABLE=      sslmitm
 #DEFAULT_VERSIONS+=                     ssl=openssl


### PR DESCRIPTION
### Motivation
- Desativar geração de símbolos e logs de debug no port após resolução dos problemas, deixando o build mais enxuto sem flags de depuração adicionais.

### Description
- Removidos os overrides de build `DEBUG_CFLAGS`, `DEBUG_CXXFLAGS` e `DEBUG_VARS` do arquivo `www/e2guardian54/Makefile`, mantendo apenas os toggles de configure `DEBUG_CONFIGURE_ON`/`DEBUG_CONFIGURE_OFF`.

### Testing
- Não foram executados testes automatizados; a alteração é um ajuste de metadados do `Makefile` e requer a construção do port para validação de runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b7932fea0832e8507544c5be6f25e)