### PR TITLE
Improve Kontrol upgrade detection and add Kontrol-repo-setup helper

### DIFF
--- a/sysutils/pfSense-upgrade/Makefile
+++ b/sysutils/pfSense-upgrade/Makefile
@@ -17,7 +17,8 @@ NO_MTREE=	yes
 NO_BUILD=	yes
 
 PLIST_FILES=	libexec/pfSense-upgrade \
-		sbin/pfSense-upgrade
+		sbin/pfSense-upgrade \
+		sbin/Kontrol-repo-setup
 
 do-extract:
 	@${MKDIR} ${WRKSRC}
@@ -27,9 +28,11 @@ do-install:
 	${MKDIR} ${STAGEDIR}${PREFIX}/sbin
 	${MKDIR} ${STAGEDIR}${PREFIX}/libexec
 	${MKDIR} ${STAGEDIR}${PREFIX}/share/pfSense
-	${INSTALL_SCRIPT} ${WRKSRC}/pfSense-upgrade \
-		${STAGEDIR}${PREFIX}/libexec
-	${INSTALL_SCRIPT} ${WRKSRC}/pfSense-upgrade.wrapper \
+	${INSTALL_SCRIPT} ${WRKSRC}/Kontrol-upgrade \
+		${STAGEDIR}${PREFIX}/libexec/pfSense-upgrade
+	${INSTALL_SCRIPT} ${WRKSRC}/Kontrol-upgrade.wrapper \
 		${STAGEDIR}${PREFIX}/sbin/pfSense-upgrade
+	${INSTALL_SCRIPT} ${WRKSRC}/Kontrol-repo-setup \
+		${STAGEDIR}${PREFIX}/sbin/Kontrol-repo-setup
 
 .include <bsd.port.mk>

--- a/sysutils/pfSense-upgrade/files/Kontrol-repo-setup
+++ b/sysutils/pfSense-upgrade/files/Kontrol-repo-setup
@@ -1,0 +1,135 @@
+#!/bin/sh
+#
+# Kontrol-repo-setup
+#
+# Setup repository configuration and pkg ABI for Kontrol/pfSense systems.
+
+usage() {
+	me=$(basename $0)
+	cat << EOD >&2
+Usage: ${me} [-U]
+	-U          - Do not update repository information
+EOD
+}
+
+repo_is_custom() {
+	local _pkg_repo_conf_path="${1}"
+
+	if [ -n "$(echo ${_pkg_repo_conf_path} | grep ${product}-repo-custom)" ]; then
+		return 0
+	fi
+	return 1
+}
+
+validate_repo_conf() {
+	local _repo_conf="/usr/local/etc/pkg/repos/${product}.conf"
+	local _default="/usr/local/share/${product}/pkg/repos/${product}-repo.conf"
+
+	pkg_repo_conf_path=$(read_xml_tag.sh string system/pkg_repo_conf_path)
+	if [ -z "${pkg_repo_conf_path}" -o ! -f "${pkg_repo_conf_path}" ]; then
+		pkg_repo_conf_path="${_default}"
+	fi
+
+	mkdir -p /usr/local/etc/pkg/repos
+
+	if [ -e "${_repo_conf}" -a ! -L "${_repo_conf}" ]; then
+		rm -f ${_repo_conf}
+	fi
+
+	if [ "$(readlink ${_repo_conf} 2>/dev/null)" != \
+	    "${pkg_repo_conf_path}" ]; then
+		ln -sf ${pkg_repo_conf_path} ${_repo_conf}
+	fi
+}
+
+abi_setup() {
+	local _freebsd_version=$(uname -r)
+	local _pkg_repo_conf="/usr/local/etc/pkg/repos/${product}.conf"
+
+	CUR_ABI="FreeBSD:${_freebsd_version%%.*}:${arch}"
+	CUR_ALTABI="freebsd:${_freebsd_version%%.*}"
+
+	if [ "${arch}" = "armv6" ]; then
+		CUR_ALTABI="${CUR_ALTABI}:${arch}:32:el:eabi:hardfp"
+	elif [ "${arch}" = "armv7" ]; then
+		CUR_ALTABI="${CUR_ALTABI}:${arch}:32:el:eabi:softfp"
+	elif [ "${arch}" = "aarch64" ]; then
+		CUR_ALTABI="${CUR_ALTABI}:${arch}:64"
+	elif [ "${arch}" = "i386" ]; then
+		CUR_ALTABI="${CUR_ALTABI}:x86:32"
+	else
+		CUR_ALTABI="${CUR_ALTABI}:x86:64"
+	fi
+
+	if [ ! -e ${_pkg_repo_conf} ]; then
+		validate_repo_conf
+	fi
+
+	local _repo_abi_file=$(readlink ${_pkg_repo_conf})
+
+	if [ -f ${_repo_abi_file%%.conf}.abi ]; then
+		ABI=$(cat ${_repo_abi_file%%.conf}.abi)
+	else
+		ABI=${CUR_ABI}
+	fi
+
+	if [ -f ${_repo_abi_file%%.conf}.altabi ]; then
+		ALTABI=$(cat ${_repo_abi_file%%.conf}.altabi)
+	else
+		ALTABI=${CUR_ALTABI}
+	fi
+
+	echo "ABI=${ABI}" > /usr/local/etc/pkg.conf
+	echo "ALTABI=${ALTABI}" >> /usr/local/etc/pkg.conf
+
+	AUTH_CA="/etc/ssl/netgate-ca.pem"
+	AUTH_CERT="/etc/ssl/pfSense-repo-custom.cert"
+	AUTH_KEY="/etc/ssl/pfSense-repo-custom.key"
+	if repo_is_custom "${pkg_repo_conf_path}" -a -f "${AUTH_CA}" \
+	    -a -f "${AUTH_CERT}" -a -f "${AUTH_KEY}" ; then
+		cat << EOF >> /usr/local/etc/pkg.conf
+PKG_ENV {
+	SSL_CA_CERT_FILE=${AUTH_CA}
+	SSL_CLIENT_CERT_FILE=${AUTH_CERT}
+	SSL_CLIENT_KEY_FILE=${AUTH_KEY}
+}
+EOF
+	fi
+
+	if [ "${arch}" = "aarch64" ]; then
+		cat << EOF >> /usr/local/etc/pkg.conf
+PKG_ENV {
+	OPENSSL_CONF=/etc/thoth/openssl.cnf
+	SSL_CA_CERT_FILE=/etc/thoth/ca.pem
+	SSL_CLIENT_CERT_FILE=/etc/thoth/device.pem
+	SSL_CLIENT_KEY_FILE=/etc/thoth/key.pem
+}
+EOF
+	fi
+}
+
+dont_update=""
+while getopts "U" opt; do
+	case ${opt} in
+		U)
+			dont_update=1
+			;;
+		*)
+			usage
+			exit 1
+			;;
+	esac
+done
+
+arch=$(uname -p)
+product=$(php -n /usr/local/sbin/read_global_var product_name Kontrol)
+
+validate_repo_conf
+abi_setup
+
+if [ -z "${dont_update}" ]; then
+	/usr/local/bin/php -r 'require_once("pkg-utils.inc");update_repos();'
+	/usr/local/sbin/pkg-static update -f >/dev/null 2>&1
+fi
+
+exit 0

--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -1082,12 +1082,182 @@ get_meta_pkg_name() {
 	fi
 }
 
+get_repo_abi_major() {
+	local _repo_conf="${1}"
+	local _abi_file="${_repo_conf%%.conf}.abi"
+	local _abi="${CUR_ABI}"
+
+	[ -f "${_abi_file}" ] && _abi=$(cat "${_abi_file}")
+	echo "${_abi}" | awk -F: '{print $2}'
+}
+
+get_repo_abi_values() {
+	local _repo_conf="${1}"
+	local _abi_file="${_repo_conf%%.conf}.abi"
+	local _altabi_file="${_repo_conf%%.conf}.altabi"
+
+	REPO_ABI="${CUR_ABI}"
+	REPO_ALTABI="${CUR_ALTABI}"
+	[ -f "${_abi_file}" ] && REPO_ABI=$(cat "${_abi_file}")
+	[ -f "${_altabi_file}" ] && REPO_ALTABI=$(cat "${_altabi_file}")
+}
+
+prepare_repo_override_dir() {
+	local _repo_conf="${1}"
+	local _tmp_dir=""
+
+	_tmp_dir=$(mktemp -d "/tmp/${product}.repo.XXXXXX") || return 1
+	cp -f "${_repo_conf}" "${_tmp_dir}/${product}.conf"
+	echo "${_tmp_dir}"
+}
+
+cleanup_repo_override_dir() {
+	local _repo_dir="${1}"
+
+	[ -n "${_repo_dir}" -a -d "${_repo_dir}" ] && rm -rf "${_repo_dir}"
+}
+
+compare_pkg_version_repo() {
+	local _pkg_name="${1}"
+	local _repo_dir="${2}"
+	local _abi="${3}"
+	local _altabi="${4}"
+
+	if [ -z "${_pkg_name}" ]; then
+		echo '!'
+		return 1
+	fi
+
+	if ! is_pkg_installed ${_pkg_name}; then
+		echo '!'
+		return 1
+	fi
+
+	local _lver=$(_pkg query %v ${_pkg_name})
+
+	if [ -z "${_lver}" ]; then
+		_echo "ERROR: It was not possible to determine ${_pkg_name}" \
+		    "local version"
+		_exit 1
+	fi
+
+	local _rver=$(pkg-static -o REPOS_DIR=${_repo_dir} \
+	    -o ABI=${_abi} -o ALTABI=${_altabi} rquery -U %v ${_pkg_name})
+
+	if [ -z "${_rver}" ]; then
+		_rver=$(pkg-static -o REPOS_DIR=${_repo_dir} \
+		    -o ABI=${_abi} -o ALTABI=${_altabi} rquery %v ${_pkg_name})
+	fi
+
+	if [ -z "${_rver}" ]; then
+		_echo "ERROR: It was not possible to determine ${_pkg_name}" \
+		    "remote version"
+		_exit 1
+	fi
+
+	local _version=$(_pkg version -t ${_lver} ${_rver})
+
+	if [ $? -ne 0 ]; then
+		_echo "ERROR: Error comparing ${_pkg_name} local and remote" \
+		    "versions"
+		_exit 1
+	fi
+
+	echo ${_version}
+	return 0
+}
+
+check_upgrade_repo_override() {
+	local _mute="${1}"
+	local _skip_update="${2}"
+	local _meta_pkg="${3}"
+	local _core_pkgs="${4}"
+	local _current_repo_conf="/usr/local/etc/pkg/repos/${product}.conf"
+	local _current_repo_target=""
+	local _current_major=""
+	local _best_conf=""
+	local _best_major=""
+
+	if [ -L "${_current_repo_conf}" ]; then
+		_current_repo_target=$(readlink ${_current_repo_conf})
+	elif [ -f "${_current_repo_conf}" ]; then
+		_current_repo_target="${_current_repo_conf}"
+	fi
+
+	if [ -n "${_current_repo_target}" ]; then
+		_current_major=$(get_repo_abi_major "${_current_repo_target}")
+	fi
+
+	for _conf in /usr/local/share/${product}/pkg/repos/${product}-repo*.conf;
+	do
+		[ -f "${_conf}" ] || continue
+		local _major=$(get_repo_abi_major "${_conf}")
+		[ -z "${_major}" ] && continue
+
+		if [ -z "${_best_major}" ] || [ "${_major}" -gt "${_best_major}" ]; then
+			_best_major="${_major}"
+			_best_conf="${_conf}"
+		fi
+	done
+
+	if [ -z "${_best_conf}" ]; then
+		return 1
+	fi
+
+	if [ -n "${_current_major}" -a "${_best_major}" -le "${_current_major}" ]; then
+		return 1
+	fi
+
+	get_repo_abi_values "${_best_conf}"
+
+	local _repo_dir=$(prepare_repo_override_dir "${_best_conf}")
+	if [ -z "${_repo_dir}" ]; then
+		return 1
+	fi
+
+	if [ -z "${_skip_update}" -a -z "${dont_update}" ]; then
+		pkg-static -o REPOS_DIR=${_repo_dir} -o ABI=${REPO_ABI} \
+		    -o ALTABI=${REPO_ALTABI} update -f >/dev/null 2>&1
+	fi
+
+	for _package in ${_meta_pkg} ${_core_pkgs}; do
+		local _version_compare=$(compare_pkg_version_repo ${_package} \
+		    ${_repo_dir} ${REPO_ABI} ${REPO_ALTABI})
+
+		case "${_version_compare}" in
+			=|'>')
+				continue
+				;;
+		esac
+
+		local _new_version=$(pkg-static -o REPOS_DIR=${_repo_dir} \
+		    -o ABI=${REPO_ABI} -o ALTABI=${REPO_ALTABI} \
+		    rquery -U %v ${_package})
+
+		if [ -z "${_new_version}" ]; then
+			_new_version=$(pkg-static -o REPOS_DIR=${_repo_dir} \
+			    -o ABI=${REPO_ABI} -o ALTABI=${REPO_ALTABI} \
+			    rquery %v ${_package})
+		fi
+
+		[ -z "${_mute}" ] \
+		    && _echo \
+		    "${_new_version} version of ${product} is available"
+		cleanup_repo_override_dir "${_repo_dir}"
+		return 2
+	done
+
+	cleanup_repo_override_dir "${_repo_dir}"
+	return 1
+}
+
 check_upgrade() {
 	local _mute="$1"
 	local _skip_update="$2"
 	local _meta_pkg=$(get_meta_pkg_name)
 	local _core_pkgs=$(pkg-static query -e \
 	    "%n ~ ${product}-kernel-* || %n ~ ${product}-base*" %n 2>/dev/null)
+	local _repo_behind=""
 
 	# Do not upgrade while wg interfaces are assigned
 	if sed '/<interfaces>/,/<\/interfaces>/!d' /cf/conf/config.xml \
@@ -1116,9 +1286,8 @@ check_upgrade() {
 				continue
 				;;
 			'>')
-				[ -z "${_mute}" ] \
-				    && _echo "Your system is on a newer version"
-				return 0
+				_repo_behind=1
+				continue
 				;;
 		esac
 
@@ -1128,6 +1297,18 @@ check_upgrade() {
 		    "${_new_version} version of ${product} is available"
 		return 2
 	done
+
+	check_upgrade_repo_override "${_mute}" "${_skip_update}" \
+	    "${_meta_pkg}" "${_core_pkgs}"
+	if [ $? -eq 2 ]; then
+		return 2
+	fi
+
+	if [ -n "${_repo_behind}" ]; then
+		[ -z "${_mute}" ] \
+		    && _echo "Your system is on a newer version"
+		return 0
+	fi
 
 	[ -z "${_mute}" ] \
 	    && _echo "Your system is up to date"


### PR DESCRIPTION
### Motivation
- The upgrade detection could miss newer releases when the active repo points to an older ABI because `pkg rquery` is executed only against the active repo and `pkg.conf` ABI, causing the widget and `pfSense-upgrade -c` to report incorrectly after repo switches. 
- Provide a small, portable helper to ensure repo symlink/ABI and optional metadata refresh without changing the pfSense application code.

### Description
- Added a new `Kontrol-repo-setup` helper script at `sysutils/pfSense-upgrade/files/Kontrol-repo-setup` that validates the active repo symlink, writes `ABI`/`ALTABI` into `/usr/local/etc/pkg.conf`, injects repo-specific SSL cert config when appropriate, and optionally refreshes repo metadata unless called with `-U`.
- Modified the port `Makefile` to install the helper (`sbin/Kontrol-repo-setup`) and to install the packaged Kontrol scripts under the port (`libexec/pfSense-upgrade` and `sbin/pfSense-upgrade`).
- Extended `Kontrol-upgrade` (`sysutils/pfSense-upgrade/files/Kontrol-upgrade`) with functions to enumerate packaged repo files, read their `.abi/.altabi` values, and perform an override `pkg-static` lookup against the higher-ABI repo (functions: `get_repo_abi_major`, `get_repo_abi_values`, `prepare_repo_override_dir`, `cleanup_repo_override_dir`, `compare_pkg_version_repo`, `check_upgrade_repo_override`).
- Updated `check_upgrade()` to use the override probe so that if there is a packaged repo with a newer ABI it will check that repo directly and correctly return RC=2 (new version available) when appropriate, while preserving previous behavior when the system repo is newer.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981424b3714832eab92038831545281)