### PR TITLE
Avoid ABI-mismatch repo upgrades and refresh version cache

### DIFF
--- a/sysutils/pfSense-upgrade/files/Kontrol-repo-setup
+++ b/sysutils/pfSense-upgrade/files/Kontrol-repo-setup
@@ -127,6 +127,23 @@ product=$(php -n /usr/local/sbin/read_global_var product_name Kontrol)
 validate_repo_conf
 abi_setup
 
+repo_state_file="/var/run/${product}_repo_conf_path"
+repo_conf_path="/usr/local/etc/pkg/repos/${product}.conf"
+current_repo_conf="$(readlink ${repo_conf_path} 2>/dev/null)"
+if [ -z "${current_repo_conf}" -a -f "${repo_conf_path}" ]; then
+	current_repo_conf="${repo_conf_path}"
+fi
+if [ -n "${current_repo_conf}" ]; then
+	if [ -f "${repo_state_file}" ]; then
+		previous_repo_conf="$(cat "${repo_state_file}")"
+		if [ "${previous_repo_conf}" != "${current_repo_conf}" ]; then
+			rm -f "/var/run/${product}_version" \
+			    "/var/run/${product}_version.rc"
+		fi
+	fi
+	echo "${current_repo_conf}" > "${repo_state_file}"
+fi
+
 if [ -z "${dont_update}" ]; then
 	/usr/local/bin/php -r 'require_once("pkg-utils.inc");update_repos();'
 	/usr/local/sbin/pkg-static update -f >/dev/null 2>&1

--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -446,6 +446,10 @@ pkg_update() {
 }
 
 pkg_upgrade_repo() {
+	if [ -n "${NEW_MAJOR}" -a "${action}" != "upgrade" ]; then
+		return
+	fi
+
 	if [ -n "${reinstall_pkg}" ] \
 	    || [ -z "${NEW_MAJOR}" -a "$(compare_pkg_version pkg)" = "<" ]; then
 		pkg_unlock pkg


### PR DESCRIPTION
### Motivation
- Prevent routine checks from automatically upgrading `pkg` or the `<product>-repo` when a major ABI mismatch is detected (e.g. repository for FreeBSD-15 on a FreeBSD-14 system). 
- Ensure the system version cache is invalidated when the configured repo changes, including when the repo config file is not a symlink, so widgets and update checks re-detect new versions correctly.

### Description
- Added an early guard in `pkg_upgrade_repo()` to return immediately when `NEW_MAJOR` is set and `action` is not `upgrade`, avoiding automatic `pkg`/`<product>-repo` upgrades outside an explicit upgrade action. 
- Updated `sysutils/pfSense-upgrade/files/Kontrol-repo-setup` to detect non-symlink repo configs by reading the repo config path in `repo_conf_path` when `readlink` returns empty, and to persist the current repo config path in `/var/run/${product}_repo_conf_path` while removing `/var/run/${product}_version` and `/var/run/${product}_version.rc` when the repo changes. 
- Files changed: `sysutils/pfSense-upgrade/files/Kontrol-upgrade` and `sysutils/pfSense-upgrade/files/Kontrol-repo-setup`.
- Attempted to apply the same `Kontrol-upgrade` change to the `RELENG_2_8_1` branch, but the target scripts were not present in that tree so the change was not applied there.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982040dfe8c832eb57cd05762181109)