### PR TITLE
Refresh pkg metadata during boot upgrades, handle missing gnid, and persist repo config state

### DIFF
--- a/sysutils/pfSense-upgrade/files/Kontrol-repo-setup
+++ b/sysutils/pfSense-upgrade/files/Kontrol-repo-setup
@@ -127,6 +127,23 @@ product=$(php -n /usr/local/sbin/read_global_var product_name Kontrol)
 validate_repo_conf
 abi_setup
 
+repo_state_file="/var/run/${product}_repo_conf_path"
+repo_conf_path="/usr/local/etc/pkg/repos/${product}.conf"
+current_repo_conf="$(readlink ${repo_conf_path} 2>/dev/null)"
+if [ -z "${current_repo_conf}" -a -f "${repo_conf_path}" ]; then
+	current_repo_conf="${repo_conf_path}"
+fi
+if [ -n "${current_repo_conf}" ]; then
+	if [ -f "${repo_state_file}" ]; then
+		previous_repo_conf="$(cat "${repo_state_file}")"
+		if [ "${previous_repo_conf}" != "${current_repo_conf}" ]; then
+			rm -f "/var/run/${product}_version" \
+			    "/var/run/${product}_version.rc"
+		fi
+	fi
+	echo "${current_repo_conf}" > "${repo_state_file}"
+fi
+
 if [ -z "${dont_update}" ]; then
 	/usr/local/bin/php -r 'require_once("pkg-utils.inc");update_repos();'
 	/usr/local/sbin/pkg-static update -f >/dev/null 2>&1

--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -446,6 +446,10 @@ pkg_update() {
 }
 
 pkg_upgrade_repo() {
+	if [ -n "${NEW_MAJOR}" -a "${action}" != "upgrade" ]; then
+		return
+	fi
+
 	if [ -n "${reinstall_pkg}" ] \
 	    || [ -z "${NEW_MAJOR}" -a "$(compare_pkg_version pkg)" = "<" ]; then
 		pkg_unlock pkg
@@ -913,6 +917,8 @@ pkg_upgrade() {
 	fi
 
 	if [ "${next_stage}" = "2" ]; then
+		pkg_update force
+
 		pkg_lock "${pkg_prefix}*"
 		unlock_additional_pkgs=1
 
@@ -1006,6 +1012,8 @@ pkg_upgrade() {
 	fi
 
 	if [ "${next_stage}" = "3" ]; then
+		pkg_update force
+
 		if upgrade_available; then
 			delete_annotation=1
 			_exec "pkg-static upgrade${dont_update}" \
@@ -1561,8 +1569,12 @@ fi
 product_version=$(cat /etc/version)
 do_not_send_uniqueid=$(read_xml_tag.sh boolean system/do_not_send_uniqueid)
 if [ "${do_not_send_uniqueid}" != "true" ]; then
-	uniqueid=$(gnid)
-	export HTTP_USER_AGENT="${product}/${product_version}:${uniqueid}"
+	if command -v gnid >/dev/null 2>&1; then
+		uniqueid=$(gnid)
+		export HTTP_USER_AGENT="${product}/${product_version}:${uniqueid}"
+	else
+		export HTTP_USER_AGENT="${product}/${product_version}"
+	fi
 else
 	export HTTP_USER_AGENT="${product}/${product_version}"
 fi


### PR DESCRIPTION
### Motivation
- Fix intermittent upgrade failures observed after the first reboot where `pkg-static upgrade` fails with "Repository … cannot be opened. 'pkg update' required" because repo metadata is not refreshed in boot-stage upgrade phases. 
- Avoid boot-stage crashes when the `gnid` binary is not present and scripts attempt to call it for `HTTP_USER_AGENT`.
- Ensure repo configuration changes are detected and the cached product version state is invalidated so version detection and widgets re-detect correctly.

### Description
- Added a check around `gnid` in `sysutils/pfSense-upgrade/files/Kontrol-upgrade` so the binary is only invoked when present and `HTTP_USER_AGENT` falls back to a safe value otherwise. 
- Force repository metadata refresh with `pkg_update force` at upgrade `next_stage` 2 and 3 in `sysutils/pfSense-upgrade/files/Kontrol-upgrade` so `pkg-static upgrade` runs against up-to-date meta data. 
- Added an early guard in `pkg_upgrade_repo()` to return when `NEW_MAJOR` is set and `action` is not `upgrade`, preventing unintended repo/pkg upgrades outside explicit upgrades. 
- Persist detected repo config path in `sysutils/pfSense-upgrade/files/Kontrol-repo-setup` to `/var/run/${product}_repo_conf_path` and remove `/var/run/${product}_version` and `/var/run/${product}_version.rc` when the repo config changes so cached version state is invalidated. 
- Files modified: `sysutils/pfSense-upgrade/files/Kontrol-upgrade` and `sysutils/pfSense-upgrade/files/Kontrol-repo-setup`.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982040dfe8c832eb57cd05762181109)