### PR TITLE
Fix pkg major-upgrade boot-stage failures: export IGNORE_OSVERSION, refresh repos, persist repo state, guard repo upgrades, and handle missing `gnid`

### DIFF
--- a/sysutils/pfSense-upgrade/files/Kontrol-repo-setup
+++ b/sysutils/pfSense-upgrade/files/Kontrol-repo-setup
@@ -127,6 +127,23 @@ product=$(php -n /usr/local/sbin/read_global_var product_name Kontrol)
 validate_repo_conf
 abi_setup
 
+repo_state_file="/var/run/${product}_repo_conf_path"
+repo_conf_path="/usr/local/etc/pkg/repos/${product}.conf"
+current_repo_conf="$(readlink ${repo_conf_path} 2>/dev/null)"
+if [ -z "${current_repo_conf}" -a -f "${repo_conf_path}" ]; then
+	current_repo_conf="${repo_conf_path}"
+fi
+if [ -n "${current_repo_conf}" ]; then
+	if [ -f "${repo_state_file}" ]; then
+		previous_repo_conf="$(cat "${repo_state_file}")"
+		if [ "${previous_repo_conf}" != "${current_repo_conf}" ]; then
+			rm -f "/var/run/${product}_version" \
+			    "/var/run/${product}_version.rc"
+		fi
+	fi
+	echo "${current_repo_conf}" > "${repo_state_file}"
+fi
+
 if [ -z "${dont_update}" ]; then
 	/usr/local/bin/php -r 'require_once("pkg-utils.inc");update_repos();'
 	/usr/local/sbin/pkg-static update -f >/dev/null 2>&1

--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -446,6 +446,10 @@ pkg_update() {
 }
 
 pkg_upgrade_repo() {
+	if [ -n "${NEW_MAJOR}" -a "${action}" != "upgrade" ]; then
+		return
+	fi
+
 	if [ -n "${reinstall_pkg}" ] \
 	    || [ -z "${NEW_MAJOR}" -a "$(compare_pkg_version pkg)" = "<" ]; then
 		pkg_unlock pkg
@@ -913,6 +917,12 @@ pkg_upgrade() {
 	fi
 
 	if [ "${next_stage}" = "2" ]; then
+		if [ -n "${is_pkg_locked}" ]; then
+			export IGNORE_OSVERSION=yes
+		fi
+
+		pkg_update force
+
 		pkg_lock "${pkg_prefix}*"
 		unlock_additional_pkgs=1
 
@@ -938,6 +948,9 @@ pkg_upgrade() {
 		if upgrade_available; then
 			delete_annotation=1
 			if [ -n "${is_pkg_locked}" ]; then
+				_exec "pkg-static bootstrap -f" \
+				    "Bootstrapping pkg for major upgrade" mute
+
 				# Upgrade pkg
 				pkg_unlock pkg
 				_pkg annotate -q -D ${kernel_pkg} new_major
@@ -1006,6 +1019,12 @@ pkg_upgrade() {
 	fi
 
 	if [ "${next_stage}" = "3" ]; then
+		if [ -n "${is_pkg_locked}" ]; then
+			export IGNORE_OSVERSION=yes
+		fi
+
+		pkg_update force
+
 		if upgrade_available; then
 			delete_annotation=1
 			_exec "pkg-static upgrade${dont_update}" \
@@ -1561,8 +1580,12 @@ fi
 product_version=$(cat /etc/version)
 do_not_send_uniqueid=$(read_xml_tag.sh boolean system/do_not_send_uniqueid)
 if [ "${do_not_send_uniqueid}" != "true" ]; then
-	uniqueid=$(gnid)
-	export HTTP_USER_AGENT="${product}/${product_version}:${uniqueid}"
+	if command -v gnid >/dev/null 2>&1; then
+		uniqueid=$(gnid)
+		export HTTP_USER_AGENT="${product}/${product_version}:${uniqueid}"
+	else
+		export HTTP_USER_AGENT="${product}/${product_version}"
+	fi
 else
 	export HTTP_USER_AGENT="${product}/${product_version}"
 fi


### PR DESCRIPTION
### Motivation
- Prevent `pkg` aborting with OSVERSION mismatches during multi-stage major upgrades by ensuring the bootstrap/ignore flow is active in boot-stage scripts.
- Ensure repository metadata is up-to-date early in boot-stage upgrade phases to avoid running `pkg-static upgrade` against stale metadata.
- Invalidate cached product version state when repository configuration changes so version detection and widgets re-detect correctly.
- Make `HTTP_USER_AGENT` construction robust when the `gnid` binary is not present.

### Description
- Persist the repo configuration path to `/var/run/${product}_repo_conf_path` in `sysutils/pfSense-upgrade/files/Kontrol-repo-setup` and remove `/var/run/${product}_version` and `/var/run/${product}_version.rc` when the repo config changes to invalidate cached version state.
- Force repo metadata refresh early by running the existing PHP `update_repos()` call and `pkg-static update -f` in `Kontrol-repo-setup` when updates are allowed.
- Add an early guard in `pkg_upgrade_repo()` to `return` when `NEW_MAJOR` is set and `action` is not `upgrade` to avoid unintended repo/pkg upgrades outside explicit upgrade runs.
- In `sysutils/pfSense-upgrade/files/Kontrol-upgrade`, export `IGNORE_OSVERSION=yes` when `is_pkg_locked` is set in both stage 2 and stage 3, and call `pkg_update force` before performing `pkg` operations in those stages.
- Ensure `pkg-static` is bootstrapped in stage 2 when `is_pkg_locked` by running `pkg-static bootstrap -f` and then upgrade/reinstall `pkg` and core packages via `pkg-static` as needed.
- Make `HTTP_USER_AGENT` building robust by using `command -v gnid` and falling back to `"${product}/${product_version}"` when `gnid` is unavailable.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982040dfe8c832eb57cd05762181109)