### PR TITLE
Bootstrap automático do pkg quando `pkg-static update` falha em major upgrade

### DIFF
--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -407,6 +407,13 @@ pkg_update() {
 	    ${_mute} "" do_not_exit
 
 	if [ $? -ne 0 -a -z "${_do_not_bootstrap}" ]; then
+		if [ -n "${NEW_MAJOR}" ]; then
+			_exec "${_pkg_binary} bootstrap -f" \
+			    "Bootstrap pkg due to major OS upgrade"
+			pkg_update "${force}" "${_mute}" _do_not_bootstrap
+			return
+		fi
+
 		# Since pkg version 1.13 it moved to use repository metadata
 		# version 2, which cannot be processed by older pkg binaries
 		#


### PR DESCRIPTION
### Motivation
- Corrigir falha no processo de atualização de repositórios que ocorre após um primeiro boot em upgrades de major OS, onde o `pkg-static update` retorna erro "no meta file" mesmo com `meta.conf` presente. 
- Tratar o caso onde o binário `pkg` local é antigo e incapaz de processar metadados do repositório após mudança de meta version.

### Description
- Alterado `sysutils/pfSense-upgrade/files/Kontrol-upgrade` na função `pkg_update()` para detectar falha de `pkg-static update` durante um `NEW_MAJOR` e forçar um `pkg bootstrap -f` antes de tentar atualizar os repositórios novamente. 
- Após o `bootstrap` o script reaplica `pkg_update` com o sinalizador `_do_not_bootstrap` para evitar loops infinitos e retorna imediatamente ao terminar o fluxo de bootstrap. 
- A modificação usa a variável `_pkg_binary` já presente para chamar o `bootstrap` e preserva a lógica existente de detecção de meta.conf/versão para os demais casos.

### Testing
- Não foram executados testes automatizados neste rollout (nenhum teste automatizado solicitado nem rodado).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69829651f420832e983c6f2ca4eb6274)