### PR TITLE
sysutils/pfSense-upgrade: preservar OSVERSION em /usr/local/etc/pkg.conf

### DIFF
--- a/sysutils/pfSense-upgrade/Makefile
+++ b/sysutils/pfSense-upgrade/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	Kontrol-upgrade
 PORTVERSION=	1.3.22
-PORTREVISION=	# empty
+PORTREVISION=	1
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/sysutils/pfSense-upgrade/files/Kontrol-repo-setup
+++ b/sysutils/pfSense-upgrade/files/Kontrol-repo-setup
@@ -79,8 +79,11 @@ abi_setup() {
 		ALTABI=${CUR_ALTABI}
 	fi
 
+	local _osversion=$(sysctl -n kern.osreldate)
+
 	echo "ABI=${ABI}" > /usr/local/etc/pkg.conf
 	echo "ALTABI=${ALTABI}" >> /usr/local/etc/pkg.conf
+	echo "OSVERSION=${_osversion}" >> /usr/local/etc/pkg.conf
 
 	AUTH_CA="/etc/ssl/netgate-ca.pem"
 	AUTH_CERT="/etc/ssl/pfSense-repo-custom.cert"

--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -306,9 +306,12 @@ abi_setup() {
 		ALTABI=${CUR_ALTABI}
 	fi
 
+	local _osversion=$(sysctl -n kern.osreldate)
+
 	# Make sure pkg.conf is set properly so GUI can work
 	echo "ABI=${ABI}" > /usr/local/etc/pkg.conf
 	echo "ALTABI=${ALTABI}" >> /usr/local/etc/pkg.conf
+	echo "OSVERSION=${_osversion}" >> /usr/local/etc/pkg.conf
 
 	AUTH_CA="/etc/ssl/netgate-ca.pem"
 	AUTH_CERT="/etc/ssl/pfSense-repo-custom.cert"


### PR DESCRIPTION
### Motivation

- Corrigir comportamento observado durante migração de Kontrol/pfSense 2.7.x (FreeBSD 14) para 2.8.1 (FreeBSD 15) onde `pkg` pode deduzir um `OSVERSION` incorreto e apontar para repositórios incompatíveis durante o boot intermediário. 
- Garantir que a configuração de repositório (`/usr/local/etc/pkg.conf`) preserve explícita e consistentemente `OSVERSION` junto com `ABI`/`ALTABI` para evitar inconsistências entre a versão do `pkg` instalada e o repositório remoto.

### Description

- Adiciona leitura de `kern.osreldate` via `sysctl -n kern.osreldate` e gravação de `OSVERSION=${_osversion}` em `/usr/local/etc/pkg.conf` nos scripts `files/Kontrol-upgrade` e `files/Kontrol-repo-setup` para fixar explicitamente a versão do sistema que o `pkg` deve usar. 
- Bump do `PORTREVISION` em `sysutils/pfSense-upgrade/Makefile` de vazio para `1` para refletir a alteração do comportamento dos scripts instalados. 
- As alterações preservam a lógica existente de seleção de `ABI`/`ALTABI` e apenas adicionam o campo `OSVERSION` ao arquivo `pkg.conf` gerado.

### Testing

- Nenhum teste automatizado foi executado.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982a2b628b4832eb0b558666855674d)