### PR TITLE
Atualiza scripts de upgrade Kontrol com base no upstream e remove dependência de repoc

### DIFF
--- a/sysutils/pfSense-upgrade/Makefile
+++ b/sysutils/pfSense-upgrade/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	Kontrol-upgrade
-PORTVERSION=	1.2.11
+PORTVERSION=	1.2.12
 PORTREVISION=	# empty
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty

--- a/sysutils/pfSense-upgrade/files/Kontrol-repo-setup
+++ b/sysutils/pfSense-upgrade/files/Kontrol-repo-setup
@@ -2,151 +2,275 @@
 #
 # Kontrol-repo-setup
 #
-# Setup repository configuration and pkg ABI for Kontrol/pfSense systems.
+# part of pfSense (https://www.pfsense.org)
+# Copyright (c) 2015-2023 Rubicon Communications, LLC (Netgate)
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 usage() {
 	me=$(basename $0)
-	cat << EOD >&2
-Usage: ${me} [-U]
-	-U          - Do not update repository information
+        cat << EOD >&2
+Usage: $(basename "$0") [-hU] [<destdir> <conf>]
+	-h		- this help text
+	-U		- do not update the repository settings
+
+	<destdir> overrides the destination for the pkg.conf file and repos directory
+	<conf> overrides system/pkg_repo_conf_path in the config
 EOD
 }
 
-repo_is_custom() {
-	local _pkg_repo_conf_path="${1}"
+_pkg() {
+	/usr/local/sbin/pkg-static "$@" 2>/dev/null
+	return $?
+}
 
-	if [ -n "$(echo ${_pkg_repo_conf_path} | grep ${product}-repo-custom)" ]; then
-		return 0
+get_default_repo() {
+	local _pkg_repo_files="${PLUS_CERT_BASE}/${PRODUCT}-repo-*.name"
+	for file in ${_pkg_repo_files}; do
+
+		repo_path="${file%.name}"
+		if [ -f "${repo_path}.default" ]; then
+			echo "${repo_path}.conf"
+			return
+		fi
+	done
+	echo ""
+}
+
+get_repo_name() {
+	local _repo_conf="${1}"
+	repo_path="${_repo_conf%.conf}"
+	repo_name="${repo_path}.name"
+	if [ ! -f "${repo_name}" ]; then
+		echo -n ""
+		return
 	fi
-	return 1
+	/bin/cat "${repo_name}"
 }
 
 validate_repo_conf() {
-	local _repo_conf="/usr/local/etc/pkg/repos/${product}.conf"
-	local _default="/usr/local/share/${product}/pkg/repos/${product}-repo.conf"
+	local default_file=$(ls -1 ${PLUS_CERT_BASE}/*.default 2>/dev/null | tail -n 1)
+	local default="${PLUS_CERT_BASE}/${PRODUCT}-repo-stable.conf"
+	local repo_name=$(get_repo_name "${PKG_REPO_CONF_PATH}")
+	local pkg_repo_conf="${PLUS_CERT_BASE}/${PRODUCT}-repo-${repo_name}.conf"
 
-	pkg_repo_conf_path=$(read_xml_tag.sh string system/pkg_repo_conf_path)
-	if [ -z "${pkg_repo_conf_path}" -o ! -f "${pkg_repo_conf_path}" ]; then
-		pkg_repo_conf_path="${_default}"
+	if [ -n "${default_file}" ] && [ -f "${default_file}" ]; then
+		default="${default_file%%.default}.conf"
 	fi
 
-	mkdir -p /usr/local/etc/pkg/repos
-
-	if [ -e "${_repo_conf}" -a ! -L "${_repo_conf}" ]; then
-		rm -f ${_repo_conf}
+	# Use the default config if pkg_repo_conf points to an invalid file, unless
+	# invoked with destdir and conf arguments as indicated by a non-null string
+	# in dbdir. In this case, abort with an error rather than do something
+	# unexpected for this mode of operation.
+	if [ -z "${pkg_repo_conf}" ] || [ ! -f "${pkg_repo_conf}" ]; then
+		if [ -n "${dbdir}" ]; then
+			echo "No such file ${pkg_repo_conf}"
+			exit 1
+		fi
+		pkg_repo_conf=${default}
 	fi
 
-	if [ "$(readlink ${_repo_conf} 2>/dev/null)" != \
-	    "${pkg_repo_conf_path}" ]; then
-		ln -sf ${pkg_repo_conf_path} ${_repo_conf}
+	if [ -f "${pkg_repo_conf}" ]; then
+		if [ -e "${PFSENSE_REPO_CONF}" -a ! -L "${PFSENSE_REPO_CONF}" ]; then
+			rm -f ${PFSENSE_REPO_CONF}
+			ln -sf ${pkg_repo_conf} ${PFSENSE_REPO_CONF}
+		fi
+
+		if [ "$(readlink ${PFSENSE_REPO_CONF})" != \
+		    "${pkg_repo_conf}" ]; then
+			mkdir -p $(dirname "${PFSENSE_REPO_CONF}")
+			ln -sf ${pkg_repo_conf} ${PFSENSE_REPO_CONF}
+		fi
+		export PKG_REPO_CONF_PATH="${pkg_repo_conf}"
 	fi
 }
 
 abi_setup() {
-	local _freebsd_version=$(uname -r)
-	local _pkg_repo_conf="/usr/local/etc/pkg/repos/${product}.conf"
+	local _arch="$(uname -p)"
+	local _freebsd_version="$(uname -r)"
+	local _repo_conf_file="$(readlink ${PFSENSE_REPO_CONF})"
 
-	CUR_ABI="FreeBSD:${_freebsd_version%%.*}:${arch}"
+	CUR_ABI="FreeBSD:${_freebsd_version%%.*}:${_arch}"
 	CUR_ALTABI="freebsd:${_freebsd_version%%.*}"
 
-	if [ "${arch}" = "armv6" ]; then
-		CUR_ALTABI="${CUR_ALTABI}:${arch}:32:el:eabi:hardfp"
-	elif [ "${arch}" = "armv7" ]; then
-		CUR_ALTABI="${CUR_ALTABI}:${arch}:32:el:eabi:softfp"
-	elif [ "${arch}" = "aarch64" ]; then
-		CUR_ALTABI="${CUR_ALTABI}:${arch}:64"
-	elif [ "${arch}" = "i386" ]; then
+	if [ "${_arch}" = "armv6" ]; then
+		CUR_ALTABI="${CUR_ALTABI}:${_arch}:32:el:eabi:hardfp"
+	elif [ "${_arch}" = "armv7" ]; then
+		CUR_ALTABI="${CUR_ALTABI}:${_arch}:32:el:eabi:softfp"
+	elif [ "${_arch}" = "aarch64" ]; then
+		CUR_ALTABI="${CUR_ALTABI}:${_arch}:64"
+	elif [ "${_arch}" = "i386" ]; then
 		CUR_ALTABI="${CUR_ALTABI}:x86:32"
 	else
 		CUR_ALTABI="${CUR_ALTABI}:x86:64"
 	fi
 
-	if [ ! -e ${_pkg_repo_conf} ]; then
-		validate_repo_conf
-	fi
-
-	local _repo_abi_file=$(readlink ${_pkg_repo_conf})
-
-	if [ -f ${_repo_abi_file%%.conf}.abi ]; then
-		ABI=$(cat ${_repo_abi_file%%.conf}.abi)
+	if [ -f ${_repo_conf_file%%.conf}.abi ]; then
+		ABI=$(cat ${_repo_conf_file%%.conf}.abi)
 	else
 		ABI=${CUR_ABI}
 	fi
 
-	if [ -f ${_repo_abi_file%%.conf}.altabi ]; then
-		ALTABI=$(cat ${_repo_abi_file%%.conf}.altabi)
+	if [ -f ${_repo_conf_file%%.conf}.altabi ]; then
+		ALTABI=$(cat ${_repo_conf_file%%.conf}.altabi)
 	else
 		ALTABI=${CUR_ALTABI}
 	fi
 
-	echo "ABI=${ABI}" > /usr/local/etc/pkg.conf
-	echo "ALTABI=${ALTABI}" >> /usr/local/etc/pkg.conf
+	# Make sure pkg.conf is set properly so GUI can work
+	cat << EOF > "${PKG_CONF}"
+ABI=${ABI}
+ALTABI=${ALTABI}
+EOF
+	if [ -n "${dbdir}" ] && [ -n "${reposdir}" ]; then
+			cat << EOF >> ${PKG_CONF}""
+PKG_DBDIR=${dbdir}
+REPOS_DIR=[${reposdir}]
+EOF
+	fi
 
 	AUTH_CA="/etc/ssl/netgate-ca.pem"
-	AUTH_CERT="/etc/ssl/pfSense-repo-custom.cert"
-	AUTH_KEY="/etc/ssl/pfSense-repo-custom.key"
-	if repo_is_custom "${pkg_repo_conf_path}" -a -f "${AUTH_CA}" \
-	    -a -f "${AUTH_CERT}" -a -f "${AUTH_KEY}" ; then
-		cat << EOF >> /usr/local/etc/pkg.conf
+	REPO_NAME=$(get_repo_name "${PKG_REPO_CONF_PATH}")
+	PLUS_REPO_CONF="${PLUS_CERT_BASE}/${PRODUCT}-repo-${REPO_NAME}.conf"
+	PLUS_CERT="${PLUS_CERT_BASE}/${PRODUCT}-repo-${REPO_NAME}-cert.pem"
+	PLUS_KEY="${PLUS_CERT_BASE}/${PRODUCT}-repo-${REPO_NAME}-key.pem"
+	if [ -f "${PLUS_REPO_CONF}" ] && \
+	   [ "${PLUS_REPO_CONF}" != "$(realpath "${PFSENSE_REPO_CONF}")" ]; then
+		rm -f "${PFSENSE_REPO_CONF}"
+		ln -s "${PLUS_REPO_CONF}" "${PFSENSE_REPO_CONF}"
+	fi
+	if [ -f "${AUTH_CA}" -a -f "${PLUS_CERT}" -a -f "${PLUS_KEY}" ]; then
+		cat << EOF >> "${PKG_CONF}"
 PKG_ENV {
 	SSL_CA_CERT_FILE=${AUTH_CA}
-	SSL_CLIENT_CERT_FILE=${AUTH_CERT}
-	SSL_CLIENT_KEY_FILE=${AUTH_KEY}
+	SSL_CLIENT_CERT_FILE=${PLUS_CERT}
+	SSL_CLIENT_KEY_FILE=${PLUS_KEY}
 }
 EOF
 	fi
 
-	if [ "${arch}" = "aarch64" ]; then
-		cat << EOF >> /usr/local/etc/pkg.conf
-PKG_ENV {
-	OPENSSL_CONF=/etc/thoth/openssl.cnf
-	SSL_CA_CERT_FILE=/etc/thoth/ca.pem
-	SSL_CLIENT_CERT_FILE=/etc/thoth/device.pem
-	SSL_CLIENT_KEY_FILE=/etc/thoth/key.pem
-}
-EOF
+	err=0
+
+	local _pkg_abi=$(_pkg query %q pkg)
+	if [ "${CUR_ABI}" != "${_pkg_abi}" ] && [ "${_pkg_abi}" != "${ABI}" ]; then
+		# Upgrade pkg
+		err=11
 	fi
+
+	if [ "${CUR_ABI}" != "${ABI}" ] && [ "${CUR_ABI}" != "${ALTABI}" ]; then
+		# Set NEW_MAJOR
+		if [ "${err}" -eq 11 ]; then
+			err=13
+		else
+			err=12
+		fi
+	fi
+
+	return $err
 }
 
-dont_update=""
-while getopts "U" opt; do
+
+pfSense_repo_setup() {
+
+	cp "${PFSENSE_REPO_CONF}" "/tmp/${PRODUCT}.conf.copy"
+
+	if [ -z "${NOUPDATE}" ]; then
+		/usr/local/bin/php -r \
+		    'require_once("pkg-utils.inc");update_repos();'
+		/usr/local/sbin/pkg-static update -f >/dev/null 2>&1
+	fi
+
+	# Validate the new settings
+	validate_repo_conf
+
+	# Setup the repository.
+	abi_setup
+	err=$?
+
+	# If conf differs, may need force a pkg update
+	if ! cmp -s "${PFSENSE_REPO_CONF}" "/tmp/${PRODUCT}.conf.copy" && \
+	    [ "${err}" -eq 0 ]; then
+		err=14
+	fi
+	rm -f "/tmp/${PRODUCT}.conf.copy"
+
+	return $err
+}
+
+
+#
+# main()
+#
+
+PHP="/usr/local/bin/php"
+READ_XML_TAG="/usr/local/sbin/read_xml_tag.sh"
+export PLUS_CERT_BASE="$("${PHP}" -n /usr/local/sbin/read_global_var pkg_repos_path Kontrol)"
+export PRODUCT="$("${PHP}" -n /usr/local/sbin/read_global_var product_name Kontrol)"
+export PFSENSE_REPO_CONF="/usr/local/etc/pkg/repos/${PRODUCT}.conf"
+export PKG_CONF="/usr/local/etc/pkg.conf"
+export PKG_REPO_CONF_PATH="$("${READ_XML_TAG}" string system/pkg_repo_conf_path)"
+
+# If no branch is saved on the XML configuration, use the default repo.
+if [ -z "${PKG_REPO_CONF_PATH}" ]; then
+	export PKG_REPO_CONF_PATH="$(get_default_repo)"
+fi
+
+unset NOUPDATE
+while getopts hU opt; do
 	case ${opt} in
-		U)
-			dont_update=1
-			;;
-		*)
-			usage
-			exit 1
-			;;
+	h)
+		usage
+		exit 0
+		;;
+	U)
+		NOUPDATE=1
+		;;
+	*)
+		usage
+		exit 1
+		;;
 	esac
 done
 
-arch=$(uname -p)
-product=$(php -n /usr/local/sbin/read_global_var product_name Kontrol)
-
-validate_repo_conf
-abi_setup
-
-repo_state_file="/var/run/${product}_repo_conf_path"
-repo_conf_path="/usr/local/etc/pkg/repos/${product}.conf"
-current_repo_conf="$(readlink ${repo_conf_path} 2>/dev/null)"
-if [ -z "${current_repo_conf}" -a -f "${repo_conf_path}" ]; then
-	current_repo_conf="${repo_conf_path}"
-fi
-if [ -n "${current_repo_conf}" ]; then
-	if [ -f "${repo_state_file}" ]; then
-		previous_repo_conf="$(cat "${repo_state_file}")"
-		if [ "${previous_repo_conf}" != "${current_repo_conf}" ]; then
-			rm -f "/var/run/${product}_version" \
-			    "/var/run/${product}_version.rc"
-		fi
+shift $((${OPTIND}-1))
+if [ $# != 0 ]; then
+	if [ $# != 2 ]; then
+		usage
+		exit 1
 	fi
-	echo "${current_repo_conf}" > "${repo_state_file}"
+	dbdir="${1}/db"
+	reposdir="${1}/repos"
+	export PKG_CONF="${1}/pkg.conf"
+	export PFSENSE_REPO_CONF="${reposdir}/${PRODUCT}.conf"
+	export PKG_REPO_CONF_PATH=$2
 fi
 
-if [ -z "${dont_update}" ]; then
-	/usr/local/bin/php -r 'require_once("pkg-utils.inc");update_repos();'
-	/usr/local/sbin/pkg-static update -f >/dev/null 2>&1
-fi
+#
+# Validate the actual repo setup.
+# Make sure it points to a valid file or fallback to the default.
+#
+validate_repo_conf
 
-exit 0
+# Fetch the repository data and setup the repository access.
+pfSense_repo_setup
+err=$?
+
+# Exit codes:
+# 0 = okay
+# 1 = error
+# 11 = update pkg
+# 12 = new major
+# 13 = update pkg + new major
+# 14 = conf changed, check pkg version
+exit $err

--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -3,7 +3,7 @@
 # pfSense-upgrade
 #
 # part of pfSense (https://www.pfsense.org)
-# Copyright (c) 2015-2022 Rubicon Communications, LLC (Netgate)
+# Copyright (c) 2015-2023 Rubicon Communications, LLC (Netgate)
 # All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,7 +36,8 @@ Usage: ${me} [-46bdfhnRUy] [-l logfile] [-p socket] [-c|-u|[-i|-d] pkg_name]
 	-y          - Assume yes as the answer to any possible interaction
 
 The following parameters are mutually exclusive:
-	-c          - Check if upgrade is necessary
+	-c          - Check if update is available in the current repo
+	-C          - Check if upgrade is available in any of the available repos
 	-i pkg_name - Install package PKG_NAME
 	-r pkg_name - Remove package PKG_NAME
 	-u          - Update repository information
@@ -45,16 +46,27 @@ EOD
 
 _echo() {
 	local _n=""
-	if [ "${1}" = "-n" ]; then
-		shift
-		_n="-n"
-	fi
+	local _out="/dev/stdout"
+	while getopts no: opt; do
+		case ${opt} in
+		n)
+			_n="-n"
+			shift
+			;;
+		o)
+			if [ "${OPTARG}" = "stderr" ]; then
+				_out="/dev/${OPTARG}"
+			fi
+			shift; shift
+			;;
+		esac
+	done
 
 	if [ -z "${logfile}" ]; then
 		logfile=/dev/null
 	fi
 
-	echo ${_n} "${@}" | tee -a ${logfile}
+	echo ${_n} "${@}" | tee -a ${logfile} > ${_out}
 }
 
 _exec() {
@@ -149,6 +161,387 @@ _exit() {
 	fi
 
 	exit ${_rc}
+}
+
+# Returns the current root filesystem
+_be_get_rootfs() {
+	/sbin/mount | /usr/bin/awk '/ \/ / {print $1}'
+}
+
+# Test if root filesystem is on UFS
+_be_is_root_on_ufs() {
+	echo "$( _be_get_rootfs )" | grep -q -m 1 -E "^/dev/"
+}
+
+# Returns the pool that contains the root filesystem
+_be_get_root_pool() {
+	_be_get_rootfs | /usr/bin/awk -F '/' '{print $1}'
+}
+
+# Returns the BE dataset
+_be_get_beds() {
+	local _pool="$( _be_get_root_pool )"
+	local _beds="$( _be_get_rootfs | /usr/bin/awk -F '/' '{print $2}' )"
+
+	echo "${_pool}/${_beds}"
+}
+
+# determine the ZFS dataset that holds a given file/folder
+_be_get_dataset_of_path() {
+	local _path="${1}"
+
+	/sbin/zfs list -H -t filesystem -o name -r "${_path}" 2>/dev/null
+}
+
+# determines if a given path is held by the root dataset or a child of
+# the root dataset.
+_be_is_path_on_root() {
+	local _path="${1}"
+
+	_be_get_dataset_of_path "${_path}" | grep -q -m 1 "$( _be_get_rootfs )"
+}
+
+# test if root filesystem is on ZFS
+_be_is_root_on_zfs() {
+	# just the opposite...
+	!(_be_is_root_on_ufs)
+}
+
+#
+# test the system for BE-readiness (e.g. fails on UFS systems)
+#
+# notes:
+#    1. Perform a sanity check using `bectl check`
+#    2. Check to see if /cf lives on the root dataset
+#    3. Check to see if /var/db/pkg lives on the root dataset
+#    4. TODO: add additional sanity checks?
+#
+_be_readiness_check() {
+	_be_is_root_on_zfs \
+		&& /sbin/bectl check \
+		&& _be_is_path_on_root "/cf" \
+		&& _be_is_path_on_root "/var/db/pkg"
+}
+
+# See _be_readiness_check...
+_be_not_readiness_check() {
+	# just the opposite...
+	!(_be_readiness_check)
+}
+
+# Translates a BE name into a dataset path
+_be_name_to_ds() {
+	local _name="${1}"
+
+	echo "$( _be_get_beds )/${_name}"
+}
+
+# returns the base package version
+_be_get_pkg_version() {
+	_ver="$( _pkg query %v "${product}-base" 2>/dev/null )"
+	if [ $? -eq 0 ]; then
+		echo "${_ver}"
+		return 0
+	fi
+	echo "unknown"
+	return 1
+}
+
+# Returns the active BE
+_be_get_active() {
+	/sbin/bectl list -H | /usr/bin/awk 'index($2, "N") {print $1}' | /usr/bin/head -n1
+}
+
+# Returns the active dataset
+_be_get_active_ds() {
+	_be_name_to_ds "$( _be_get_active )"
+}
+
+# Set a ZFS property
+_be_zfs_set_property() {
+	local _target="${1}"
+	local _property="${2}"
+	local _value="${3}"
+
+	/sbin/zfs set "${_property}=${_value}" "${_target}" 1>/dev/null 2>&1
+
+	# sanity check by reading the value back and comparing with what we expect
+	[ "$( _be_zfs_get_property "${_target}" "${_property}" )" = "${_value}" ]
+}
+
+# Get a ZFS property
+_be_zfs_get_property() {
+	local _target="${1}"
+	local _property="${2}"
+
+	/sbin/zfs get -H -o value "${_property}" "${_target}" 2>/dev/null
+}
+
+# Check if dataset exists
+_be_zfs_dataset_exists() {
+	local _dataset="${1}"
+
+	/sbin/zfs list "${_dataset}" 1>/dev/null 2>&1
+}
+
+# Destroy a ZFS datset
+_be_zfs_destroy() {
+	local _dataset="${1}"
+	( !(_be_zfs_dataset_exists "${_dataset}") ) && return 0
+	/sbin/zfs destroy -fr "${_dataset}" 1>/dev/null 2>&1
+}
+
+# Create a ZFS dataset
+_be_zfs_create() {
+	local _source_path="${1}"
+	local _target_dataset="${2}"
+
+	# create the new target dataset
+	/sbin/zfs create -o mountpoint="${_source_path}" "${_target_dataset}" 1>/dev/null 2>&1	
+}
+
+# Sanity check that we have a valid rollback BE
+_be_has_valid_rollback_be() {
+	local _active_ds="$( _be_get_active_ds )"
+	local _rollback_be="$( _be_zfs_get_property "${_active_ds}" pfsense:rollbackbe )"
+
+	# Check to see if the active dataset has a rollback be dataset.
+	_be_zfs_dataset_exists "$( _be_name_to_ds "${_rollback_be}" )"
+}
+
+# See _be_has_valid_rollback_be
+_be_has_not_valid_rollback_be() {
+	# Just the opposite...
+	!(_be_has_valid_rollback_be)
+}
+
+# Check if we are in the process of upgrading.
+# We don't necessarily know how many times pfSense-upgrade will be called during a given
+# system upgrade, so we wait and reset this flag in pfSense-rc to be sure we are done.
+_be_is_upgrading() {
+	local _active_ds="$( _be_get_active_ds )"
+	local _upgrading="$( _be_zfs_get_property "${_active_ds}" pfsense:upgrading )"
+
+	[ "${_upgrading}" = "yes" ]
+}
+
+# Guard for _be_prune
+_be_prune_guard() {
+	# various reasons to bail out early from _be_prune below...
+	_be_is_root_on_ufs || _be_readiness_check
+}
+
+# Cleans up any BEs that might exist on incompatible systems
+_be_prune() {
+	_be_prune_guard && return 1
+	/sbin/bectl list -H |
+	while read _name _status _mp _space _creation; do
+		/sbin/bectl destroy -o "${_name}" 1>/dev/null 2>&1
+	done
+	return 0
+}
+
+# Check if automatic update BEs should be created prior to performing a system update
+_be_autobe_disabled() {
+	local _disableautobe="$(read_xml_tag.sh boolean system/firmware/disableautobe)"
+
+	[ "${_disableautobe}" = "true" ] 
+}
+
+# Guard for _be_pre_upgrade
+_be_pre_upgrade_guard() {
+	local _disableautobe="$(read_xml_tag.sh boolean system/firmware/disableautobe)"
+	
+	# various reasons to bail early from _be_prep_upgrade below...
+	_be_not_readiness_check || _be_autobe_disabled || _be_is_upgrading || is_ce
+}
+
+# Prepare the system to upgrade by creating a BE before touching the
+# current environment. We also set some useful ZFS user properties
+# here as well for displaying in the UI.
+_be_prep_upgrade() {
+	# short-circuit when applicable, return 0 to proceed with upgrade
+	_be_pre_upgrade_guard && return 0
+
+	local _timestamp="$( date "+%Y%m%d%H%M%S" )"
+	local _be_name="auto-$( _be_get_active )-${_timestamp}"
+
+	_echo -n ">>> Creating automatic rollback boot environment..."
+
+	/sbin/bectl create -r "${_be_name}" 1>/dev/null 2>&1
+	if [ $? -eq 0 ]; then
+		local _active_ds="$( _be_get_active_ds )"
+		local _ds_name="$( _be_name_to_ds ${_be_name} )"
+
+		# save a tiny bit of state to ensure we only run this once
+		_be_zfs_set_property ${_active_ds} pfsense:upgrading yes
+
+		# cache some useful bits for easily scraping for the UI
+		_be_zfs_set_property ${_active_ds} pfsense:rollbackbe ${_be_name}
+		_be_zfs_set_property ${_ds_name} pfsense:description "Automatically created by system update"
+		_be_zfs_set_property ${_ds_name} pfsense:version "$( _be_get_pkg_version )"
+	fi
+
+	_echo " done."
+
+	# did we actually create a valid rollback BE?
+	# if something went wrong during the above, this will cause the upgrade to terminate immediately... 
+	_be_has_not_valid_rollback_be && return 1
+
+	# looks good
+	return 0
+}
+
+# Guard for _be_prep_reboot
+_be_prep_reboot_guard() {
+	# various reasons to bail early from _be_prep_reboot below...
+	_be_not_readiness_check
+}
+
+# Prepare the system to reboot by ensuring that we are rebooting into the
+# BE that is actively being upgraded.
+_be_prep_reboot() {
+	# short-circuit when applicable
+	_be_prep_reboot_guard && return 0
+
+	local _name="$( _be_get_active )"
+
+	_echo -n ">>> Activating boot environment ${_name}..."
+
+	/sbin/bectl activate "${_name}" 1>/dev/null 2>&1
+
+	_echo " done."
+}
+
+# Prepare the system for a dataset migration
+_be_pre_migration() {
+	local _source_path="${1}"
+	local _target_dataset="${2}"
+	local _tmp_source_path="/tmp${_source_path}.old"
+
+	# create a scratch location
+	/bin/mkdir -p "${_tmp_source_path}" 1>/dev/null 2>&1
+
+	# save a copy of the source data to the scratch location
+	/bin/cp -pR "${_source_path}/" "${_tmp_source_path}" 1>/dev/null 2>&1
+
+	# destroy source location
+	/bin/rm -fr "${_source_path}" 1>/dev/null 2>&1
+}
+
+# Create a dataset with some special properties
+_be_create_dataset() {
+	local _source_path="${1}"
+	local _target_dataset="${2}"
+	local _tmp_source_path="/tmp${_source_path}.old"
+
+	# ensure we are starting off with a consistent state
+	_be_zfs_destroy "${_target_dataset}"
+
+	# create the new target dataset
+	_be_zfs_create "${_source_path}" "${_target_dataset}"
+
+	# set target dataset properties
+	_be_zfs_set_property "${_target_dataset}" setuid off
+	_be_zfs_set_property "${_target_dataset}" exec off
+	_be_zfs_set_property "${_target_dataset}" canmount noauto
+}
+
+# Force remount a dataset
+_be_remount_ds() {
+	local _dataset="${1}"
+
+	/sbin/zfs list -rH -o mountpoint,name,canmount,mounted -s mountpoint -t filesystem "${_dataset}" | \
+	while read _mp _name _canmount _mounted ; do
+		# skip filesystems that must not be mounted
+		[ "$_canmount" = "off" ] && continue
+		case "$_mp" in
+		"none" | "legacy" | "/" | "/$_be")
+			# do nothing for filesystems with unset or legacy mountpoint
+			# or those that would be mounted over /
+			;;
+		"/$_be/"*)
+			# skip filesystems that are already mounted
+			[ "$_mounted" = "yes" ] && \
+				/sbin/unmount -f -t zfs $_name 1>/dev/null 2>&1
+			# filesystems with mountpoint relative to BE
+			/sbin/mount -t zfs $_name ${_mp#/$_be} 1>/dev/null 2>&1
+			;;
+		*)
+			# skip filesystems that are already mounted
+			[ "$_mounted" = "yes" ] && \
+				/sbin/zfs unmount -f $_name 1>/dev/null 2>&1
+			# filesystems with mountpoint elsewhere
+			/sbin/zfs mount $_name 1>/dev/null 2>&1
+			;;
+		esac
+	done
+}
+
+# Cleanup the migration
+_be_post_migration() {
+	local _source_path="${1}"
+	local _target_dataset="${2}"
+	local _tmp_source_path="/tmp${_source_path}.old"
+
+	# relocate data back from scratch location to source location
+	/bin/cp -pR "${_tmp_source_path}/" "${_source_path}" 1>/dev/null 2>&1
+
+	# destroy scratch location
+	/bin/rm -fr "${_tmp_source_path}" 1>/dev/null 2>&1
+
+	# cycle the dataset mount
+	_be_remount_ds "${_target_dataset}"
+}
+
+# Do a complete migration given a source path and a target dataset
+_be_do_migration() {
+	local _source_path="${1}"
+	local _target_dataset="${2}"
+
+	# short-circuit if the layout is already compatible and migration can be skipped
+	_be_is_path_on_root ${_source_path} && !([ -L "${_source_path}" ]) && return 0
+
+	_echo -n "Migrating ${_source_path} to ZFS dataset ${_target_dataset}..."
+
+	# move source data to a scratch location
+	_be_pre_migration "${_source_path}" "${_target_dataset}"
+
+	# create the target dataset
+	_be_create_dataset "${_source_path}" "${_target_dataset}"
+
+	# move source data from scratch location and cleanup
+	_be_post_migration "${_source_path}" "${_target_dataset}"
+
+	_echo " done."
+}
+
+# Guard for _be_migrate
+_be_migrate_guard() {
+	# various reasons to bail early from _be_migrate below...
+	_be_is_root_on_ufs
+}
+
+# Read a table of migrations and perform each one when on ZFS
+_be_migrate() {
+	# short-circuit if we are on UFS
+	_be_migrate_guard && return 0
+
+	# the actual list of migrations to perform
+	local _migration_table="
+	#	PATH		DATASET
+		/cf		$( _be_get_active_ds )/cf
+		/var/cache/pkg	$( _be_get_active_ds )/var_cache_pkg
+		/var/db/pkg	$( _be_get_active_ds )/var_db_pkg
+	" # END-QUOTE
+
+	# now we do the migrations...
+	echo "${_migration_table}" | while read _path _dataset; do
+		# skip rows beginning with # (intended for comments as above)
+		case "$_path" in "#"*|"") continue; esac
+		_be_do_migration "${_path}" "${_dataset}"
+	done
+	return 0
 }
 
 notice() {
@@ -260,6 +653,10 @@ is_ce() {
 	return 1
 }
 
+is_plus() {
+	!(is_ce)
+}
+
 repo_is_plus_upgrade() {
 	pkg_repo_conf_path=$(read_xml_tag.sh string system/pkg_repo_conf_path)
 
@@ -269,86 +666,38 @@ repo_is_plus_upgrade() {
 	return 1
 }
 
-abi_setup() {
-	local _freebsd_version=$(uname -r)
-	local _pkg_repo_conf="/usr/local/etc/pkg/repos/${product}.conf"
+custom_repo_cleanup() {
+	local _custom_repo_files="/usr/local/share/${product}/pkg/repos/${product}-repo-custom.*"
 
-	CUR_ABI="FreeBSD:${_freebsd_version%%.*}:${arch}"
-	CUR_ALTABI="freebsd:${_freebsd_version%%.*}"
-
-	if [ "${arch}" = "armv6" ]; then
-		CUR_ALTABI="${CUR_ALTABI}:${arch}:32:el:eabi:hardfp"
-	elif [ "${arch}" = "armv7" ]; then
-		CUR_ALTABI="${CUR_ALTABI}:${arch}:32:el:eabi:softfp"
-	elif [ "${arch}" = "aarch64" ]; then
-		CUR_ALTABI="${CUR_ALTABI}:${arch}:64"
-	elif [ "${arch}" = "i386" ]; then
-		CUR_ALTABI="${CUR_ALTABI}:x86:32"
-	else
-		CUR_ALTABI="${CUR_ALTABI}:x86:64"
-	fi
-
-	if [ ! -e ${_pkg_repo_conf} ]; then
-		validate_repo_conf
-	fi
-
-	local _repo_abi_file=$(readlink ${_pkg_repo_conf})
-
-	if [ -f ${_repo_abi_file%%.conf}.abi ]; then
-		ABI=$(cat ${_repo_abi_file%%.conf}.abi)
-	else
-		ABI=${CUR_ABI}
-	fi
-
-	if [ -f ${_repo_abi_file%%.conf}.altabi ]; then
-		ALTABI=$(cat ${_repo_abi_file%%.conf}.altabi)
-	else
-		ALTABI=${CUR_ALTABI}
-	fi
-
-	# Make sure pkg.conf is set properly so GUI can work
-	echo "ABI=${ABI}" > /usr/local/etc/pkg.conf
-	echo "ALTABI=${ALTABI}" >> /usr/local/etc/pkg.conf
-
-	AUTH_CA="/etc/ssl/netgate-ca.pem"
-	AUTH_CERT="/etc/ssl/pfSense-repo-custom.cert"
-	AUTH_KEY="/etc/ssl/pfSense-repo-custom.key"
-	if repo_is_plus_upgrade -a -f "${AUTH_CA}" -a -f "${AUTH_CERT}" -a \
-	     -f "${AUTH_KEY}" ; then
-		cat << EOF >> /usr/local/etc/pkg.conf
-PKG_ENV {
-	SSL_CA_CERT_FILE=${AUTH_CA}
-	SSL_CLIENT_CERT_FILE=${AUTH_CERT}
-	SSL_CLIENT_KEY_FILE=${AUTH_KEY}
+	/usr/local/bin/php -r \
+	    "require_once('config.inc'); \
+	     require_once('config.lib.inc'); \
+	     config_del_path('system/pkg_repo_conf_path'); \
+	     write_config('Remove the ${product} upgrade repo');"
+	/bin/rm -f ${_custom_repo_files}
 }
-EOF
+
+copy_dtb() {
+	local _dtb_src="${1}"
+	local _dtb_src_old="${2}"
+	local _dtb_dst_old="${3}"
+
+	dtb_drc=""
+	if [ -f "${_dtb_src}" ]; then
+		dtb_src="${_dtb_src}"
+	elif [ -f "${_dtb_src_old}" ]; then
+		dtb_src="${_dtb_src_old}"
+	fi
+	if [ -z "${dtb_src}" ]; then
+		return 1
 	fi
 
-	# XXX Replace it by a function that detect thoth hardware
-	if [ "${arch}" = "aarch64" ]; then
-		cat << EOF >> /usr/local/etc/pkg.conf
-PKG_ENV {
-	OPENSSL_CONF=/etc/thoth/openssl.cnf
-	SSL_CA_CERT_FILE=/etc/thoth/ca.pem
-	SSL_CLIENT_CERT_FILE=/etc/thoth/device.pem
-	SSL_CLIENT_KEY_FILE=/etc/thoth/key.pem
-}
-EOF
+	if [ -n "${_dtb_dst_old}" ]; then
+		cp "${dtb_src}" "/boot/msdos/${_dtb_dst_old}"
 	fi
+	cp "${dtb_src}" "/boot/msdos"
 
-	local _pkg_abi=$(_pkg query %q pkg)
-	if [ "${CUR_ABI}" != "${_pkg_abi}" -a "${_pkg_abi}" != "${ABI}" ]; then
-		reinstall_pkg=1
-	fi
-
-	if [ "${CUR_ABI}" = "${ABI}" -o "${CUR_ABI}" = "${ALTABI}" ] ; then
-		NEW_MAJOR=""
-	else
-		NEW_MAJOR=1
-		export IGNORE_OSVERSION=yes
-	fi
-
-	export CUR_ABI CUR_ALTABI ABI ALTABI NEW_MAJOR
+	return 0
 }
 
 get_pkg_repo_url() {
@@ -393,6 +742,15 @@ pkg_update() {
 	[ "${1}" = "force" ] \
 	    && _force=" -f"
 
+	if [ -n "${reinstall_pkg}" ] \
+	    || [ -z "${NEW_MAJOR}" -a "$(compare_pkg_version pkg)" = "<" ]; then
+		pkg_unlock pkg
+		_exec "pkg-static upgrade${dont_update} pkg" "Upgrading pkg" \
+		    mute
+		reinstall_pkg=""
+		_force=" -f"
+	fi
+
 	if [ -z "${_force}" -a -n "${dont_update}" ]; then
 		return 0
 	fi
@@ -400,20 +758,10 @@ pkg_update() {
 	[ "${2}" = "mute" ] \
 	    && _mute="mute"
 
-	/usr/local/bin/php -r 'require_once("pkg-utils.inc");update_repos();'
-	abi_setup
-
 	_exec "pkg-static update${_force}" "Updating repositories metadata" \
 	    ${_mute} "" do_not_exit
 
 	if [ $? -ne 0 -a -z "${_do_not_bootstrap}" ]; then
-		if [ -n "${NEW_MAJOR}" ]; then
-			_exec "${_pkg_binary} bootstrap -f" \
-			    "Bootstrap pkg due to major OS upgrade"
-			pkg_update "${force}" "${_mute}" _do_not_bootstrap
-			return
-		fi
-
 		# Since pkg version 1.13 it moved to use repository metadata
 		# version 2, which cannot be processed by older pkg binaries
 		#
@@ -424,17 +772,6 @@ pkg_update() {
 		local _cmp=$(_pkg version -t ${_ver} "1.13")
 		if [ "${_cmp}" != "<" ]; then
 			return
-		fi
-
-		# Make fetch to work with thoth
-		local _fetch_env=""
-		local _fetch_args=""
-		if [ "${arch}" = "aarch64" ]; then
-			_fetch_env="env OPENSSL_CONF=/etc/thoth/openssl.cnf"
-			_fetch_args="--cert=/etc/thoth/device.pem"
-			_fetch_args="${_fetch_args} --key=/etc/thoth/key.pem"
-			_fetch_args="${_fetch_args} --ca-cert=/etc/thoth/ca.pem"
-			_pkg_binary="/usr/local/sbin/pkg-static"
 		fi
 
 		local _url=$(get_pkg_repo_url)
@@ -450,60 +787,6 @@ pkg_update() {
 			pkg_update "${force}" "${_mute}" _do_not_bootstrap
 		fi
 	fi
-}
-
-pkg_upgrade_repo() {
-	if [ -n "${NEW_MAJOR}" -a "${action}" != "upgrade" ]; then
-		return
-	fi
-
-	if [ -n "${reinstall_pkg}" ] \
-	    || [ -z "${NEW_MAJOR}" -a "$(compare_pkg_version pkg)" = "<" ]; then
-		pkg_unlock pkg
-		_exec "pkg-static upgrade${dont_update} pkg" "Upgrading pkg" \
-		    mute
-		reinstall_pkg=""
-		pkg_update force
-	fi
-
-	local _repo_pkg="${product}-repo"
-
-	case "$(compare_pkg_version ${_repo_pkg})" in
-		"<")
-			local _force=""
-			;;
-		">")
-			# Do not downgrade repository package when repo points to
-			# an older ABI or release branch.
-			return
-			;;
-		"=")
-			return
-			;;
-		*)
-			_echo "ERROR: Unable to compare version of ${_repo_pkg}"
-			_exit 1
-	esac
-
-	cp /usr/local/etc/pkg/repos/${product}.conf /tmp/${product}.conf.copy
-	if !(is_ce && repo_is_plus_upgrade) ; then
-		_exec "pkg-static upgrade${dont_update}${_force} ${_repo_pkg}" \
-		    "Upgrading ${_repo_pkg}" mute
-	fi
-	abi_setup
-	# If conf differs, for an update
-	if ! cmp -s /usr/local/etc/pkg/repos/${product}.conf \
-	    /tmp/${product}.conf.copy; then
-		pkg_update force
-
-		# New repo may contain newer pkg
-		if [ -z "${NEW_MAJOR}" -a "$(compare_pkg_version pkg)" = "<" ]
-		then
-			_exec "pkg-static upgrade pkg" "Upgrading pkg" mute
-			pkg_update force
-		fi
-	fi
-	rm -f /tmp/${product}.conf.copy
 }
 
 upgrade_available() {
@@ -663,6 +946,14 @@ pkg_upgrade() {
 			rm -f ${logfile}
 		fi
 
+		# Cleanup BEs on incompatible systems.
+		# Note: This is a no-op on UFS
+		_be_prune
+
+		# Migrate datasets on systems not compatible with BEs.
+		# Note: This is a no-op on UFS
+		_be_migrate
+
 		pkg_update force
 
 		# Lock pkg to avoid having pkg binary for version N+1 installed
@@ -680,8 +971,6 @@ pkg_upgrade() {
 		if [ "$(compare_pkg_version ${product}-upgrade)" != "=" ]; then
 			_new_pfsense_upgrade=1
 		fi
-
-		pkg_upgrade_repo
 
 		# If a new version of pfSense-upgrade is available, upgrade it
 		# and return a special code 99 used by wrapper to run newer
@@ -733,7 +1022,7 @@ pkg_upgrade() {
 		fi
 
 		# Always make sure important packages are set as vital
-		set_vital_flag pkg ${kernel_pkg} ${product} ${product}-rc \
+		set_vital_flag pkg ${kernel_pkg} ${product}-boot ${product} \
 		    ${product}-base ${uboot_pkg}
 
 		check_upgrade mute skip_update
@@ -795,6 +1084,14 @@ pkg_upgrade() {
 			fi
 		fi
 
+		# Prepare system by creating a rollback BE
+		# Note: This is a no-op on UFS (or on CE)
+		_be_prep_upgrade
+		if [ $? -ne 0 ]; then
+			_echo "ERROR: Unable to create automatic rollback boot environment."
+			_exit 1
+		fi
+
 		# Detect the move from suricata to suricata4
 		if is_pkg_installed ${product}-pkg-suricata \
 		    && _pkg rquery -U %n ${product}-pkg-suricata4 \
@@ -848,13 +1145,24 @@ pkg_upgrade() {
 				[ -f /tmp/loader.rc.local ] \
 				    && cp /tmp/loader.rc.local /boot 2>/dev/null
 			fi
-			# Force upgrade pfSense-rc together with kernel. It's
-			# failing for some reason on armv[67] even with the
-			# proper dependency version registered
-			if upgrade_available ${product}-rc; then
-				_exec "pkg-static upgrade -U ${product}-rc" \
-				    "Upgrading ${product}-rc"
+
+			# Attempt to force update boot package and install efi
+			# loader first, bail if it fails
+			_echo -n ">>> Upgrading ${product}-boot..."
+			_exec "umount -f /boot/efi" "Unmounting /boot/efi" mute ignore_result
+			local _output=$(_exec "pkg-static upgrade -f ${product}-boot")
+			if [ $(expr "'${_output}'" : '.*POST-INSTALL script failed.*') != "0" ]; then
+				_echo " failed."
+				_exit 1
 			fi
+			echo " done."
+
+			# Remove vital flag from pfSense-rc so we can remove it later,
+			# now that the rc scripts are part of security/pfSense
+			if is_pkg_installed "${product}-rc"; then
+				unset_vital_flag "${product}-rc"
+			fi
+
 			# In the past /boot/loader.conf was part of kernel pkg
 			# and now it's an orphan file.  Check if current
 			# installation has it registered on kernel pkg and make
@@ -873,14 +1181,20 @@ pkg_upgrade() {
 				# Mount /boot/msdos and update the DTB in FAT
 				# slice.
 				mount /boot/msdos >/dev/null 2>&1
-				cp /boot/dtb/armada-3720-netgate-1100.dtb /boot/msdos
+				DTB_SRC="/boot/dtb/netgate/armada-3720-netgate-1100.dtb"
+				DTB_SRC_OLD="/boot/dtb/armada-3720-netgate-1100.dtb"
+				DTB_DST_OLD="armada-3720-sg1100.dtb"
+				copy_dtb "${DTB_SRC}" "${DTB_SRC_OLD}" "${DTB_DST_OLD}"
 				umount /boot/msdos >/dev/null 2>&1
 			fi
 			if [ "${SYSTEM}" = "2100" ]; then
 				# Mount /boot/msdos and update the DTB in FAT
 				# slice.
 				mount /boot/msdos >/dev/null 2>&1
-				cp /boot/dtb/armada-3720-netgate-2100.dtb /boot/msdos
+				DTB_SRC="/boot/dtb/netgate/armada-3720-netgate-2100.dtb"
+				DTB_SRC_OLD="/boot/dtb/armada-3720-netgate-2100.dtb"
+				DTB_DST_OLD="armada-3720-sg2100.dtb"
+				copy_dtb "${DTB_SRC}" "${DTB_SRC_OLD}" "${DTB_DST_OLD}"
 				umount /boot/msdos >/dev/null 2>&1
 			fi
 		fi
@@ -924,12 +1238,6 @@ pkg_upgrade() {
 	fi
 
 	if [ "${next_stage}" = "2" ]; then
-		if [ -n "${is_pkg_locked}" ]; then
-			export IGNORE_OSVERSION=yes
-		fi
-
-		pkg_update force
-
 		pkg_lock "${pkg_prefix}*"
 		unlock_additional_pkgs=1
 
@@ -954,10 +1262,14 @@ pkg_upgrade() {
 
 		if upgrade_available; then
 			delete_annotation=1
-			if [ -n "${is_pkg_locked}" ]; then
-				_exec "pkg-static bootstrap -f" \
-				    "Bootstrapping pkg for major upgrade" mute
 
+			# Remove legacy pfSense-rc package if present
+			if is_pkg_installed "${product}-rc"; then
+				echo "Removing ${product}-rc"
+				_pkg delete -yf "${product}-rc"
+			fi
+
+			if [ -n "${is_pkg_locked}" ]; then
 				# Upgrade pkg
 				pkg_unlock pkg
 				_pkg annotate -q -D ${kernel_pkg} new_major
@@ -980,9 +1292,6 @@ pkg_upgrade() {
 						${uboot_update}
 					fi
 				fi
-
-				# Make sure PHP setup is fine
-				/etc/rc.php_ini_setup >/dev/null 2>&1
 			else
 				# Upgrade core packages
 				_exec "pkg-static upgrade -r ${product}-core" \
@@ -996,15 +1305,23 @@ pkg_upgrade() {
 			    "Upgrading necessary packages"
 			delete_annotation=""
 
+			# Make sure PHP setup is fine
+			_exec "/etc/rc.d/ldconfig onestart" \
+			    "Updating ldconfig" mute ignore_result
+			/etc/rc.php_ini_setup >/dev/null 2>&1
+
 			# Always make sure important packages are set as vital
-			set_vital_flag pkg ${kernel_pkg} ${product} \
-			    ${product}-rc ${product}-base ${uboot_pkg}
+			set_vital_flag pkg ${kernel_pkg} ${product}-boot ${product} \
+			    ${product}-base ${uboot_pkg}
 
 			# Register that system is running latest pkg_set_version
 			cp -f ${pkg_set_version} ${running_pkg_set_version}
 
 			# Cleanup possible crash report from PHP upgrade
 			rm -f /tmp/PHP_errors.log
+
+			# Clean up .pkgsave files
+			find / -name \*.pkgsave -delete
 		fi
 
 		_pkg annotate -q -M ${kernel_pkg} next_stage 3
@@ -1026,21 +1343,24 @@ pkg_upgrade() {
 	fi
 
 	if [ "${next_stage}" = "3" ]; then
-		if [ -n "${is_pkg_locked}" ]; then
-			export IGNORE_OSVERSION=yes
-		fi
-
-		pkg_update force
-
 		if upgrade_available; then
 			delete_annotation=1
 			_exec "pkg-static upgrade${dont_update}" \
 			    "Upgrading necessary packages"
 			delete_annotation=""
+			# Make sure PHP setup is fine
+			_exec "/etc/rc.d/ldconfig onestart" \
+			    "Updating ldconfig" mute ignore_result
+			/etc/rc.php_ini_setup >/dev/null 2>&1
 		fi
 
 		# Cleanup a possible crash report created during PHP upgrade
 		rm -f /tmp/PHP_errors.log
+
+		# Remove the pfSense Plus upgrade repository.
+		if is_plus -a repo_is_plus_upgrade ; then
+			custom_repo_cleanup
+		fi
 
 		_pkg annotate -q -D ${kernel_pkg} next_stage
 
@@ -1104,179 +1424,10 @@ get_meta_pkg_name() {
 	elif is_pkg_installed ${product}; then
 		echo "${product}"
 	else
-		_echo "ERROR: It was not possible to identify which" \
+		_echo -o stderr "ERROR: It was not possible to identify which" \
 		    "${product} meta package is installed"
 		_exit 1
 	fi
-}
-
-get_repo_abi_major() {
-	local _repo_conf="${1}"
-	local _abi_file="${_repo_conf%%.conf}.abi"
-	local _abi="${CUR_ABI}"
-
-	[ -f "${_abi_file}" ] && _abi=$(cat "${_abi_file}")
-	echo "${_abi}" | awk -F: '{print $2}'
-}
-
-get_repo_abi_values() {
-	local _repo_conf="${1}"
-	local _abi_file="${_repo_conf%%.conf}.abi"
-	local _altabi_file="${_repo_conf%%.conf}.altabi"
-
-	REPO_ABI="${CUR_ABI}"
-	REPO_ALTABI="${CUR_ALTABI}"
-	[ -f "${_abi_file}" ] && REPO_ABI=$(cat "${_abi_file}")
-	[ -f "${_altabi_file}" ] && REPO_ALTABI=$(cat "${_altabi_file}")
-}
-
-prepare_repo_override_dir() {
-	local _repo_conf="${1}"
-	local _tmp_dir=""
-
-	_tmp_dir=$(mktemp -d "/tmp/${product}.repo.XXXXXX") || return 1
-	cp -f "${_repo_conf}" "${_tmp_dir}/${product}.conf"
-	echo "${_tmp_dir}"
-}
-
-cleanup_repo_override_dir() {
-	local _repo_dir="${1}"
-
-	[ -n "${_repo_dir}" -a -d "${_repo_dir}" ] && rm -rf "${_repo_dir}"
-}
-
-compare_pkg_version_repo() {
-	local _pkg_name="${1}"
-	local _repo_dir="${2}"
-	local _abi="${3}"
-	local _altabi="${4}"
-
-	if [ -z "${_pkg_name}" ]; then
-		echo '!'
-		return 1
-	fi
-
-	if ! is_pkg_installed ${_pkg_name}; then
-		echo '!'
-		return 1
-	fi
-
-	local _lver=$(_pkg query %v ${_pkg_name})
-
-	if [ -z "${_lver}" ]; then
-		_echo "ERROR: It was not possible to determine ${_pkg_name}" \
-		    "local version"
-		_exit 1
-	fi
-
-	local _rver=$(pkg-static -o REPOS_DIR=${_repo_dir} \
-	    -o ABI=${_abi} -o ALTABI=${_altabi} rquery -U %v ${_pkg_name})
-
-	if [ -z "${_rver}" ]; then
-		_rver=$(pkg-static -o REPOS_DIR=${_repo_dir} \
-		    -o ABI=${_abi} -o ALTABI=${_altabi} rquery %v ${_pkg_name})
-	fi
-
-	if [ -z "${_rver}" ]; then
-		_echo "ERROR: It was not possible to determine ${_pkg_name}" \
-		    "remote version"
-		_exit 1
-	fi
-
-	local _version=$(_pkg version -t ${_lver} ${_rver})
-
-	if [ $? -ne 0 ]; then
-		_echo "ERROR: Error comparing ${_pkg_name} local and remote" \
-		    "versions"
-		_exit 1
-	fi
-
-	echo ${_version}
-	return 0
-}
-
-check_upgrade_repo_override() {
-	local _mute="${1}"
-	local _skip_update="${2}"
-	local _meta_pkg="${3}"
-	local _core_pkgs="${4}"
-	local _current_repo_conf="/usr/local/etc/pkg/repos/${product}.conf"
-	local _current_repo_target=""
-	local _current_major=""
-	local _best_conf=""
-	local _best_major=""
-
-	if [ -L "${_current_repo_conf}" ]; then
-		_current_repo_target=$(readlink ${_current_repo_conf})
-	elif [ -f "${_current_repo_conf}" ]; then
-		_current_repo_target="${_current_repo_conf}"
-	fi
-
-	if [ -n "${_current_repo_target}" ]; then
-		_current_major=$(get_repo_abi_major "${_current_repo_target}")
-	fi
-
-	for _conf in /usr/local/share/${product}/pkg/repos/${product}-repo*.conf;
-	do
-		[ -f "${_conf}" ] || continue
-		local _major=$(get_repo_abi_major "${_conf}")
-		[ -z "${_major}" ] && continue
-
-		if [ -z "${_best_major}" ] || [ "${_major}" -gt "${_best_major}" ]; then
-			_best_major="${_major}"
-			_best_conf="${_conf}"
-		fi
-	done
-
-	if [ -z "${_best_conf}" ]; then
-		return 1
-	fi
-
-	if [ -n "${_current_major}" -a "${_best_major}" -le "${_current_major}" ]; then
-		return 1
-	fi
-
-	get_repo_abi_values "${_best_conf}"
-
-	local _repo_dir=$(prepare_repo_override_dir "${_best_conf}")
-	if [ -z "${_repo_dir}" ]; then
-		return 1
-	fi
-
-	if [ -z "${_skip_update}" -a -z "${dont_update}" ]; then
-		pkg-static -o REPOS_DIR=${_repo_dir} -o ABI=${REPO_ABI} \
-		    -o ALTABI=${REPO_ALTABI} update -f >/dev/null 2>&1
-	fi
-
-	for _package in ${_meta_pkg} ${_core_pkgs}; do
-		local _version_compare=$(compare_pkg_version_repo ${_package} \
-		    ${_repo_dir} ${REPO_ABI} ${REPO_ALTABI})
-
-		case "${_version_compare}" in
-			=|'>')
-				continue
-				;;
-		esac
-
-		local _new_version=$(pkg-static -o REPOS_DIR=${_repo_dir} \
-		    -o ABI=${REPO_ABI} -o ALTABI=${REPO_ALTABI} \
-		    rquery -U %v ${_package})
-
-		if [ -z "${_new_version}" ]; then
-			_new_version=$(pkg-static -o REPOS_DIR=${_repo_dir} \
-			    -o ABI=${REPO_ABI} -o ALTABI=${REPO_ALTABI} \
-			    rquery %v ${_package})
-		fi
-
-		[ -z "${_mute}" ] \
-		    && _echo \
-		    "${_new_version} version of ${product} is available"
-		cleanup_repo_override_dir "${_repo_dir}"
-		return 2
-	done
-
-	cleanup_repo_override_dir "${_repo_dir}"
-	return 1
 }
 
 check_upgrade() {
@@ -1285,7 +1436,6 @@ check_upgrade() {
 	local _meta_pkg=$(get_meta_pkg_name)
 	local _core_pkgs=$(pkg-static query -e \
 	    "%n ~ ${product}-kernel-* || %n ~ ${product}-base*" %n 2>/dev/null)
-	local _repo_behind=""
 
 	# Do not upgrade while wg interfaces are assigned
 	if sed '/<interfaces>/,/<\/interfaces>/!d' /cf/conf/config.xml \
@@ -1304,40 +1454,95 @@ check_upgrade() {
 	[ -z "${_skip_update}" ] \
 	    && pkg_update "" mute
 
-	pkg_upgrade_repo
-
 	local _version_compare=""
-	for _package in ${_meta_pkg} ${_core_pkgs}; do
-		_version_compare=$(compare_pkg_version ${_package})
-		case "${_version_compare}" in
-			=)
+	local _installed_version=""
+	if [ "${action}" == "checkall" ]; then
+		# Get newest of meta or core packages as our baseline version
+		for _package in ${_meta_pkg} ${_core_pkgs}; do
+			local _other_version=$(_pkg query %v ${_package})
+			if [ -z "${_installed_version}" ] || [ $(_pkg version -t ${_installed_version} ${_other_version}) ]; then
+				_installed_version=${_other_version}
+			fi
+		done
+
+		local _new_version="0"
+		local _version_compare=""
+		local _db_dir="/tmp/db/${product}/pkg"
+		for _repo in /usr/local/share/${product}/pkg/repos/${product}-repo*.conf; do
+			[ -e "${_repo}" ] || continue
+			local _reponame=$(_echo $_repo | sed "s/.*${product}-repo-\\(.*\\).conf/\\1/g")
+			local _repopath=${_db_dir}/${_reponame}
+			local _pkg_args=""
+
+			# Skip repos with devel names
+			if [ "${_reponame}" == "devel" ]; then
 				continue
+			fi
+
+			local _is_configured_repo=$( \
+				[ "${_repo}" = "$(stat -f %Y /usr/local/etc/pkg/repos/${product}.conf)" ] >/dev/null 2>&1; \
+				printf $?
+				  )
+			local _pkgs="${_meta_pkg} ${_core_pkgs}"
+			if [ ${_is_configured_repo} -ne 0 ]; then
+				_pkgs="${product}-base"
+				_pkg_args="-C ${_repopath}/pkg.conf"
+				# No repo db files, initialize
+				if [ ! -f "${_db_dir}/${_reponame}/db/repo-${product}.sqlite" ] ||
+				   [ ! -f "${_db_dir}/${_reponame}/db/repo-${product}-core.sqlite" ]; then
+					mkdir -p ${_repopath}
+					${product}-repo-setup ${_db_dir}/${_reponame} $_repo > /dev/null 2>&1
+					$(_pkg ${_pkg_args} update)
+				fi
+			fi
+
+			for _package in ${_pkgs}; do
+				if [ ${_is_configured_repo} -ne 0 ]; then
+				   	_version_compare=$(compare_pkg_version "${_package}" "${_new_version}" "${_repopath}/pkg.conf")
+				else
+					_version_compare=$(compare_pkg_version "${_package}" "${_new_version}")
+				fi
+				if [ "${_version_compare}" == "<" ]; then
+					_new_version=$(_pkg ${_pkg_args} rquery -U %v ${_package})
+				fi
+			done
+		done
+		_version_compare=$(_pkg version -t "${_installed_version}" "${_new_version}")
+		case "${_version_compare}" in
+			'<')
+				if [ -z "${_mute}" ]; then
+					_echo "${_new_version} version of ${product} is available"
+				fi
+				return 2
 				;;
 			'>')
-				_repo_behind=1
-				continue
+				if [ -z "${_mute}" ]; then
+				    _echo "Your system is on a newer version"
+				fi
+				return 0
 				;;
 		esac
+	else
+		for _package in ${_meta_pkg} ${_core_pkgs}; do
+			_version_compare=$(compare_pkg_version ${_package})
+			case "${_version_compare}" in
+				!|=)
+					continue
+					;;
+				'>')
+					[ -z "${_mute}" ] \
+						&& _echo "Your system is on a newer version"
+					return 0
+					;;
+			esac
 
-		local _new_version=$(_pkg rquery -U %v ${_package})
-		[ -z "${_mute}" ] \
-		    && _echo \
-		    "${_new_version} version of ${product} is available"
-		return 2
-	done
-
-	check_upgrade_repo_override "${_mute}" "${_skip_update}" \
-	    "${_meta_pkg}" "${_core_pkgs}"
-	if [ $? -eq 2 ]; then
-		return 2
+		    _new_version=$(_pkg rquery -U %v ${_package})
+			if [ -z "${_mute}" ]; then
+				_echo "${_new_version} version of ${product} is available"
+			fi
+			return 2
+		done
 	fi
-
-	if [ -n "${_repo_behind}" ]; then
-		[ -z "${_mute}" ] \
-		    && _echo "Your system is on a newer version"
-		return 0
-	fi
-
 	[ -z "${_mute}" ] \
 	    && _echo "Your system is up to date"
 	return 0
@@ -1352,10 +1557,17 @@ is_pkg_installed() {
 
 compare_pkg_version() {
 	local _pkg_name="${1}"
+	local _lver="${2}"
+	local _pkg_conf="${3}"
+	local _conf_args=""
 
 	if [ -z "${_pkg_name}" ]; then
 		echo '!'
 		return 1
+	fi
+
+	if [ -n "${_pkg_conf}" ]; then
+		_conf_args="-C ${_pkg_conf}"
 	fi
 
 	if ! is_pkg_installed ${_pkg_name}; then
@@ -1363,34 +1575,39 @@ compare_pkg_version() {
 		return 1
 	fi
 
-	local _lver=$(_pkg query %v ${_pkg_name})
-
 	if [ -z "${_lver}" ]; then
-		_echo "ERROR: It was not possible to determine ${_pkg_name}" \
-		    "local version"
-		_exit 1
+	   local _lver=$(_pkg query %v ${_pkg_name})
 	fi
 
-	local _rver=$(_pkg rquery -U %v ${_pkg_name})
+	if [ -z "${_lver}" ]; then
+		_echo -o stderr "ERROR: It was not possible to determine ${_pkg_name}" \
+		    "local version"
+		echo '!'
+		return 1
+	fi
+
+	local _rver=$(_pkg rquery ${_conf_args} -U %v ${_pkg_name})
 
 	# Maybe we need fresh metadata, lets try to obtain it respecting
 	# dont_update variable
 	if [ -z "${_rver}" ]; then
-		_rver=$(_pkg rquery ${dont_update} %v ${_pkg_name})
+		_rver=$(_pkg ${dont_update} ${_conf_args} rquery %v ${_pkg_name})
 	fi
 
 	if [ -z "${_rver}" ]; then
-		_echo "ERROR: It was not possible to determine ${_pkg_name}" \
+		_echo -o stderr "ERROR: It was not possible to determine ${_pkg_name}" \
 		    "remote version"
-		_exit 1
+		echo '!'
+		return 1
 	fi
 
 	local _version=$(_pkg version -t ${_lver} ${_rver})
 
 	if [ $? -ne 0 ]; then
-		_echo "ERROR: Error comparing ${_pkg_name} local and remote" \
+		_echo -o stderr "ERROR: Error comparing ${_pkg_name} local and remote" \
 		    "versions"
-		_exit 1
+		echo '!'
+		return 1
 	fi
 
 	echo ${_version}
@@ -1486,6 +1703,14 @@ do_reboot() {
 		_msg="in ${reboot_after} seconds."
 	fi
 
+	# Ensure that we are *always* rebooting into the BE that is actively being upgraded
+	# Note: This is a no-op on UFS
+	_be_prep_reboot
+	if [ $? -ne 0 ]; then
+		_echo "ERROR: Unable to activate the boot environment being upgraded ($( _be_get_active ))."
+		_exit 1
+	fi
+
 	local _complete="System is going to be upgraded"
 	if [ -z "${dont_reboot}" ]; then
 		_echo "${_complete}.  Rebooting ${_msg}"
@@ -1503,39 +1728,6 @@ do_reboot() {
 		echo "Upgrade is complete." | wall
 		/etc/rc.notify_message -e -m "Upgrade is complete." \
 		    >/dev/null 2>&1
-	fi
-}
-
-validate_repo_conf() {
-	# Make sure to use default repo conf when it doesn't exist
-	pkg_repo_conf="/usr/local/etc/pkg/repos/${product}.conf"
-
-	default_path="/usr/local/share/${product}/pkg/repos"
-	default_file=$(ls -1 ${default_path}/*.default 2>/dev/null | tail -n 1)
-
-	if [ -n "${default_file}" -a -f "${default_file}" ]; then
-		default="${default_file%%.default}"
-	else
-		default="${default_path}/${product}-repo.conf"
-	fi
-
-	pkg_repo_conf_path=$(read_xml_tag.sh string system/pkg_repo_conf_path)
-
-	if [ -z "${pkg_repo_conf_path}" -o ! -f "${pkg_repo_conf_path}" ]; then
-		pkg_repo_conf_path=${default}
-	fi
-
-	if [ -f "${pkg_repo_conf_path}" ]; then
-		if [ -e "${pkg_repo_conf}" -a ! -L "${pkg_repo_conf}" ]; then
-			rm -f ${pkg_repo_conf}
-			ln -sf ${pkg_repo_conf_path} ${pkg_repo_conf}
-		fi
-
-		if [ "$(readlink ${pkg_repo_conf})" != \
-		    "${pkg_repo_conf_path}" ]; then
-			mkdir -p /usr/local/etc/pkg/repos
-			ln -sf ${pkg_repo_conf_path} ${pkg_repo_conf}
-		fi
 	fi
 }
 
@@ -1579,25 +1771,19 @@ export pkg_prefix=$(php -n /usr/local/sbin/read_global_var pkg_prefix \
 export platform=$(cat /etc/platform)
 
 USE_MFS_TMPVAR=$(read_xml_tag.sh boolean system/use_mfs_tmpvar)
-if [ "${USE_MFS_TMPVAR}" = "true" -a ! -e /conf/ram_disks_failed ]; then
-	export PKG_DBDIR=/root/var/db/pkg
-	export PKG_CACHEDIR=/root/var/cache/pkg
-fi
+# if [ "${USE_MFS_TMPVAR}" = "true" -a ! -e /conf/ram_disks_failed ]; then
+#	export PKG_DBDIR=/root/var/db/pkg
+#	export PKG_CACHEDIR=/root/var/cache/pkg
+# fi
 
 product_version=$(cat /etc/version)
 do_not_send_uniqueid=$(read_xml_tag.sh boolean system/do_not_send_uniqueid)
 if [ "${do_not_send_uniqueid}" != "true" ]; then
-	if command -v gnid >/dev/null 2>&1; then
-		uniqueid=$(gnid)
-		export HTTP_USER_AGENT="${product}/${product_version}:${uniqueid}"
-	else
-		export HTTP_USER_AGENT="${product}/${product_version}"
-	fi
+	uniqueid=$(gnid)
+	export HTTP_USER_AGENT="${product}/${product_version}:${uniqueid}"
 else
 	export HTTP_USER_AGENT="${product}/${product_version}"
 fi
-
-validate_repo_conf
 
 # Flags used in _exit
 export delete_annotation=""
@@ -1628,7 +1814,7 @@ unset action
 unset action_pkg
 unset force_ipv4
 unset force_ipv6
-while getopts 46b:cdfi:hp:l:nr:RuUy opt; do
+while getopts 46b:cCdfi:hp:l:nr:RuUy opt; do
 	case ${opt} in
 		4)
 			if [ -n "${force_ipv6}" ]; then
@@ -1650,6 +1836,8 @@ while getopts 46b:cdfi:hp:l:nr:RuUy opt; do
 			;;
 		c)
 			action="check"
+			;;
+		C)  action="checkall"
 			;;
 		d)
 			stdout=''
@@ -1774,14 +1962,34 @@ if [ -e "${progress_file}" ]; then
 	rm -f ${progress_file}
 fi
 
-arch=$(uname -p)
+unset NEW_MAJOR
 
-# Initialize the Thoth certificates on ARM64
-if [ "${arch}" = "aarch64" ]; then
-	/usr/local/bin/ping-auth.sh > /dev/null
-fi
-
-abi_setup
+# Fetch the latest settings.
+/usr/local/sbin/${product}-repo-setup ${dont_update}
+case "$?" in
+1)
+	echo "failed to update the repository settings!!!"
+	exit 1
+	;;
+11)
+	reinstall_pkg=1
+	;;
+12)
+	NEW_MAJOR=1
+	export IGNORE_OSVERSION=yes
+	;;
+13)
+	reinstall_pkg=1
+	NEW_MAJOR=1
+	export IGNORE_OSVERSION=yes
+	;;
+14)
+	# New repo may contain newer pkg
+	if [ "$(compare_pkg_version pkg)" = "<" ]; then
+		_exec "pkg-static upgrade pkg" "Upgrading pkg" mute
+	fi
+	;;
+esac
 
 # Set itself as vital to prevent users ending up without upgrade script
 set_vital_flag ${product}-upgrade
@@ -1795,8 +2003,6 @@ else
 fi
 
 if [ "${action}" = "install" ]; then
-	pkg_upgrade_repo
-
 	new_php_pkg=$(_pkg rquery -U %dn $(get_meta_pkg_name) \
 	    | egrep '^php[0-9]{2}$')
 
@@ -1816,7 +2022,7 @@ if [ -n "${NEW_MAJOR}" -a "${action}" = "install" ]; then
 fi
 
 case "${action}" in
-	check)
+	check | checkall)
 		check_upgrade
 		_exit $?
 		;;

--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade.wrapper
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade.wrapper
@@ -3,7 +3,7 @@
 # pfSense-upgrade.wrapper
 #
 # part of pfSense (https://www.pfsense.org)
-# Copyright (c) 2015-2022 Rubicon Communications, LLC (Netgate)
+# Copyright (c) 2015-2023 Rubicon Communications, LLC (Netgate)
 # All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
### Motivation
- Sincronizar e adaptar o port de upgrade com o conteúdo upstream do pfSense para permitir upgrades entre FreeBSD 14/15 no produto Kontrol. 
- Eliminar a dependência de binários fechados terminados em `-repoc` substituindo chamadas por rotinas abertas para atualizar repositórios. 
- Ajustar paths, nomes de produto e prefixos para o ambiente Kontrol (ex.: `Kontrol`, `Kontrol-pkg-`) e suportar o fluxo de múltiplos repositórios locais. 

### Description
- Copiei e sincronizei os scripts upstream para o port `sysutils/pfSense-upgrade` renomeados para `Kontrol-*` e atualizei o `Makefile` (`PORTVERSION` aumentado para `1.2.12`). 
- Substituí a chamada ao binário fechado de atualização de repositório por uma combinação de `php -r 'require_once("pkg-utils.inc");update_repos();'` e `pkg-static update -f` dentro de `Kontrol-repo-setup`, evitando o uso de `*-repoc`. 
- Adaptei a lógica de descoberta e inicialização de DBs de repositório para varrer `/usr/local/share/${product}/pkg/repos/${product}-repo*.conf` e inicializar por repositório com `${product}-repo-setup` quando necessário, preservando compatibilidade com o código PHP que chama `{$g['product_name']}-repo-setup`. 
- Ajustei variáveis e comportamentos específicos do produto para `Kontrol` (por exemplo `product`, `product_label`, `pkg_prefix`) e sincronizei alterações do wrapper e cabeçalhos de licença/ano. 
- Incorporei e habilitei no script de upgrade suporte a BE (Boot Environments) e rotinas de migração/rollback que já existem no upstream, além de refinamentos no fluxo de atualização (reinstalação de `pkg`, tratamento de NEW_MAJOR, preparação de BE antes do upgrade e ativação de BE antes do reboot). 

### Testing
- Nenhum teste automatizado foi executado sobre o código modificado.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69835c358800832ea2027c36237e0167)