### PR TITLE
sysutils/pfSense-upgrade: use OSVERSION in pkg.conf

### DIFF
--- a/sysutils/pfSense-upgrade/Makefile
+++ b/sysutils/pfSense-upgrade/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	Kontrol-upgrade
 PORTVERSION=	1.3.26
-PORTREVISION=	# empty
+PORTREVISION=	1
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/sysutils/pfSense-upgrade/files/Kontrol-repo-setup
+++ b/sysutils/pfSense-upgrade/files/Kontrol-repo-setup
@@ -44,22 +44,11 @@ validate_repo_conf() {
 
 abi_setup() {
 	local _freebsd_version=$(uname -r)
+	local _osversion=$(sysctl -n kern.osreldate 2>/dev/null)
 	local _pkg_repo_conf="/usr/local/etc/pkg/repos/${product}.conf"
 
 	CUR_ABI="FreeBSD:${_freebsd_version%%.*}:${arch}"
-	CUR_ALTABI="freebsd:${_freebsd_version%%.*}"
-
-	if [ "${arch}" = "armv6" ]; then
-		CUR_ALTABI="${CUR_ALTABI}:${arch}:32:el:eabi:hardfp"
-	elif [ "${arch}" = "armv7" ]; then
-		CUR_ALTABI="${CUR_ALTABI}:${arch}:32:el:eabi:softfp"
-	elif [ "${arch}" = "aarch64" ]; then
-		CUR_ALTABI="${CUR_ALTABI}:${arch}:64"
-	elif [ "${arch}" = "i386" ]; then
-		CUR_ALTABI="${CUR_ALTABI}:x86:32"
-	else
-		CUR_ALTABI="${CUR_ALTABI}:x86:64"
-	fi
+	CUR_OSVERSION="${_osversion}"
 
 	if [ ! -e ${_pkg_repo_conf} ]; then
 		validate_repo_conf
@@ -73,14 +62,14 @@ abi_setup() {
 		ABI=${CUR_ABI}
 	fi
 
-	if [ -f ${_repo_abi_file%%.conf}.altabi ]; then
-		ALTABI=$(cat ${_repo_abi_file%%.conf}.altabi)
+	if [ -f ${_repo_abi_file%%.conf}.osversion ]; then
+		OSVERSION=$(cat ${_repo_abi_file%%.conf}.osversion)
 	else
-		ALTABI=${CUR_ALTABI}
+		OSVERSION=${CUR_OSVERSION}
 	fi
 
 	echo "ABI=${ABI}" > /usr/local/etc/pkg.conf
-	echo "ALTABI=${ALTABI}" >> /usr/local/etc/pkg.conf
+	echo "OSVERSION=${OSVERSION}" >> /usr/local/etc/pkg.conf
 
 	AUTH_CA="/etc/ssl/netgate-ca.pem"
 	AUTH_CERT="/etc/ssl/pfSense-repo-custom.cert"

--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -271,22 +271,11 @@ repo_is_plus_upgrade() {
 
 abi_setup() {
 	local _freebsd_version=$(uname -r)
+	local _osversion=$(sysctl -n kern.osreldate 2>/dev/null)
 	local _pkg_repo_conf="/usr/local/etc/pkg/repos/${product}.conf"
 
 	CUR_ABI="FreeBSD:${_freebsd_version%%.*}:${arch}"
-	CUR_ALTABI="freebsd:${_freebsd_version%%.*}"
-
-	if [ "${arch}" = "armv6" ]; then
-		CUR_ALTABI="${CUR_ALTABI}:${arch}:32:el:eabi:hardfp"
-	elif [ "${arch}" = "armv7" ]; then
-		CUR_ALTABI="${CUR_ALTABI}:${arch}:32:el:eabi:softfp"
-	elif [ "${arch}" = "aarch64" ]; then
-		CUR_ALTABI="${CUR_ALTABI}:${arch}:64"
-	elif [ "${arch}" = "i386" ]; then
-		CUR_ALTABI="${CUR_ALTABI}:x86:32"
-	else
-		CUR_ALTABI="${CUR_ALTABI}:x86:64"
-	fi
+	CUR_OSVERSION="${_osversion}"
 
 	if [ ! -e ${_pkg_repo_conf} ]; then
 		validate_repo_conf
@@ -300,15 +289,15 @@ abi_setup() {
 		ABI=${CUR_ABI}
 	fi
 
-	if [ -f ${_repo_abi_file%%.conf}.altabi ]; then
-		ALTABI=$(cat ${_repo_abi_file%%.conf}.altabi)
+	if [ -f ${_repo_abi_file%%.conf}.osversion ]; then
+		OSVERSION=$(cat ${_repo_abi_file%%.conf}.osversion)
 	else
-		ALTABI=${CUR_ALTABI}
+		OSVERSION=${CUR_OSVERSION}
 	fi
 
 	# Make sure pkg.conf is set properly so GUI can work
 	echo "ABI=${ABI}" > /usr/local/etc/pkg.conf
-	echo "ALTABI=${ALTABI}" >> /usr/local/etc/pkg.conf
+	echo "OSVERSION=${OSVERSION}" >> /usr/local/etc/pkg.conf
 
 	AUTH_CA="/etc/ssl/netgate-ca.pem"
 	AUTH_CERT="/etc/ssl/pfSense-repo-custom.cert"
@@ -341,14 +330,14 @@ EOF
 		reinstall_pkg=1
 	fi
 
-	if [ "${CUR_ABI}" = "${ABI}" -o "${CUR_ABI}" = "${ALTABI}" ] ; then
+	if [ "${CUR_ABI}" = "${ABI}" ] ; then
 		NEW_MAJOR=""
 	else
 		NEW_MAJOR=1
 		export IGNORE_OSVERSION=yes
 	fi
 
-	export CUR_ABI CUR_ALTABI ABI ALTABI NEW_MAJOR
+	export CUR_ABI CUR_OSVERSION ABI OSVERSION NEW_MAJOR
 }
 
 get_pkg_repo_url() {
@@ -1115,12 +1104,13 @@ get_repo_abi_major() {
 get_repo_abi_values() {
 	local _repo_conf="${1}"
 	local _abi_file="${_repo_conf%%.conf}.abi"
-	local _altabi_file="${_repo_conf%%.conf}.altabi"
+	local _osversion_file="${_repo_conf%%.conf}.osversion"
 
 	REPO_ABI="${CUR_ABI}"
-	REPO_ALTABI="${CUR_ALTABI}"
+	REPO_OSVERSION="${CUR_OSVERSION}"
 	[ -f "${_abi_file}" ] && REPO_ABI=$(cat "${_abi_file}")
-	[ -f "${_altabi_file}" ] && REPO_ALTABI=$(cat "${_altabi_file}")
+	[ -f "${_osversion_file}" ] \
+	    && REPO_OSVERSION=$(cat "${_osversion_file}")
 }
 
 prepare_repo_override_dir() {
@@ -1142,7 +1132,7 @@ compare_pkg_version_repo() {
 	local _pkg_name="${1}"
 	local _repo_dir="${2}"
 	local _abi="${3}"
-	local _altabi="${4}"
+	local _osversion="${4}"
 
 	if [ -z "${_pkg_name}" ]; then
 		echo '!'
@@ -1163,11 +1153,11 @@ compare_pkg_version_repo() {
 	fi
 
 	local _rver=$(pkg-static -o REPOS_DIR=${_repo_dir} \
-	    -o ABI=${_abi} -o ALTABI=${_altabi} rquery -U %v ${_pkg_name})
+	    -o ABI=${_abi} -o OSVERSION=${_osversion} rquery -U %v ${_pkg_name})
 
 	if [ -z "${_rver}" ]; then
 		_rver=$(pkg-static -o REPOS_DIR=${_repo_dir} \
-		    -o ABI=${_abi} -o ALTABI=${_altabi} rquery %v ${_pkg_name})
+		    -o ABI=${_abi} -o OSVERSION=${_osversion} rquery %v ${_pkg_name})
 	fi
 
 	if [ -z "${_rver}" ]; then
@@ -1238,12 +1228,12 @@ check_upgrade_repo_override() {
 
 	if [ -z "${_skip_update}" -a -z "${dont_update}" ]; then
 		pkg-static -o REPOS_DIR=${_repo_dir} -o ABI=${REPO_ABI} \
-		    -o ALTABI=${REPO_ALTABI} update -f >/dev/null 2>&1
+		    -o OSVERSION=${REPO_OSVERSION} update -f >/dev/null 2>&1
 	fi
 
 	for _package in ${_meta_pkg} ${_core_pkgs}; do
 		local _version_compare=$(compare_pkg_version_repo ${_package} \
-		    ${_repo_dir} ${REPO_ABI} ${REPO_ALTABI})
+		    ${_repo_dir} ${REPO_ABI} ${REPO_OSVERSION})
 
 		case "${_version_compare}" in
 			=|'>')
@@ -1252,12 +1242,12 @@ check_upgrade_repo_override() {
 		esac
 
 		local _new_version=$(pkg-static -o REPOS_DIR=${_repo_dir} \
-		    -o ABI=${REPO_ABI} -o ALTABI=${REPO_ALTABI} \
+		    -o ABI=${REPO_ABI} -o OSVERSION=${REPO_OSVERSION} \
 		    rquery -U %v ${_package})
 
 		if [ -z "${_new_version}" ]; then
 			_new_version=$(pkg-static -o REPOS_DIR=${_repo_dir} \
-			    -o ABI=${REPO_ABI} -o ALTABI=${REPO_ALTABI} \
+			    -o ABI=${REPO_ABI} -o OSVERSION=${REPO_OSVERSION} \
 			    rquery %v ${_package})
 		fi
 


### PR DESCRIPTION
### Motivation
- Corrigir falha no processo de upgrade causada pela incompatibilidade entre ABI/ALTABI e a nova versão do `pkg` que passou a utilizar `OSVERSION`, e acomodar repositórios com meta version 2 que exigem bootstrap de `pkg` em sistemas com base FreeBSD antiga.
- Evitar que o port escreva `ALTABI` em `/usr/local/etc/pkg.conf`, já que `pkg` moderno ignora `ALTABI` e exige `ABI`/`OSVERSION` corretamente setados.

### Description
- Substitui o uso de `ALTABI` por `OSVERSION` em `sysutils/pfSense-upgrade/files/Kontrol-upgrade`, lendo `.osversion` do arquivo de repositório quando presente e caindo para `kern.osreldate` via `sysctl` quando ausente, e atualiza variáveis exportadas (`CUR_OSVERSION`, `OSVERSION`, `REPO_OSVERSION`).
- Atualiza `sysutils/pfSense-upgrade/files/Kontrol-repo-setup` para escrever `OSVERSION` (em vez de `ALTABI`) em `/usr/local/etc/pkg.conf` e para obter fallback de `kern.osreldate` quando necessário.
- Altera chamadas a `pkg-static`/`pkg` que antes usavam `-o ALTABI=...` para `-o OSVERSION=...` (por exemplo em `rquery`, `update`), e ajusta funções que comparam versões remotas para usar `OSVERSION` como parâmetro de repositório.
- Incrementa `PORTREVISION` no `Makefile` para refletir a atualização dos scripts do port.

### Testing
- Nenhum teste automatizado foi executado nesta alteração.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698386b6a2a8832ea11c262dab073af1)