### PR TITLE
Retry de `pkg-static update` durante upgrade em boot

### DIFF
--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -394,8 +394,27 @@ pkg_update() {
 
 	_exec "pkg-static update${_force}" "Updating repositories metadata" \
 	    ${_mute} "" do_not_exit
+	local _update_rc=$?
 
-	if [ $? -ne 0 -a -z "${_do_not_bootstrap}" ]; then
+	if [ ${_update_rc} -ne 0 -a -n "${booting}" ]; then
+		local _retry_max=6
+		local _retry_wait=10
+		local _retry=1
+		while [ ${_retry} -le ${_retry_max} ]; do
+			_echo "Repository update failed during boot." \
+			    "Retrying in ${_retry_wait}s" \
+			    "(${_retry}/${_retry_max})..."
+			sleep ${_retry_wait}
+			_exec "pkg-static update${_force}" \
+			    "Updating repositories metadata" ${_mute} "" \
+			    do_not_exit
+			_update_rc=$?
+			[ ${_update_rc} -eq 0 ] && break
+			_retry=$(( _retry + 1 ))
+		done
+	fi
+
+	if [ ${_update_rc} -ne 0 -a -z "${_do_not_bootstrap}" ]; then
 		# Since pkg version 1.13 it moved to use repository metadata
 		# version 2, which cannot be processed by older pkg binaries
 		#


### PR DESCRIPTION
### Motivation
- Corrigir falhas transitórias de atualização de repositórios que ocorrem durante os estágios de upgrade enquanto o sistema está fazendo boot, causando reboot/início incompleto do processo de upgrade.
- Mitigar problemas provocados por rede/repositório não prontos logo após reboot sem alterar a lógica existente de `bootstrap` para mudanças de meta versão do `pkg`.

### Description
- Capturei o código de retorno de `pkg-static update` em `_update_rc` em vez de depender de `$?` imediato para permitir lógica de retentativa. 
- Adicionei um loop de retentativas ativado quando a variável `booting` está definida com `_retry_max=6` e `_retry_wait=10s`, que chama `_exec "pkg-static update..."` novamente e faz log via `_echo` enquanto aguarda entre tentativas. 
- Mantive a lógica existente de forçar `pkg bootstrap -f` quando apropriado, trocando a condição que usava `$?` para verificar `_update_rc` antes de seguir com o fluxo de `bootstrap` e meta.conf.

### Testing
- Nenhum teste automatizado foi executado para esta alteração.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69838d382a68832ea5ffa434d84627e8)