### PR TITLE
Try installing missing repo package during upgrade check

### DIFF
--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -458,6 +458,16 @@ pkg_upgrade_repo() {
 
 	local _repo_pkg="${product}-repo"
 
+	if ! is_pkg_installed ${_repo_pkg}; then
+		_exec "pkg-static install${dont_update} ${_repo_pkg}" \
+		    "Installing ${_repo_pkg}" mute "" do_not_exit
+		if [ $? -ne 0 ]; then
+			_echo "WARNING: Unable to install ${_repo_pkg};" \
+			    "skipping repository package upgrade"
+			return
+		fi
+	fi
+
 	case "$(compare_pkg_version ${_repo_pkg})" in
 		"<")
 			local _force=""


### PR DESCRIPTION
### Motivation
- The upgrade flow could abort with "Unable to compare version of ${product}-repo" when the repository package was not installed and the script attempted a version comparison.
- Handle cases where the repository points at a different ABI/release (for example pfSense 2.7.2 on FreeBSD 14 while the repo points to 2.8.1 on FreeBSD 15) by attempting to ensure the repo package exists before comparing.

### Description
- In `pkg_upgrade_repo()` attempt `pkg-static install${dont_update} ${_repo_pkg}` via `_exec` when `${product}-repo` is not installed, using `do_not_exit` to avoid hard failures.
- If the install returns non-zero, emit a `WARNING` and return to skip repository package upgrade instead of aborting with an error.
- Preserve the existing `compare_pkg_version` logic and upgrade/`abi_setup` flow for the cases where the package exists or is successfully installed.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984f345516c832ea945ce0797139474)