### PR TITLE
Corrige detecção de ABI em Kontrol-upgrade para tratar repositórios de major OS sem forçar operações de upgrade

### DIFF
--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -293,18 +293,19 @@ abi_setup() {
 	fi
 
 	local _repo_abi_file=$(readlink ${_pkg_repo_conf})
+	local _repo_abi="${CUR_ABI}"
+	local _repo_altabi="${CUR_ALTABI}"
 
 	if [ -f ${_repo_abi_file%%.conf}.abi ]; then
-		ABI=$(cat ${_repo_abi_file%%.conf}.abi)
-	else
-		ABI=${CUR_ABI}
+		_repo_abi=$(cat ${_repo_abi_file%%.conf}.abi)
 	fi
 
 	if [ -f ${_repo_abi_file%%.conf}.altabi ]; then
-		ALTABI=$(cat ${_repo_abi_file%%.conf}.altabi)
-	else
-		ALTABI=${CUR_ALTABI}
+		_repo_altabi=$(cat ${_repo_abi_file%%.conf}.altabi)
 	fi
+
+	ABI="${_repo_abi}"
+	ALTABI="${_repo_altabi}"
 
 	# Make sure pkg.conf is set properly so GUI can work
 	OSVERSION=$(sysctl -n kern.osreldate)
@@ -342,11 +343,17 @@ EOF
 		reinstall_pkg=1
 	fi
 
-	if [ "${CUR_ABI}" = "${ABI}" -o "${CUR_ABI}" = "${ALTABI}" ] ; then
+	if [ "${CUR_ABI}" = "${_repo_abi}" -o "${CUR_ABI}" = "${_repo_altabi}" ] ; then
 		NEW_MAJOR=""
 	else
 		NEW_MAJOR=1
-		export IGNORE_OSVERSION=yes
+	fi
+
+	if [ -n "${NEW_MAJOR}" -a "${action}" != "upgrade" ]; then
+		ABI="${CUR_ABI}"
+		ALTABI="${CUR_ALTABI}"
+	else
+		[ -n "${NEW_MAJOR}" ] && export IGNORE_OSVERSION=yes
 	fi
 
 	export CUR_ABI CUR_ALTABI ABI ALTABI NEW_MAJOR


### PR DESCRIPTION
### Motivation
- Foi identificado que, ao apontar o sistema para um repositório de uma versão futura (ex.: 2.8.1 / FreeBSD 15) enquanto o sistema ainda roda FreeBSD 14, o script `Kontrol-upgrade` tomava a ABI do repositório e passava a tratar o ambiente como da versão futura, causando erros do `pkg` (ABI/OSVERSION divergentes). 
- É necessário detectar quando um repositório representa um "new major" (mudança de ABI) sem quebrar operações de leitura/checagem e sem forçar comportamento de upgrade em caminhos que apenas consultam/checagens. 
- O alvo é tornar o port `Kontrol-upgrade` mais resiliente a trocas de branch/repo feitas pela interface web, evitando que ações não-upgrade provoquem falhas de arquitetura ABI.

### Description
- Ajusta `abi_setup()` em `sysutils/pfSense-upgrade/files/Kontrol-upgrade` para ler os valores do `.abi`/`.altabi` do repositório em variáveis temporárias (`_repo_abi`, `_repo_altabi`) em vez de sobrescrever imediatamente as variáveis do sistema. 
- Mantém a detecção de `NEW_MAJOR` comparando `CUR_ABI` com os valores do repositório, mas altera o comportamento: quando `NEW_MAJOR` for detectado e a ação atual **não** for `upgrade`, o script restaura `ABI`/`ALTABI` para os valores correntes (`CUR_ABI`/`CUR_ALTABI`) para que operações não-upgrade continuem usando a ABI em execução. 
- Só exporta `IGNORE_OSVERSION` (workaround para permitir bootstrap em casos de upgrade real) quando for um fluxo de upgrade efetivo, evitando side-effects em checagens/ações de consulta. 
- Arquivo modificado: `sysutils/pfSense-upgrade/files/Kontrol-upgrade` (patch aplicado e commit realizado com mensagem "Fix ABI handling in Kontrol-upgrade").

### Testing
- Nenhum teste automatizado foi executado durante a alteração (`not run`); somente validações estáticas do patch/commit foram realizadas. 
- Recomenda-se testar em um ambiente controlado os seguintes cenários antes de promover a alteração em produção: executar `Kontrol-upgrade -c` com o repositório apontando para a mesma ABI, para uma ABI futura (checar que a detecção de nova major retorna código esperado sem quebrar consultas) e realizar um `upgrade` completo para validar que o caminho de upgrade ainda aplica `IGNORE_OSVERSION` e procede com o bootstrap/upgrade.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989e20c1bc0832e9b52be3ef8de6ded)