### PR TITLE
Isolate repo override cache and sanitize ABI env in Kontrol-upgrade

### DIFF
--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -293,23 +293,19 @@ abi_setup() {
 	fi
 
 	local _repo_abi_file=$(readlink ${_pkg_repo_conf})
+	local _repo_abi="${CUR_ABI}"
+	local _repo_altabi="${CUR_ALTABI}"
 
 	if [ -f ${_repo_abi_file%%.conf}.abi ]; then
-		ABI=$(cat ${_repo_abi_file%%.conf}.abi)
-	else
-		ABI=${CUR_ABI}
+		_repo_abi=$(cat ${_repo_abi_file%%.conf}.abi)
 	fi
 
 	if [ -f ${_repo_abi_file%%.conf}.altabi ]; then
-		ALTABI=$(cat ${_repo_abi_file%%.conf}.altabi)
-	else
-		ALTABI=${CUR_ALTABI}
+		_repo_altabi=$(cat ${_repo_abi_file%%.conf}.altabi)
 	fi
 
-	# Make sure pkg.conf is set properly so GUI can work
-	OSVERSION=$(sysctl -n kern.osreldate)
-	echo "ABI=${ABI}" > /usr/local/etc/pkg.conf
-	echo "OSVERSION=${OSVERSION}" >> /usr/local/etc/pkg.conf
+	ABI="${_repo_abi}"
+	ALTABI="${_repo_altabi}"
 
 	AUTH_CA="/etc/ssl/netgate-ca.pem"
 	AUTH_CERT="/etc/ssl/pfSense-repo-custom.cert"
@@ -342,12 +338,24 @@ EOF
 		reinstall_pkg=1
 	fi
 
-	if [ "${CUR_ABI}" = "${ABI}" -o "${CUR_ABI}" = "${ALTABI}" ] ; then
+	if [ "${CUR_ABI}" = "${_repo_abi}" -o "${CUR_ABI}" = "${_repo_altabi}" ] ; then
 		NEW_MAJOR=""
 	else
 		NEW_MAJOR=1
-		export IGNORE_OSVERSION=yes
 	fi
+
+	if [ -n "${NEW_MAJOR}" -a "${action}" != "upgrade" ]; then
+		ABI="${CUR_ABI}"
+		ALTABI="${CUR_ALTABI}"
+	else
+		[ -n "${NEW_MAJOR}" ] && export IGNORE_OSVERSION=yes
+	fi
+
+	# Make sure pkg.conf is set properly so GUI can work
+	OSVERSION=$(sysctl -n kern.osreldate)
+	echo "ABI=${ABI}" > /usr/local/etc/pkg.conf
+	echo "OSVERSION=${OSVERSION}" >> /usr/local/etc/pkg.conf
+	[ -n "${ALTABI}" ] && echo "ALTABI=${ALTABI}" >> /usr/local/etc/pkg.conf
 
 	export CUR_ABI CUR_ALTABI ABI ALTABI NEW_MAJOR
 }
@@ -1154,11 +1162,17 @@ compare_pkg_version_repo() {
 		_exit 1
 	fi
 
-	local _rver=$(pkg-static -o REPOS_DIR=${_repo_dir} \
+	local _repo_cache="${_repo_dir}/cache"
+	mkdir -p "${_repo_cache}"
+
+	local _rver=$(env -u ABI -u ALTABI -u OSVERSION \
+	    pkg-static -o REPOS_DIR=${_repo_dir} -o REPO_CACHEDIR=${_repo_cache} \
 	    -o ABI=${_abi} -o ALTABI=${_altabi} rquery -U %v ${_pkg_name})
 
 	if [ -z "${_rver}" ]; then
-		_rver=$(pkg-static -o REPOS_DIR=${_repo_dir} \
+		_rver=$(env -u ABI -u ALTABI -u OSVERSION \
+		    pkg-static -o REPOS_DIR=${_repo_dir} \
+		    -o REPO_CACHEDIR=${_repo_cache} \
 		    -o ABI=${_abi} -o ALTABI=${_altabi} rquery %v ${_pkg_name})
 	fi
 
@@ -1229,8 +1243,11 @@ check_upgrade_repo_override() {
 	fi
 
 	if [ -z "${_skip_update}" -a -z "${dont_update}" ]; then
-		pkg-static -o REPOS_DIR=${_repo_dir} -o ABI=${REPO_ABI} \
-		    -o ALTABI=${REPO_ALTABI} update -f >/dev/null 2>&1
+		env -u ABI -u ALTABI -u OSVERSION \
+		    pkg-static -o REPOS_DIR=${_repo_dir} \
+		    -o REPO_CACHEDIR=${_repo_dir}/cache \
+		    -o ABI=${REPO_ABI} -o ALTABI=${REPO_ALTABI} \
+		    update -f >/dev/null 2>&1
 	fi
 
 	for _package in ${_meta_pkg} ${_core_pkgs}; do
@@ -1243,15 +1260,91 @@ check_upgrade_repo_override() {
 				;;
 		esac
 
-		local _new_version=$(pkg-static -o REPOS_DIR=${_repo_dir} \
+		local _new_version=$(env -u ABI -u ALTABI -u OSVERSION \
+		    pkg-static -o REPOS_DIR=${_repo_dir} \
+		    -o REPO_CACHEDIR=${_repo_dir}/cache \
 		    -o ABI=${REPO_ABI} -o ALTABI=${REPO_ALTABI} \
 		    rquery -U %v ${_package})
 
 		if [ -z "${_new_version}" ]; then
-			_new_version=$(pkg-static -o REPOS_DIR=${_repo_dir} \
+			_new_version=$(env -u ABI -u ALTABI -u OSVERSION \
+			    pkg-static -o REPOS_DIR=${_repo_dir} \
+			    -o REPO_CACHEDIR=${_repo_dir}/cache \
 			    -o ABI=${REPO_ABI} -o ALTABI=${REPO_ALTABI} \
 			    rquery %v ${_package})
 		fi
+
+		[ -z "${_new_version}" ] && continue
+
+		[ -z "${_mute}" ] \
+		    && _echo \
+		    "${_new_version} version of ${product} is available"
+		cleanup_repo_override_dir "${_repo_dir}"
+		return 2
+	done
+
+	cleanup_repo_override_dir "${_repo_dir}"
+	return 1
+}
+
+check_upgrade_current_repo_override() {
+	local _mute="${1}"
+	local _skip_update="${2}"
+	local _meta_pkg="${3}"
+	local _core_pkgs="${4}"
+	local _current_repo_conf="/usr/local/etc/pkg/repos/${product}.conf"
+	local _current_repo_target=""
+
+	if [ -L "${_current_repo_conf}" ]; then
+		_current_repo_target=$(readlink ${_current_repo_conf})
+	elif [ -f "${_current_repo_conf}" ]; then
+		_current_repo_target="${_current_repo_conf}"
+	fi
+
+	if [ -z "${_current_repo_target}" ]; then
+		return 1
+	fi
+
+	get_repo_abi_values "${_current_repo_target}"
+
+	local _repo_dir=$(prepare_repo_override_dir "${_current_repo_target}")
+	if [ -z "${_repo_dir}" ]; then
+		return 1
+	fi
+
+	if [ -z "${_skip_update}" -a -z "${dont_update}" ]; then
+		env -u ABI -u ALTABI -u OSVERSION \
+		    pkg-static -o REPOS_DIR=${_repo_dir} \
+		    -o REPO_CACHEDIR=${_repo_dir}/cache \
+		    -o ABI=${REPO_ABI} -o ALTABI=${REPO_ALTABI} \
+		    update -f >/dev/null 2>&1
+	fi
+
+	for _package in ${_meta_pkg} ${_core_pkgs}; do
+		local _version_compare=$(compare_pkg_version_repo ${_package} \
+		    ${_repo_dir} ${REPO_ABI} ${REPO_ALTABI})
+
+		case "${_version_compare}" in
+			=|'>')
+				continue
+				;;
+		esac
+
+		local _new_version=$(env -u ABI -u ALTABI -u OSVERSION \
+		    pkg-static -o REPOS_DIR=${_repo_dir} \
+		    -o REPO_CACHEDIR=${_repo_dir}/cache \
+		    -o ABI=${REPO_ABI} -o ALTABI=${REPO_ALTABI} \
+		    rquery -U %v ${_package})
+
+		if [ -z "${_new_version}" ]; then
+			_new_version=$(env -u ABI -u ALTABI -u OSVERSION \
+			    pkg-static -o REPOS_DIR=${_repo_dir} \
+			    -o REPO_CACHEDIR=${_repo_dir}/cache \
+			    -o ABI=${REPO_ABI} -o ALTABI=${REPO_ALTABI} \
+			    rquery %v ${_package})
+		fi
+
+		[ -z "${_new_version}" ] && continue
 
 		[ -z "${_mute}" ] \
 		    && _echo \
@@ -1271,6 +1364,17 @@ check_upgrade() {
 	local _core_pkgs=$(pkg-static query -e \
 	    "%n ~ ${product}-kernel-* || %n ~ ${product}-base*" %n 2>/dev/null)
 	local _repo_behind=""
+
+	if [ -n "${NEW_MAJOR}" -a "${action}" != "upgrade" ]; then
+		check_upgrade_current_repo_override "${_mute}" "${_skip_update}" \
+		    "${_meta_pkg}" "${_core_pkgs}"
+		if [ $? -eq 2 ]; then
+			return 2
+		fi
+		[ -z "${_mute}" ] \
+		    && _echo "Your system is up to date"
+		return 0
+	fi
 
 	# Do not upgrade while wg interfaces are assigned
 	if sed '/<interfaces>/,/<\/interfaces>/!d' /cf/conf/config.xml \


### PR DESCRIPTION
### Motivation
- Prevent repo metadata/cache from one branch contaminating queries against an override repo and producing empty `rquery` results. 
- Avoid persisting repository ABI/ALTABI into `pkg.conf` before the final ABI decision to stop `pkg` ABI/OSVERSION conflicts. 
- Detect newer repo versions for the currently selected repo without forcing upgrade flows or producing incomplete "version ... is available" messages.

### Description
- Use temporary variables in `abi_setup()` (`_repo_abi`, `_repo_altabi`) and only apply them to `ABI`/`ALTABI` after the final decision, and persist `ALTABI` to `pkg.conf` when available in `sysutils/pfSense-upgrade/files/Kontrol-upgrade`.
- When a `NEW_MAJOR` is detected but `action` is not `upgrade`, restore `ABI`/`ALTABI` to `CUR_ABI`/`CUR_ALTABI`; only export `IGNORE_OSVERSION` for actual upgrade flows.
- Run `pkg-static` override queries with a sanitized environment (`env -u ABI -u ALTABI -u OSVERSION`) and a per-override cache directory (`-o REPO_CACHEDIR=${_repo_dir}/cache`), creating the cache dir as needed to isolate repository metadata in `compare_pkg_version_repo`, `check_upgrade_repo_override`, and the new `check_upgrade_current_repo_override`.
- Avoid printing incomplete upgrade messages by skipping echo when `rquery` returns empty and continue to the next package instead of emitting a blank-version message.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989e20c1bc0832e9b52be3ef8de6ded)