### PR TITLE
Fix upgrade detection after ABI change on check

### DIFF
--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -1367,6 +1367,28 @@ check_upgrade() {
 		return 2
 	fi
 
+	if [ -n "${NEW_MAJOR}" -a "${action}" = "check" ]; then
+		_exec "pkg-static bootstrap -f" \
+		    "Bootstrapping pkg due to ABI change" mute \
+		    ignore_result do_not_exit
+
+		check_upgrade_current_repo_override "${_mute}" "${_skip_update}" \
+		    "${_meta_pkg}" "${_core_pkgs}"
+		if [ $? -eq 2 ]; then
+			return 2
+		fi
+
+		check_upgrade_repo_override "${_mute}" "${_skip_update}" \
+		    "${_meta_pkg}" "${_core_pkgs}"
+		if [ $? -eq 2 ]; then
+			return 2
+		fi
+
+		[ -z "${_mute}" ] \
+		    && _echo "Your system is up to date"
+		return 0
+	fi
+
 	if [ -n "${NEW_MAJOR}" -a "${action}" != "upgrade" ]; then
 		[ -z "${_mute}" ] \
 		    && _echo "Your system is up to date"


### PR DESCRIPTION
### Motivation
- After switching branches that change the ABI, a `Kontrol-upgrade -c` check could report the system as up-to-date because local `pkg` metadata/binary was not refreshed to match the new repository ABI.

### Description
- When a new major ABI is detected and the action is `check`, run `pkg-static bootstrap -f` to refresh `pkg` metadata and binaries.
- After bootstrapping, re-run `check_upgrade_current_repo_override` and `check_upgrade_repo_override` to reevaluate available upgrades before reporting status.
- Change applied in `sysutils/pfSense-upgrade/files/Kontrol-upgrade` by adding a guarded block around `if [ -n "${NEW_MAJOR}" -a "${action}" = "check" ]` that performs the bootstrap and retries the repo checks.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a395b9ee0832e811d40305df71c9b)