### PR TITLE
Improve debug logging, capture repo/pkg configs, and preserve upgrade log

### DIFF
--- a/sysutils/pfSense-upgrade/Makefile
+++ b/sysutils/pfSense-upgrade/Makefile
@@ -16,6 +16,10 @@ LICENSE=	APACHE20
 NO_MTREE=	yes
 NO_BUILD=	yes
 
+OPTIONS_DEFINE=	DEBUG
+DEBUG_DESC=	Enable verbose debug logging by default
+OPTIONS_DEFAULT=DEBUG
+
 PLIST_FILES=	libexec/Kontrol-upgrade \
 		sbin/Kontrol-upgrade \
 		sbin/Kontrol-repo-setup
@@ -23,6 +27,12 @@ PLIST_FILES=	libexec/Kontrol-upgrade \
 do-extract:
 	@${MKDIR} ${WRKSRC}
 	${CP} -r ${FILESDIR}/* ${WRKSRC}
+
+post-patch:
+.if defined(PORT_OPTIONS) && ${PORT_OPTIONS:MDEBUG}
+	${REINPLACE_CMD} 's/^DEBUG_DEFAULT=0/DEBUG_DEFAULT=1/' \
+		${WRKSRC}/Kontrol-upgrade
+.endif
 
 do-install:
 	${MKDIR} ${STAGEDIR}${PREFIX}/sbin

--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -18,6 +18,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+DEBUG_DEFAULT=0
+
 usage() {
 	me=$(basename $0)
 	cat << EOD >&2
@@ -57,6 +59,44 @@ _echo() {
 	echo ${_n} "${@}" | tee -a ${logfile}
 }
 
+_debug() {
+	if [ -z "${debug_enabled}" ]; then
+		return 0
+	fi
+
+	local _ts
+	_ts=$(date "+%Y-%m-%d %H:%M:%S")
+	_echo "DEBUG ${_ts} ${*}"
+}
+
+_debug_file() {
+	if [ -z "${debug_enabled}" ]; then
+		return 0
+	fi
+
+	local _file="${1}"
+	local _ts
+	_ts=$(date "+%Y-%m-%d %H:%M:%S")
+
+	if [ -z "${_file}" ]; then
+		_echo "DEBUG ${_ts} file=(empty)"
+		return 0
+	fi
+
+	if [ ! -f "${_file}" ]; then
+		_echo "DEBUG ${_ts} file=${_file} (not found)"
+		return 0
+	fi
+
+	_echo "DEBUG ${_ts} file=${_file} (begin)"
+	while IFS= read -r _line; do
+		_ts=$(date "+%Y-%m-%d %H:%M:%S")
+		_echo "DEBUG ${_ts} file=${_file}: ${_line}"
+	done < "${_file}"
+	_ts=$(date "+%Y-%m-%d %H:%M:%S")
+	_echo "DEBUG ${_ts} file=${_file} (end)"
+}
+
 _exec() {
 	local _cmd="${1}"
 	local _msg="${2}"
@@ -73,6 +113,8 @@ _exec() {
 	if [ "${_mute}" != "mute" ]; then
 		_stdout=''
 	fi
+
+	_debug "exec cmd='${_cmd}' msg='${_msg}' mute='${_mute}'"
 
 	[ -n "${_msg}" ] \
 	    && _echo -n ">>> ${_msg}... "
@@ -100,10 +142,12 @@ _exec() {
 	if [ ${_result} -eq 0 -o -n "${_ignore_result}" ]; then
 		[ -n "${_stdout}" -a -n "${_msg}" ] \
 		    && _echo "done."
+		_debug "exec result=success code=${_result}"
 		return 0
 	else
 		[ -n "${_stdout}" -a -n "${_msg}" ] \
 		    && _echo "failed."
+		_debug "exec result=failure code=${_result}"
 		[ -n "${_do_not_exit}" ] \
 		    && return 1 \
 		    || _exit 1
@@ -307,6 +351,12 @@ abi_setup() {
 	ABI="${_repo_abi}"
 	ALTABI="${_repo_altabi}"
 
+	_debug "abi_setup freebsd_version=${_freebsd_version} arch=${arch} CUR_ABI=${CUR_ABI} CUR_ALTABI=${CUR_ALTABI}"
+	_debug "abi_setup repo_conf=${_pkg_repo_conf} repo_target=${_repo_abi_file} ABI=${ABI} ALTABI=${ALTABI}"
+	_debug "abi_setup repo_dir=/usr/local/share/${product}/pkg/repos"
+	_debug_file "/usr/local/share/${product}/pkg/repos/${product}-repo.conf"
+	_debug_file "/usr/local/share/${product}/pkg/repos/${product}-repo-previous.conf"
+
 	AUTH_CA="/etc/ssl/netgate-ca.pem"
 	AUTH_CERT="/etc/ssl/pfSense-repo-custom.cert"
 	AUTH_KEY="/etc/ssl/pfSense-repo-custom.key"
@@ -356,6 +406,9 @@ EOF
 	echo "ABI=${ABI}" > /usr/local/etc/pkg.conf
 	echo "OSVERSION=${OSVERSION}" >> /usr/local/etc/pkg.conf
 
+	_debug "abi_setup pkg_abi=${_pkg_abi} reinstall_pkg=${reinstall_pkg:-0} NEW_MAJOR=${NEW_MAJOR:-0} OSVERSION=${OSVERSION}"
+	_debug_file "/usr/local/etc/pkg.conf"
+
 	export CUR_ABI CUR_ALTABI ABI NEW_MAJOR
 }
 
@@ -378,6 +431,7 @@ get_pkg_repo_url() {
 	if [ -n "${_srv}" ]; then
 		local _n=$(host -t SRV _https._tcp.${_host} 2>/dev/null | wc -l)
 		if [ ${_n} -eq 0 ]; then
+			_debug "get_pkg_repo_url srv lookup failed host=${_host}"
 			return 1
 		fi
 
@@ -388,6 +442,7 @@ get_pkg_repo_url() {
 		_url=$(echo "${_url}" | sed "s,${_host},${_real_host},")
 	fi
 
+	_debug "get_pkg_repo_url url=${_url}"
 	echo "${_url}"
 }
 
@@ -402,6 +457,7 @@ pkg_update() {
 	    && _force=" -f"
 
 	if [ -z "${_force}" -a -n "${dont_update}" ]; then
+		_debug "pkg_update skipping due to dont_update"
 		return 0
 	fi
 
@@ -410,6 +466,8 @@ pkg_update() {
 
 	/usr/local/bin/php -r 'require_once("pkg-utils.inc");update_repos();'
 	abi_setup
+
+	_debug "pkg_update force='${_force}' mute='${_mute}' do_not_bootstrap='${_do_not_bootstrap}'"
 
 	_exec "pkg-static update${_force}" "Updating repositories metadata" \
 	    ${_mute} "" do_not_exit
@@ -423,6 +481,7 @@ pkg_update() {
 		# force to bootstrap pkg on local system
 		local _ver=$(_pkg query %v pkg)
 		local _cmp=$(_pkg version -t ${_ver} "1.13")
+		_debug "pkg_update bootstrap check pkg_version=${_ver} compare=${_cmp}"
 		if [ "${_cmp}" != "<" ]; then
 			return
 		fi
@@ -440,12 +499,26 @@ pkg_update() {
 
 		local _url=$(get_pkg_repo_url)
 		if [ $? -ne 0 ]; then
+			_debug "pkg_update failed to get repo url"
 			return
+		fi
+		_debug "pkg_update repo_url=${_url}"
+
+		if [ -n "${debug_enabled}" ]; then
+			local _meta_file
+			_meta_file=$(mktemp /tmp/pkg.meta.conf.XXXXXX) || _meta_file=""
+			if [ -n "${_meta_file}" ]; then
+				${_fetch_env} fetch ${_fetch_args} -o "${_meta_file}" \
+				    ${_url}/meta.conf >/dev/null 2>&1
+				_debug_file "${_meta_file}"
+				rm -f "${_meta_file}"
+			fi
 		fi
 
 		${_fetch_env} fetch ${_fetch_args} -o /dev/null \
 		    ${_url}/meta.conf >/dev/null 2>&1
 		if [ $? -eq 0 ]; then
+			_debug "pkg_update meta.conf detected, bootstrapping pkg"
 			_exec "${_pkg_binary} bootstrap -f" \
 			    "Bootstrap pkg due to meta version change"
 			pkg_update "${force}" "${_mute}" _do_not_bootstrap
@@ -456,6 +529,7 @@ pkg_update() {
 pkg_upgrade_repo() {
 	if [ -n "${reinstall_pkg}" ] \
 	    || [ -z "${NEW_MAJOR}" -a "$(compare_pkg_version pkg)" = "<" ]; then
+		_debug "pkg_upgrade_repo upgrading pkg reinstall_pkg=${reinstall_pkg:-0} NEW_MAJOR=${NEW_MAJOR:-0}"
 		pkg_unlock pkg
 		_exec "pkg-static upgrade${dont_update} pkg" "Upgrading pkg" \
 		    mute
@@ -466,6 +540,7 @@ pkg_upgrade_repo() {
 	local _repo_pkg="${product}-repo"
 
 	if ! is_pkg_installed ${_repo_pkg}; then
+		_debug "pkg_upgrade_repo installing ${_repo_pkg}"
 		_exec "pkg-static install${dont_update} ${_repo_pkg}" \
 		    "Installing ${_repo_pkg}" mute "" do_not_exit
 		if [ $? -ne 0 ]; then
@@ -494,6 +569,7 @@ pkg_upgrade_repo() {
 
 	cp /usr/local/etc/pkg/repos/${product}.conf /tmp/${product}.conf.copy
 	if !(is_ce && repo_is_plus_upgrade) ; then
+		_debug "pkg_upgrade_repo upgrading ${_repo_pkg} force='${_force}'"
 		_exec "pkg-static upgrade${dont_update}${_force} ${_repo_pkg}" \
 		    "Upgrading ${_repo_pkg}" mute
 	fi
@@ -519,6 +595,7 @@ upgrade_available() {
 	    | sed -e '/^$/d; /is locked and may not be modified/d' \
 	    | wc -l)
 
+	_debug "upgrade_available packages='${*}' lines=${_lines}"
 	test ${_lines} -gt 0
 	return $?
 }
@@ -666,9 +743,7 @@ pkg_upgrade() {
 	need_reboot=1
 	# First upgrade stage
 	if [ -z "${next_stage}" ]; then
-		if [ -f "${logfile}" ]; then
-			rm -f ${logfile}
-		fi
+		# Preserve existing logfile; do not delete
 
 		pkg_update force
 
@@ -1182,6 +1257,8 @@ compare_pkg_version_repo() {
 		_exit 1
 	fi
 
+	_debug "compare_pkg_version_repo pkg=${_pkg_name} local=${_lver} remote=${_rver} abi=${_abi}"
+	_debug "compare_pkg_version_repo rquery_cmd=env -u ABI -u ALTABI -u OSVERSION pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_db} -o REPO_CACHEDIR=${_repo_cache} -o ABI=${_abi} rquery -U %v ${_pkg_name}"
 	local _version=$(_pkg version -t ${_lver} ${_rver})
 
 	if [ $? -ne 0 ]; then
@@ -1228,14 +1305,19 @@ check_upgrade_repo_override() {
 	done
 
 	if [ -z "${_best_conf}" ]; then
+		_debug "check_upgrade_repo_override no repo override conf found"
 		return 1
 	fi
 
 	if [ -n "${_current_major}" -a "${_best_major}" -le "${_current_major}" ]; then
+		_debug "check_upgrade_repo_override best_major=${_best_major} current_major=${_current_major} skipping"
 		return 1
 	fi
 
 	get_repo_abi_values "${_best_conf}"
+
+	_debug "check_upgrade_repo_override using best_conf=${_best_conf} REPO_ABI=${REPO_ABI} REPO_ALTABI=${REPO_ALTABI}"
+	_debug_file "${_best_conf}"
 
 	local _repo_dir=$(prepare_repo_override_dir "${_best_conf}")
 	if [ -z "${_repo_dir}" ]; then
@@ -1274,6 +1356,7 @@ check_upgrade_repo_override() {
 
 		[ -z "${_new_version}" ] && continue
 
+		_debug "check_upgrade_repo_override package=${_package} new_version=${_new_version}"
 		[ -z "${_mute}" ] \
 		    && _echo \
 		    "${_new_version} version of ${product} is available"
@@ -1300,10 +1383,14 @@ check_upgrade_current_repo_override() {
 	fi
 
 	if [ -z "${_current_repo_target}" ]; then
+		_debug "check_upgrade_current_repo_override missing repo target"
 		return 1
 	fi
 
 	get_repo_abi_values "${_current_repo_target}"
+
+	_debug "check_upgrade_current_repo_override repo_conf=${_current_repo_target} REPO_ABI=${REPO_ABI} REPO_ALTABI=${REPO_ALTABI}"
+	_debug_file "${_current_repo_target}"
 
 	local _repo_dir=$(prepare_repo_override_dir "${_current_repo_target}")
 	if [ -z "${_repo_dir}" ]; then
@@ -1342,6 +1429,7 @@ check_upgrade_current_repo_override() {
 
 		[ -z "${_new_version}" ] && continue
 
+		_debug "check_upgrade_current_repo_override package=${_package} new_version=${_new_version}"
 		[ -z "${_mute}" ] \
 		    && _echo \
 		    "${_new_version} version of ${product} is available"
@@ -1361,9 +1449,11 @@ check_upgrade() {
 	    "%n ~ ${product}-kernel-* || %n ~ ${product}-base*" %n 2>/dev/null)
 	local _repo_behind=""
 
+	_debug "check_upgrade meta_pkg=${_meta_pkg} core_pkgs='${_core_pkgs}' NEW_MAJOR=${NEW_MAJOR:-0} action=${action}"
 	check_upgrade_current_repo_override "${_mute}" "${_skip_update}" \
 	    "${_meta_pkg}" "${_core_pkgs}"
 	if [ $? -eq 2 ]; then
+		_debug "check_upgrade current repo override has upgrade"
 		return 2
 	fi
 
@@ -1375,12 +1465,14 @@ check_upgrade() {
 		check_upgrade_current_repo_override "${_mute}" "${_skip_update}" \
 		    "${_meta_pkg}" "${_core_pkgs}"
 		if [ $? -eq 2 ]; then
+			_debug "check_upgrade current repo override has upgrade after bootstrap"
 			return 2
 		fi
 
 		check_upgrade_repo_override "${_mute}" "${_skip_update}" \
 		    "${_meta_pkg}" "${_core_pkgs}"
 		if [ $? -eq 2 ]; then
+			_debug "check_upgrade repo override has upgrade"
 			return 2
 		fi
 
@@ -1390,6 +1482,7 @@ check_upgrade() {
 	fi
 
 	if [ -n "${NEW_MAJOR}" -a "${action}" != "upgrade" ]; then
+		_debug "check_upgrade NEW_MAJOR set and action not upgrade; returning up to date"
 		[ -z "${_mute}" ] \
 		    && _echo "Your system is up to date"
 		return 0
@@ -1419,15 +1512,18 @@ check_upgrade() {
 		_version_compare=$(compare_pkg_version ${_package})
 		case "${_version_compare}" in
 			=)
+				_debug "check_upgrade package=${_package} local=remote"
 				continue
 				;;
 			'>')
+				_debug "check_upgrade package=${_package} local newer"
 				_repo_behind=1
 				continue
 				;;
 		esac
 
 		local _new_version=$(_pkg rquery -U %v ${_package})
+		_debug "check_upgrade package=${_package} new_version=${_new_version}"
 		[ -z "${_mute}" ] \
 		    && _echo \
 		    "${_new_version} version of ${product} is available"
@@ -1437,6 +1533,7 @@ check_upgrade() {
 	check_upgrade_repo_override "${_mute}" "${_skip_update}" \
 	    "${_meta_pkg}" "${_core_pkgs}"
 	if [ $? -eq 2 ]; then
+		_debug "check_upgrade repo override has upgrade"
 		return 2
 	fi
 
@@ -1493,6 +1590,8 @@ compare_pkg_version() {
 		_exit 1
 	fi
 
+	_debug "compare_pkg_version pkg=${_pkg_name} local=${_lver} remote=${_rver}"
+	_debug "compare_pkg_version rquery_cmd=pkg-static rquery -U %v ${_pkg_name}"
 	local _version=$(_pkg version -t ${_lver} ${_rver})
 
 	if [ $? -ne 0 ]; then
@@ -1645,6 +1744,12 @@ validate_repo_conf() {
 			ln -sf ${pkg_repo_conf_path} ${pkg_repo_conf}
 		fi
 	fi
+
+	_debug "validate_repo_conf repo_conf_path=${pkg_repo_conf_path} repo_conf=${pkg_repo_conf}"
+	_debug "validate_repo_conf repo_dir=/usr/local/share/${product}/pkg/repos"
+	_debug_file "${pkg_repo_conf_path}"
+	_debug_file "/usr/local/share/${product}/pkg/repos/${product}-repo.conf"
+	_debug_file "/usr/local/share/${product}/pkg/repos/${product}-repo-previous.conf"
 }
 
 export LANG=C
@@ -1755,7 +1860,8 @@ while getopts 46b:cdfi:hp:l:nr:RuUy opt; do
 		c)
 			action="check"
 			;;
-		d)
+	d)
+			debug_enabled=1
 			stdout=''
 			;;
 		f)
@@ -1827,6 +1933,11 @@ elif [ -n "${force_ipv6}" ]; then
 	export IP_VERSION="6"
 fi
 
+if [ "${DEBUG_DEFAULT}" = "1" ]; then
+	debug_enabled=1
+	stdout=''
+fi
+
 # Flags used to determine if all packages must be reinstalled
 pkg_set_version="/usr/local/share/${product}/next_pkg_set_version"
 running_pkg_set_version="/usr/local/share/${product}/running_pkg_set_version"
@@ -1838,8 +1949,10 @@ if [ ! -f ${running_pkg_set_version} ]; then
 fi
 
 # Force debug if /cf/conf/upgrade_debug is present
-[ -f "/cf/conf/upgrade_debug" ] \
-    && stdout=''
+if [ -f "/cf/conf/upgrade_debug" ]; then
+	debug_enabled=1
+	stdout=''
+fi
 
 # Set default action when no parameter is set
 : ${action:="upgrade"}
@@ -1868,9 +1981,7 @@ if [ -n "${booting}" ]; then
 	export REPO_AUTOUPDATE=false
 fi
 
-if [ "${action}" != "upgrade" -a -f "${logfile}" ]; then
-	rm -f ${logfile}
-fi
+# Preserve existing logfile; do not delete
 
 progress_file=${logfile%.*}.json
 


### PR DESCRIPTION
### Motivation
- Fix missing timestamps in debug log dumps so each debug line includes date/time.
- Capture contents of `pkg.conf`, `meta.conf` and repository `.conf` files to aid diagnosis of repo/package resolution issues.
- Explicitly identify which repo file under `/usr/local/share/Kontrol/pkg/repos/` (both `Kontrol-repo.conf` and `Kontrol-repo-previous.conf`) is being used during upgrade.
- Ensure the upgrade logfile is never deleted and new entries are appended instead of truncating existing logs.

### Description
- Add `OPTIONS_DEFINE=DEBUG`, `DEBUG_DESC`, `OPTIONS_DEFAULT=DEBUG` and a `post-patch` to the Makefile to enable debug-by-default when the port option is selected, and add `DEBUG_DEFAULT` handling in the script.
- Introduce `_debug` and `_debug_file` helpers which prepend a per-line timestamp (`%Y-%m-%d %H:%M:%S`) and only run when debug is enabled via `-d`, `DEBUG_DEFAULT=1`, or `/cf/conf/upgrade_debug`.
- Log repository config files and `pkg.conf` by calling `_debug_file` for `/usr/local/etc/pkg.conf`, `/usr/local/share/${product}/pkg/repos/${product}-repo.conf`, and `/usr/local/share/${product}/pkg/repos/${product}-repo-previous.conf` at strategic places such as `abi_setup`, `validate_repo_conf`, and repo-override checks.
- When debugging, fetch remote `meta.conf` to a temp file during `pkg_update` and dump it with `_debug_file` to show the meta used by the repository URL discovered via `get_pkg_repo_url`.
- Add debug traces for executed `rquery`/pkg commands and important decision points by calling `_debug` in `_exec`, `compare_pkg_version*`, `compare_pkg_version_repo`, `pkg_update`, `pkg_upgrade_repo`, `check_upgrade*`, and related flows to record commands, return codes and computed URLs/dirs.
- Preserve the existing logfile by removing calls that deleted or recreated it and ensure all writes use append (`tee -a`) so logs are never truncated or removed.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a4947de0c832eb1deac05fede5fcf)