### PR TITLE
sysutils/pfSense-upgrade: ignore OSVERSION during future-repo upgrade detection

### DIFF
--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -1240,13 +1240,13 @@ compare_pkg_version_repo() {
 	local _repo_db="${_repo_dir}/db"
 	mkdir -p "${_repo_cache}" "${_repo_db}"
 
-	local _rver=$(env -u ABI -u ALTABI -u OSVERSION \
+	local _rver=$(env IGNORE_OSVERSION=yes -u ABI -u ALTABI -u OSVERSION \
 	    pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_db} \
 	    -o REPO_CACHEDIR=${_repo_cache} -o ABI=${_abi} \
 	    rquery -U %v ${_pkg_name})
 
 	if [ -z "${_rver}" ]; then
-		_rver=$(env -u ABI -u ALTABI -u OSVERSION \
+		_rver=$(env IGNORE_OSVERSION=yes -u ABI -u ALTABI -u OSVERSION \
 		    pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_db} \
 		    -o REPO_CACHEDIR=${_repo_cache} -o ABI=${_abi} \
 		    rquery %v ${_pkg_name})
@@ -1259,7 +1259,7 @@ compare_pkg_version_repo() {
 	fi
 
 	_debug "compare_pkg_version_repo pkg=${_pkg_name} local=${_lver} remote=${_rver} abi=${_abi}"
-	_debug "compare_pkg_version_repo rquery_cmd=env -u ABI -u ALTABI -u OSVERSION pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_db} -o REPO_CACHEDIR=${_repo_cache} -o ABI=${_abi} rquery -U %v ${_pkg_name}"
+	_debug "compare_pkg_version_repo rquery_cmd=env IGNORE_OSVERSION=yes -u ABI -u ALTABI -u OSVERSION pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_db} -o REPO_CACHEDIR=${_repo_cache} -o ABI=${_abi} rquery -U %v ${_pkg_name}"
 	local _version=$(_pkg version -t ${_lver} ${_rver})
 
 	if [ $? -ne 0 ]; then
@@ -1326,7 +1326,7 @@ check_upgrade_repo_override() {
 	fi
 
 	if [ -z "${_skip_update}" -a -z "${dont_update}" ]; then
-		env -u ABI -u ALTABI -u OSVERSION \
+		env IGNORE_OSVERSION=yes -u ABI -u ALTABI -u OSVERSION \
 		    pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_dir}/db \
 		    -o REPO_CACHEDIR=${_repo_dir}/cache -o ABI=${REPO_ABI} \
 		    update -f >/dev/null 2>&1
@@ -1342,13 +1342,13 @@ check_upgrade_repo_override() {
 				;;
 		esac
 
-		local _new_version=$(env -u ABI -u ALTABI -u OSVERSION \
+		local _new_version=$(env IGNORE_OSVERSION=yes -u ABI -u ALTABI -u OSVERSION \
 		    pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_dir}/db \
 		    -o REPO_CACHEDIR=${_repo_dir}/cache -o ABI=${REPO_ABI} \
 		    rquery -U %v ${_package})
 
 		if [ -z "${_new_version}" ]; then
-			_new_version=$(env -u ABI -u ALTABI -u OSVERSION \
+			_new_version=$(env IGNORE_OSVERSION=yes -u ABI -u ALTABI -u OSVERSION \
 			    pkg-static -o REPOS_DIR=${_repo_dir} \
 			    -o PKG_DBDIR=${_repo_dir}/db \
 			    -o REPO_CACHEDIR=${_repo_dir}/cache -o ABI=${REPO_ABI} \
@@ -1399,7 +1399,7 @@ check_upgrade_current_repo_override() {
 	fi
 
 	if [ -z "${_skip_update}" -a -z "${dont_update}" ]; then
-		env -u ABI -u ALTABI -u OSVERSION \
+		env IGNORE_OSVERSION=yes -u ABI -u ALTABI -u OSVERSION \
 		    pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_dir}/db \
 		    -o REPO_CACHEDIR=${_repo_dir}/cache -o ABI=${REPO_ABI} \
 		    update -f >/dev/null 2>&1
@@ -1415,13 +1415,13 @@ check_upgrade_current_repo_override() {
 				;;
 		esac
 
-		local _new_version=$(env -u ABI -u ALTABI -u OSVERSION \
+		local _new_version=$(env IGNORE_OSVERSION=yes -u ABI -u ALTABI -u OSVERSION \
 		    pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_dir}/db \
 		    -o REPO_CACHEDIR=${_repo_dir}/cache -o ABI=${REPO_ABI} \
 		    rquery -U %v ${_package})
 
 		if [ -z "${_new_version}" ]; then
-			_new_version=$(env -u ABI -u ALTABI -u OSVERSION \
+			_new_version=$(env IGNORE_OSVERSION=yes -u ABI -u ALTABI -u OSVERSION \
 			    pkg-static -o REPOS_DIR=${_repo_dir} \
 			    -o PKG_DBDIR=${_repo_dir}/db \
 			    -o REPO_CACHEDIR=${_repo_dir}/cache -o ABI=${REPO_ABI} \


### PR DESCRIPTION
### Motivation
- Upgrade detection can fail when the system is on FreeBSD 14 but an override repository targets a future major (FreeBSD 15), because `pkg-static` invocations used for detection honor `OSVERSION` and abort before version comparison.

### Description
- Set `IGNORE_OSVERSION=yes` in all `pkg-static` invocations used by repo-override detection paths to allow querying future-ABI repositories without OSVERSION validation errors.
- The change applies to `compare_pkg_version_repo()` rquery calls and to `check_upgrade_repo_override()` and `check_upgrade_current_repo_override()` for both `update` and `rquery` paths.
- Updated the debug trace in `compare_pkg_version_repo()` to reflect the new environment variable used during remote queries.

### Testing
- Performed a shell syntax check with `sh -n sysutils/pfSense-upgrade/files/Kontrol-upgrade`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a9030475c832e837e3b50438d81b9)