### PR TITLE
sysutils/pfSense-upgrade: evitar bootstrap do pkg durante checagem de NEW_MAJOR (opt-in legado)

### DIFF
--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -1459,11 +1459,17 @@ check_upgrade() {
 	fi
 
 	if [ -n "${NEW_MAJOR}" -a "${action}" = "check" ]; then
-		_exec "pkg-static bootstrap -f" \
-		    "Bootstrapping pkg due to ABI change" mute \
-		    ignore_result do_not_exit
-		_debug "check_upgrade bootstrap complete, forcing repo metadata refresh"
-		pkg_update force mute _do_not_bootstrap
+		if [ -n "${PF_UPGRADE_CHECK_BOOTSTRAP}" ]; then
+			_debug "check_upgrade PF_UPGRADE_CHECK_BOOTSTRAP set, using legacy pkg bootstrap flow"
+			_exec "pkg-static bootstrap -f" \
+			    "Bootstrapping pkg due to ABI change" mute \
+			    ignore_result do_not_exit
+			_debug "check_upgrade bootstrap complete, forcing repo metadata refresh"
+			pkg_update force mute _do_not_bootstrap
+		else
+			_debug "check_upgrade skipping pkg bootstrap for NEW_MAJOR detection"
+			_debug "check_upgrade set PF_UPGRADE_CHECK_BOOTSTRAP=1 to enable legacy behavior"
+		fi
 
 		check_upgrade_current_repo_override "${_mute}" "${_skip_update}" \
 		    "${_meta_pkg}" "${_core_pkgs}"


### PR DESCRIPTION
### Motivation
- Atualizar o binário `pkg` durante a fase de *detecção* (`action=check`) em situações de `NEW_MAJOR` tem causado trocas prematuras de versão e comportamento instável entre branches/ABIs.
- A intenção é separar a fase de detecção (apenas confirmar se existe upgrade no repo alvo) da fase de execução (onde o `pkg` pode efetivamente ser trocado), evitando bootstrap não-intencional do `pkg` que provoca os problemas reportados.

### Description
- Modifica `check_upgrade()` em `sysutils/pfSense-upgrade/files/Kontrol-upgrade` para não executar `pkg-static bootstrap -f` por padrão quando `NEW_MAJOR` e `action=check` estão ativos; a checagem passa a pular o bootstrap e continua as verificações de `repo_override` normalmente.
- Introduz a variável de ambiente opt-in `PF_UPGRADE_CHECK_BOOTSTRAP=1` que restaura o comportamento legado (faz o `pkg-static bootstrap -f` seguido de `pkg_update force`) para quem precisar compatibilidade ou troubleshooting.
- Adiciona mensagens de debug informando quando o bootstrap é pulado ou quando o fluxo legado é usado, preservando o restante do fluxo de detecção e das funções de override de repositório.

### Testing
- Executado `sh -n sysutils/pfSense-upgrade/files/Kontrol-upgrade` para checar sintaxe do script e o resultado foi `OK` (sucesso).
- Verificações locais de conteúdo com `rg`/`nl` e `git status` confirmaram a presença das novas mensagens e a alteração no bloco de `check_upgrade` (todas bem-sucedidas).
- Commit foi criado e a mudança aparece em diff do arquivo modificado (`sysutils/pfSense-upgrade/files/Kontrol-upgrade`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b85fb2874832e83a3e2364b137bea)