### PR TITLE
sysutils/pfSense-upgrade: require metadata refresh after pkg upgrade and fail stage2 on persistent update errors

### DIFF
--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -454,77 +454,81 @@ pkg_update() {
 
 	local _pkg_binary="/usr/sbin/pkg"
 
-	[ "${1}" = "force" ] \
-	    && _force=" -f"
+	[ "${1}" = "force" ] 	    && _force=" -f"
 
 	if [ -z "${_force}" -a -n "${dont_update}" ]; then
 		_debug "pkg_update skipping due to dont_update"
 		return 0
 	fi
 
-	[ "${2}" = "mute" ] \
-	    && _mute="mute"
+	[ "${2}" = "mute" ] 	    && _mute="mute"
 
 	/usr/local/bin/php -r 'require_once("pkg-utils.inc");update_repos();'
 	abi_setup
 
 	_debug "pkg_update force='${_force}' mute='${_mute}' do_not_bootstrap='${_do_not_bootstrap}'"
 
-	_exec "pkg-static update${_force}" "Updating repositories metadata" \
-	    ${_mute} "" do_not_exit
+	_exec "pkg-static update${_force}" "Updating repositories metadata" 	    ${_mute} "" do_not_exit
 
-	if [ $? -ne 0 -a -z "${_do_not_bootstrap}" ]; then
-		# Since pkg version 1.13 it moved to use repository metadata
-		# version 2, which cannot be processed by older pkg binaries
-		#
-		# Detect if remote repository has a meta.conf file available,
-		# what indicates it is using meta version 2, and in this case
-		# force to bootstrap pkg on local system
-		local _ver=$(_pkg query %v pkg)
-		local _cmp=$(_pkg version -t ${_ver} "1.13")
-		_debug "pkg_update bootstrap check pkg_version=${_ver} compare=${_cmp}"
-		if [ "${_cmp}" != "<" ]; then
-			return
-		fi
+	local _update_rc=$?
+	if [ ${_update_rc} -eq 0 ]; then
+		return 0
+	fi
 
-		# Make fetch to work with thoth
-		local _fetch_env=""
-		local _fetch_args=""
-		if [ "${arch}" = "aarch64" ]; then
-			_fetch_env="env OPENSSL_CONF=/etc/thoth/openssl.cnf"
-			_fetch_args="--cert=/etc/thoth/device.pem"
-			_fetch_args="${_fetch_args} --key=/etc/thoth/key.pem"
-			_fetch_args="${_fetch_args} --ca-cert=/etc/thoth/ca.pem"
-			_pkg_binary="/usr/local/sbin/pkg-static"
-		fi
+	if [ -n "${_do_not_bootstrap}" ]; then
+		return ${_update_rc}
+	fi
 
-		local _url=$(get_pkg_repo_url)
-		if [ $? -ne 0 ]; then
-			_debug "pkg_update failed to get repo url"
-			return
-		fi
-		_debug "pkg_update repo_url=${_url}"
+	# Since pkg version 1.13 it moved to use repository metadata
+	# version 2, which cannot be processed by older pkg binaries
+	#
+	# Detect if remote repository has a meta.conf file available,
+	# what indicates it is using meta version 2, and in this case
+	# force to bootstrap pkg on local system
+	local _ver=$(_pkg query %v pkg)
+	local _cmp=$(_pkg version -t ${_ver} "1.13")
+	_debug "pkg_update bootstrap check pkg_version=${_ver} compare=${_cmp}"
+	if [ "${_cmp}" != "<" ]; then
+		return ${_update_rc}
+	fi
 
-		if [ -n "${debug_enabled}" ]; then
-			local _meta_file
-			_meta_file=$(mktemp /tmp/pkg.meta.conf.XXXXXX) || _meta_file=""
-			if [ -n "${_meta_file}" ]; then
-				${_fetch_env} fetch ${_fetch_args} -o "${_meta_file}" \
-				    ${_url}/meta.conf >/dev/null 2>&1
-				_debug_file "${_meta_file}"
-				rm -f "${_meta_file}"
-			fi
-		fi
+	# Make fetch to work with thoth
+	local _fetch_env=""
+	local _fetch_args=""
+	if [ "${arch}" = "aarch64" ]; then
+		_fetch_env="env OPENSSL_CONF=/etc/thoth/openssl.cnf"
+		_fetch_args="--cert=/etc/thoth/device.pem"
+		_fetch_args="${_fetch_args} --key=/etc/thoth/key.pem"
+		_fetch_args="${_fetch_args} --ca-cert=/etc/thoth/ca.pem"
+		_pkg_binary="/usr/local/sbin/pkg-static"
+	fi
 
-		${_fetch_env} fetch ${_fetch_args} -o /dev/null \
-		    ${_url}/meta.conf >/dev/null 2>&1
-		if [ $? -eq 0 ]; then
-			_debug "pkg_update meta.conf detected, bootstrapping pkg"
-			_exec "${_pkg_binary} bootstrap -f" \
-			    "Bootstrap pkg due to meta version change"
-			pkg_update "${force}" "${_mute}" _do_not_bootstrap
+	local _url=$(get_pkg_repo_url)
+	if [ $? -ne 0 ]; then
+		_debug "pkg_update failed to get repo url"
+		return ${_update_rc}
+	fi
+	_debug "pkg_update repo_url=${_url}"
+
+	if [ -n "${debug_enabled}" ]; then
+		local _meta_file
+		_meta_file=$(mktemp /tmp/pkg.meta.conf.XXXXXX) || _meta_file=""
+		if [ -n "${_meta_file}" ]; then
+			${_fetch_env} fetch ${_fetch_args} -o "${_meta_file}" 			    ${_url}/meta.conf >/dev/null 2>&1
+			_debug_file "${_meta_file}"
+			rm -f "${_meta_file}"
 		fi
 	fi
+
+	${_fetch_env} fetch ${_fetch_args} -o /dev/null 	    ${_url}/meta.conf >/dev/null 2>&1
+	if [ $? -eq 0 ]; then
+		_debug "pkg_update meta.conf detected, bootstrapping pkg"
+		_exec "${_pkg_binary} bootstrap -f" 		    "Bootstrap pkg due to meta version change"
+		pkg_update "${force}" "${_mute}" _do_not_bootstrap
+		return $?
+	fi
+
+	return ${_update_rc}
 }
 
 pkg_upgrade_repo() {
@@ -1038,6 +1042,25 @@ pkg_upgrade() {
 				_exec "pkg-static install -f pkg" \
 				    "Reinstalling pkg due to ABI change"
 
+				# Refresh repository metadata with the new pkg binary
+				# before trying to upgrade core packages on stage 2.
+				local _pkg_update_ok=""
+				local _pkg_update_try=1
+				while [ ${_pkg_update_try} -le 3 ]; do
+					pkg_update force
+					if [ $? -eq 0 ]; then
+						_pkg_update_ok=1
+						break
+					fi
+					_debug "stage2 pkg_update attempt ${_pkg_update_try}/3 failed"
+					sleep 2
+					_pkg_update_try=$((_pkg_update_try + 1))
+				done
+				if [ -z "${_pkg_update_ok}" ]; then
+					_echo "ERROR: Unable to update repository metadata after pkg upgrade"
+					_exit 1
+				fi
+
 				# Upgrade core packages
 				_exec "pkg-static upgrade -r ${product}-core" \
 				    "Upgrading necessary core packages"
@@ -1459,11 +1482,17 @@ check_upgrade() {
 	fi
 
 	if [ -n "${NEW_MAJOR}" -a "${action}" = "check" ]; then
-		_exec "pkg-static bootstrap -f" \
-		    "Bootstrapping pkg due to ABI change" mute \
-		    ignore_result do_not_exit
-		_debug "check_upgrade bootstrap complete, forcing repo metadata refresh"
-		pkg_update force mute _do_not_bootstrap
+		if [ -n "${PF_UPGRADE_CHECK_BOOTSTRAP}" ]; then
+			_debug "check_upgrade PF_UPGRADE_CHECK_BOOTSTRAP set, using legacy pkg bootstrap flow"
+			_exec "pkg-static bootstrap -f" \
+			    "Bootstrapping pkg due to ABI change" mute \
+			    ignore_result do_not_exit
+			_debug "check_upgrade bootstrap complete, forcing repo metadata refresh"
+			pkg_update force mute _do_not_bootstrap
+		else
+			_debug "check_upgrade skipping pkg bootstrap for NEW_MAJOR detection"
+			_debug "check_upgrade set PF_UPGRADE_CHECK_BOOTSTRAP=1 to enable legacy behavior"
+		fi
 
 		check_upgrade_current_repo_override "${_mute}" "${_skip_update}" \
 		    "${_meta_pkg}" "${_core_pkgs}"
@@ -2015,7 +2044,11 @@ else
 fi
 
 if [ "${action}" = "install" ]; then
-	pkg_upgrade_repo
+	if [ "${action_pkg}" = "${product}-upgrade" ]; then
+		_debug "install action for ${action_pkg}; skipping pkg_upgrade_repo to avoid premature pkg upgrade"
+	else
+		pkg_upgrade_repo
+	fi
 
 	new_php_pkg=$(_pkg rquery -U %dn $(get_meta_pkg_name) \
 	    | egrep '^php[0-9]{2}$')


### PR DESCRIPTION
### Motivation
- Prevent stage 2 of the upgrade from continuing when repository metadata cannot be refreshed after `pkg` is upgraded, which can lead to false-success behaviour and reboots with incomplete upgrades.
- Make `pkg_update()` preserve and propagate `pkg-static update` failure codes so callers can react instead of masking failures.
- Harden the stage-2 flow against transient repo availability problems by retrying metadata refresh and aborting if it still fails.
- Avoid premature `pkg` repository/package changes during `install` of the upgrade image which may cause timing issues.

### Description
- Modified `pkg_update()` in `sysutils/pfSense-upgrade/files/Kontrol-upgrade` to capture and return the `pkg-static update` exit code instead of implicitly continuing, and preserved the existing bootstrap fallback for metadata v2 while propagating failures.
- Added a retry loop (up to 3 attempts, with short sleeps) in the stage-2 NEW_MAJOR path after reinstalling `pkg`, and explicitly abort the upgrade with an error if repository metadata cannot be refreshed.
- Added conditional behavior to `check_upgrade()` to skip the legacy `pkg` bootstrap flow by default for NEW_MAJOR detection, gated by `PF_UPGRADE_CHECK_BOOTSTRAP` to allow opt-in legacy behavior.
- Prevent `pkg_upgrade_repo` from running during an `install` action when the package being installed is the upgrader itself to avoid premature `pkg` upgrades during the install flow.

### Testing
- Performed a shell syntax check with `sh -n sysutils/pfSense-upgrade/files/Kontrol-upgrade` which completed successfully.
- Searched and inspected the modified file for the new return-paths and retry logic using `rg`/`nl`/manual inspection; the expected patterns (`local _update_rc`, `stage2 pkg_update attempt`, and the abort message) are present.
- Committed the change and created the PR; `git commit` completed successfully and no working tree changes remain.
- All automated checks executed in this rollout succeeded (syntax-check and text inspections).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b85fb2874832e83a3e2364b137bea)