### PR TITLE
sysutils/pfSense-upgrade: refresh pkg at start of stage 2

### DIFF
--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -1011,6 +1011,34 @@ pkg_upgrade() {
 	fi
 
 	if [ "${next_stage}" = "2" ]; then
+		if [ -n "${is_pkg_locked}" ]; then
+			# New major upgrades need pkg refreshed as soon as stage 2 starts
+			# so repository metadata can be read using the new ABI/tooling.
+			pkg_unlock pkg
+			_pkg annotate -q -D ${kernel_pkg} new_major
+			_exec "pkg-static install -f pkg" \
+			    "Reinstalling pkg due to ABI change"
+
+			# Refresh repository metadata with the new pkg binary before
+			# trying to upgrade any other package in stage 2.
+			local _pkg_update_ok=""
+			local _pkg_update_try=1
+			while [ ${_pkg_update_try} -le 3 ]; do
+				pkg_update force
+				if [ $? -eq 0 ]; then
+					_pkg_update_ok=1
+					break
+				fi
+				_debug "stage2 pkg_update attempt ${_pkg_update_try}/3 failed"
+				sleep 2
+				_pkg_update_try=$((_pkg_update_try + 1))
+			done
+			if [ -z "${_pkg_update_ok}" ]; then
+				_echo "ERROR: Unable to update repository metadata after pkg upgrade"
+				_exit 1
+			fi
+		fi
+
 		pkg_lock "${pkg_prefix}*"
 		unlock_additional_pkgs=1
 
@@ -1036,31 +1064,6 @@ pkg_upgrade() {
 		if upgrade_available; then
 			delete_annotation=1
 			if [ -n "${is_pkg_locked}" ]; then
-				# Upgrade pkg
-				pkg_unlock pkg
-				_pkg annotate -q -D ${kernel_pkg} new_major
-				_exec "pkg-static install -f pkg" \
-				    "Reinstalling pkg due to ABI change"
-
-				# Refresh repository metadata with the new pkg binary
-				# before trying to upgrade core packages on stage 2.
-				local _pkg_update_ok=""
-				local _pkg_update_try=1
-				while [ ${_pkg_update_try} -le 3 ]; do
-					pkg_update force
-					if [ $? -eq 0 ]; then
-						_pkg_update_ok=1
-						break
-					fi
-					_debug "stage2 pkg_update attempt ${_pkg_update_try}/3 failed"
-					sleep 2
-					_pkg_update_try=$((_pkg_update_try + 1))
-				done
-				if [ -z "${_pkg_update_ok}" ]; then
-					_echo "ERROR: Unable to update repository metadata after pkg upgrade"
-					_exit 1
-				fi
-
 				# Upgrade core packages
 				_exec "pkg-static upgrade -r ${product}-core" \
 				    "Upgrading necessary core packages"
@@ -2044,11 +2047,7 @@ else
 fi
 
 if [ "${action}" = "install" ]; then
-	if [ "${action_pkg}" = "${product}-upgrade" ]; then
-		_debug "install action for ${action_pkg}; skipping pkg_upgrade_repo to avoid premature pkg upgrade"
-	else
-		pkg_upgrade_repo
-	fi
+	pkg_upgrade_repo
 
 	new_php_pkg=$(_pkg rquery -U %dn $(get_meta_pkg_name) \
 	    | egrep '^php[0-9]{2}$')


### PR DESCRIPTION
### Motivation
- Stage 2 of major upgrades could fail to read the new repository metadata until `pkg` itself was refreshed after the first reboot, causing a non-deterministic flow where retrying the upgrade worked; the change aims to make the flow deterministic by ensuring `pkg` is refreshed as soon as stage 2 starts when needed.
- The intent is to allow the upgrade process to read repo metadata version 2 (new ABI/tooling) immediately in stage 2 so subsequent package operations succeed without requiring a prior failed attempt or manual reboot.

### Description
- Move the `pkg` reinstall and repository metadata refresh to the very beginning of stage 2 when `is_pkg_locked`/`new_major` is set, performing `pkg_unlock pkg`, `pkg-static install -f pkg` and a `pkg_update force` retry loop (up to 3 attempts) and failing hard if metadata cannot be refreshed.
- Remove the duplicate reinstall/metadata-refresh block that used to run later in stage 2 so the step runs once at the earliest practical point.
- Restore/ensure `pkg_upgrade_repo` is always executed for `action=install` (remove the previous special-case that skipped it when installing `${product}-upgrade`).
- Keep existing upgrade flow, locks, and core-package upgrade steps unchanged otherwise, and validated shell syntax after the change.

### Testing
- Ran a shell syntax check with `sh -n sysutils/pfSense-upgrade/files/Kontrol-upgrade`, which succeeded.
- Verified the patch application and repository state via `git diff` and commit, and confirmed the modified file passes the shell parser (`sh -n`) after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c98cb855c832e9bd2aaa6ee647d9b)