### PR TITLE
sysutils/pfSense-upgrade: bootstrap pkg at stage 2 start

### DIFF
--- a/sysutils/pfSense-upgrade/Makefile
+++ b/sysutils/pfSense-upgrade/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	Kontrol-upgrade
 PORTVERSION=	1.3.52
-PORTREVISION=	# empty
+PORTREVISION=	1
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -1016,27 +1016,12 @@ pkg_upgrade() {
 			# so repository metadata can be read using the new ABI/tooling.
 			pkg_unlock pkg
 			_pkg annotate -q -D ${kernel_pkg} new_major
-			_exec "pkg-static install -f pkg" \
-			    "Reinstalling pkg due to ABI change"
 
-			# Refresh repository metadata with the new pkg binary before
-			# trying to upgrade any other package in stage 2.
-			local _pkg_update_ok=""
-			local _pkg_update_try=1
-			while [ ${_pkg_update_try} -le 3 ]; do
-				pkg_update force
-				if [ $? -eq 0 ]; then
-					_pkg_update_ok=1
-					break
-				fi
-				_debug "stage2 pkg_update attempt ${_pkg_update_try}/3 failed"
-				sleep 2
-				_pkg_update_try=$((_pkg_update_try + 1))
-			done
-			if [ -z "${_pkg_update_ok}" ]; then
-				_echo "ERROR: Unable to update repository metadata after pkg upgrade"
-				_exit 1
-			fi
+			# Bootstrap pkg at phase 2 start so ABI/repository metadata
+			# changes are accepted before remaining upgrades.
+			_exec "pkg-static bootstrap -f" \
+			    "Bootstrapping pkg due to ABI change"
+			pkg_update force
 		fi
 
 		pkg_lock "${pkg_prefix}*"


### PR DESCRIPTION
### Motivation
- During NEW_MAJOR upgrades the repository metadata/ABI can change at the start of phase 2 and the upgrade can fail unless `pkg` is bootstrapped first, and manual `pkg bootstrap -f` before rerunning the upgrade was observed to allow progress.

### Description
- Replace the previous stage-2 workaround (reinstalling `pkg` and looping `pkg_update`) with an explicit `pkg-static bootstrap -f` at the beginning of stage 2 when `is_pkg_locked` is set, then run `pkg_update force`.
- Remove the retry loop and the error path that previously attempted multiple `pkg_update` retries after reinstalling `pkg`.
- Bump `PORTREVISION` from empty to `1` in the port `sysutils/pfSense-upgrade` so the package will be rebuilt with the updated script.

### Testing
- Executed a shell syntax check: `sh -n sysutils/pfSense-upgrade/files/Kontrol-upgrade`, which succeeded.
- Attempted to inspect port variables with `make -C sysutils/pfSense-upgrade -V PORTNAME -V PORTVERSION -V PORTREVISION`, which could not be completed in this Linux environment because GNU `make` is present instead of FreeBSD `bmake` (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ca1e730f4832eb2fe9c5dcfaddba6)