### PR TITLE
sysutils/pfSense-upgrade: postpone stage 2 when boot network is not ready

### DIFF
--- a/sysutils/pfSense-upgrade/Makefile
+++ b/sysutils/pfSense-upgrade/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	Kontrol-upgrade
-PORTVERSION=	1.3.44
+PORTVERSION=	1.3.45
 PORTREVISION=	# empty
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty

--- a/sysutils/pfSense-upgrade/Makefile
+++ b/sysutils/pfSense-upgrade/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	Kontrol-upgrade
-PORTVERSION=	1.3.42
+PORTVERSION=	1.3.43
 PORTREVISION=	# empty
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty

--- a/sysutils/pfSense-upgrade/Makefile
+++ b/sysutils/pfSense-upgrade/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	Kontrol-upgrade
-PORTVERSION=	1.3.49
+PORTVERSION=	1.3.50
 PORTREVISION=	# empty
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty

--- a/sysutils/pfSense-upgrade/Makefile
+++ b/sysutils/pfSense-upgrade/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	Kontrol-upgrade
-PORTVERSION=	1.3.50
+PORTVERSION=	1.3.51
 PORTREVISION=	# empty
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty

--- a/sysutils/pfSense-upgrade/Makefile
+++ b/sysutils/pfSense-upgrade/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	Kontrol-upgrade
-PORTVERSION=	1.3.43
+PORTVERSION=	1.3.44
 PORTREVISION=	# empty
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty

--- a/sysutils/pfSense-upgrade/Makefile
+++ b/sysutils/pfSense-upgrade/Makefile
@@ -16,6 +16,10 @@ LICENSE=	APACHE20
 NO_MTREE=	yes
 NO_BUILD=	yes
 
+OPTIONS_DEFINE=	DEBUG
+DEBUG_DESC=	Enable verbose debug logging by default
+OPTIONS_DEFAULT=DEBUG
+
 PLIST_FILES=	libexec/Kontrol-upgrade \
 		sbin/Kontrol-upgrade \
 		sbin/Kontrol-repo-setup
@@ -23,6 +27,12 @@ PLIST_FILES=	libexec/Kontrol-upgrade \
 do-extract:
 	@${MKDIR} ${WRKSRC}
 	${CP} -r ${FILESDIR}/* ${WRKSRC}
+
+post-patch:
+.if ${PORT_OPTIONS:MDEBUG}
+	${REINPLACE_CMD} 's/^DEBUG_DEFAULT=0/DEBUG_DEFAULT=1/' \
+		${WRKSRC}/Kontrol-upgrade
+.endif
 
 do-install:
 	${MKDIR} ${STAGEDIR}${PREFIX}/sbin

--- a/sysutils/pfSense-upgrade/Makefile
+++ b/sysutils/pfSense-upgrade/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	Kontrol-upgrade
-PORTVERSION=	1.3.51
+PORTVERSION=	1.3.52
 PORTREVISION=	# empty
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty

--- a/sysutils/pfSense-upgrade/Makefile
+++ b/sysutils/pfSense-upgrade/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	Kontrol-upgrade
-PORTVERSION=	1.3.39
+PORTVERSION=	1.3.40
 PORTREVISION=	# empty
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty

--- a/sysutils/pfSense-upgrade/Makefile
+++ b/sysutils/pfSense-upgrade/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	Kontrol-upgrade
-PORTVERSION=	1.3.38
+PORTVERSION=	1.3.39
 PORTREVISION=	# empty
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty

--- a/sysutils/pfSense-upgrade/Makefile
+++ b/sysutils/pfSense-upgrade/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	Kontrol-upgrade
-PORTVERSION=	1.3.45
+PORTVERSION=	1.3.46
 PORTREVISION=	# empty
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty

--- a/sysutils/pfSense-upgrade/Makefile
+++ b/sysutils/pfSense-upgrade/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	Kontrol-upgrade
-PORTVERSION=	1.3.40
+PORTVERSION=	1.3.41
 PORTREVISION=	# empty
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty

--- a/sysutils/pfSense-upgrade/Makefile
+++ b/sysutils/pfSense-upgrade/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	Kontrol-upgrade
-PORTVERSION=	1.3.47
+PORTVERSION=	1.3.48
 PORTREVISION=	# empty
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty

--- a/sysutils/pfSense-upgrade/Makefile
+++ b/sysutils/pfSense-upgrade/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	Kontrol-upgrade
-PORTVERSION=	1.3.48
+PORTVERSION=	1.3.49
 PORTREVISION=	# empty
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty

--- a/sysutils/pfSense-upgrade/Makefile
+++ b/sysutils/pfSense-upgrade/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	Kontrol-upgrade
-PORTVERSION=	1.3.41
+PORTVERSION=	1.3.42
 PORTREVISION=	# empty
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty

--- a/sysutils/pfSense-upgrade/Makefile
+++ b/sysutils/pfSense-upgrade/Makefile
@@ -16,6 +16,10 @@ LICENSE=	APACHE20
 NO_MTREE=	yes
 NO_BUILD=	yes
 
+OPTIONS_DEFINE=	DEBUG
+DEBUG_DESC=	Enable verbose debug logging by default
+OPTIONS_DEFAULT=DEBUG
+
 PLIST_FILES=	libexec/Kontrol-upgrade \
 		sbin/Kontrol-upgrade \
 		sbin/Kontrol-repo-setup
@@ -23,6 +27,12 @@ PLIST_FILES=	libexec/Kontrol-upgrade \
 do-extract:
 	@${MKDIR} ${WRKSRC}
 	${CP} -r ${FILESDIR}/* ${WRKSRC}
+
+post-patch:
+.if defined(PORT_OPTIONS) && ${PORT_OPTIONS:MDEBUG}
+	${REINPLACE_CMD} 's/^DEBUG_DEFAULT=0/DEBUG_DEFAULT=1/' \
+		${WRKSRC}/Kontrol-upgrade
+.endif
 
 do-install:
 	${MKDIR} ${STAGEDIR}${PREFIX}/sbin

--- a/sysutils/pfSense-upgrade/Makefile
+++ b/sysutils/pfSense-upgrade/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	Kontrol-upgrade
 PORTVERSION=	1.3.52
-PORTREVISION=	# empty
+PORTREVISION=	3
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/sysutils/pfSense-upgrade/Makefile
+++ b/sysutils/pfSense-upgrade/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	Kontrol-upgrade
-PORTVERSION=	1.3.46
+PORTVERSION=	1.3.47
 PORTREVISION=	# empty
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty

--- a/sysutils/pfSense-upgrade/Makefile
+++ b/sysutils/pfSense-upgrade/Makefile
@@ -1,14 +1,14 @@
 # $FreeBSD$
 
 PORTNAME=	Kontrol-upgrade
-PORTVERSION=	1.3.32
+PORTVERSION=	1.3.33
 PORTREVISION=	# empty
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty
 DISTFILES=	# empty
 EXTRACT_ONLY=	# empty
 
-MAINTAINER=	coreteam@pfsense.org
+MAINTAINER=	contato@kontrol.com.br
 COMMENT=	Kontrol upgrade script
 
 LICENSE=	APACHE20

--- a/sysutils/pfSense-upgrade/Makefile
+++ b/sysutils/pfSense-upgrade/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	Kontrol-upgrade
-PORTVERSION=	1.3.35
+PORTVERSION=	1.3.36
 PORTREVISION=	# empty
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty

--- a/sysutils/pfSense-upgrade/Makefile
+++ b/sysutils/pfSense-upgrade/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	Kontrol-upgrade
-PORTVERSION=	1.3.33
+PORTVERSION=	1.3.34
 PORTREVISION=	# empty
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty

--- a/sysutils/pfSense-upgrade/Makefile
+++ b/sysutils/pfSense-upgrade/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	Kontrol-upgrade
-PORTVERSION=	1.3.34
+PORTVERSION=	1.3.35
 PORTREVISION=	# empty
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty

--- a/sysutils/pfSense-upgrade/Makefile
+++ b/sysutils/pfSense-upgrade/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	Kontrol-upgrade
-PORTVERSION=	1.3.37
+PORTVERSION=	1.3.38
 PORTREVISION=	# empty
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty

--- a/sysutils/pfSense-upgrade/Makefile
+++ b/sysutils/pfSense-upgrade/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	Kontrol-upgrade
-PORTVERSION=	1.3.36
+PORTVERSION=	1.3.37
 PORTREVISION=	# empty
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty

--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -1011,6 +1011,34 @@ pkg_upgrade() {
 	fi
 
 	if [ "${next_stage}" = "2" ]; then
+		if [ -n "${is_pkg_locked}" ]; then
+			# New major upgrades need pkg refreshed as soon as stage 2 starts
+			# so repository metadata can be read using the new ABI/tooling.
+			pkg_unlock pkg
+			_pkg annotate -q -D ${kernel_pkg} new_major
+			_exec "pkg-static install -f pkg" \
+			    "Reinstalling pkg due to ABI change"
+
+			# Refresh repository metadata with the new pkg binary before
+			# trying to upgrade any other package in stage 2.
+			local _pkg_update_ok=""
+			local _pkg_update_try=1
+			while [ ${_pkg_update_try} -le 3 ]; do
+				pkg_update force
+				if [ $? -eq 0 ]; then
+					_pkg_update_ok=1
+					break
+				fi
+				_debug "stage2 pkg_update attempt ${_pkg_update_try}/3 failed"
+				sleep 2
+				_pkg_update_try=$((_pkg_update_try + 1))
+			done
+			if [ -z "${_pkg_update_ok}" ]; then
+				_echo "ERROR: Unable to update repository metadata after pkg upgrade"
+				_exit 1
+			fi
+		fi
+
 		pkg_lock "${pkg_prefix}*"
 		unlock_additional_pkgs=1
 
@@ -1036,31 +1064,6 @@ pkg_upgrade() {
 		if upgrade_available; then
 			delete_annotation=1
 			if [ -n "${is_pkg_locked}" ]; then
-				# Upgrade pkg
-				pkg_unlock pkg
-				_pkg annotate -q -D ${kernel_pkg} new_major
-				_exec "pkg-static install -f pkg" \
-				    "Reinstalling pkg due to ABI change"
-
-				# Refresh repository metadata with the new pkg binary
-				# before trying to upgrade core packages on stage 2.
-				local _pkg_update_ok=""
-				local _pkg_update_try=1
-				while [ ${_pkg_update_try} -le 3 ]; do
-					pkg_update force
-					if [ $? -eq 0 ]; then
-						_pkg_update_ok=1
-						break
-					fi
-					_debug "stage2 pkg_update attempt ${_pkg_update_try}/3 failed"
-					sleep 2
-					_pkg_update_try=$((_pkg_update_try + 1))
-				done
-				if [ -z "${_pkg_update_ok}" ]; then
-					_echo "ERROR: Unable to update repository metadata after pkg upgrade"
-					_exit 1
-				fi
-
 				# Upgrade core packages
 				_exec "pkg-static upgrade -r ${product}-core" \
 				    "Upgrading necessary core packages"
@@ -2044,11 +2047,7 @@ else
 fi
 
 if [ "${action}" = "install" ]; then
-	if [ "${action_pkg}" = "${product}-upgrade" ]; then
-		_debug "install action for ${action_pkg}; skipping pkg_upgrade_repo to avoid premature pkg upgrade"
-	else
-		pkg_upgrade_repo
-	fi
+	pkg_upgrade_repo
 
 	new_php_pkg=$(_pkg rquery -U %dn $(get_meta_pkg_name) \
 	    | egrep '^php[0-9]{2}$')

--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -531,6 +531,39 @@ pkg_update() {
 	return ${_update_rc}
 }
 
+wait_for_pkg_repo() {
+	local _tries="${1:-12}"
+	local _sleep="${2:-5}"
+	local _url="$(get_pkg_repo_url)"
+
+	if [ -z "${_url}" ]; then
+		_debug "wait_for_pkg_repo failed to get repo url"
+		return 1
+	fi
+
+	# Make fetch to work with thoth
+	local _fetch_env=""
+	local _fetch_args="-T 5"
+	if [ "${arch}" = "aarch64" ]; then
+		_fetch_env="env OPENSSL_CONF=/etc/thoth/openssl.cnf"
+		_fetch_args="${_fetch_args} --cert=/etc/thoth/device.pem"
+		_fetch_args="${_fetch_args} --key=/etc/thoth/key.pem"
+		_fetch_args="${_fetch_args} --ca-cert=/etc/thoth/ca.pem"
+	fi
+
+	local _try=1
+	while [ ${_try} -le ${_tries} ]; do
+		${_fetch_env} fetch ${_fetch_args} -o /dev/null \
+		    ${_url}/meta.conf >/dev/null 2>&1 && return 0
+
+		_debug "wait_for_pkg_repo try ${_try}/${_tries} failed url=${_url}"
+		sleep ${_sleep}
+		_try=$((_try + 1))
+	done
+
+	return 1
+}
+
 pkg_upgrade_repo() {
 	if [ -n "${reinstall_pkg}" ] \
 	    || [ -z "${NEW_MAJOR}" -a "$(compare_pkg_version pkg)" = "<" ]; then
@@ -1016,25 +1049,50 @@ pkg_upgrade() {
 			# so repository metadata can be read using the new ABI/tooling.
 			pkg_unlock pkg
 			_pkg annotate -q -D ${kernel_pkg} new_major
-			_exec "pkg-static install -f pkg" \
-			    "Reinstalling pkg due to ABI change"
 
-			# Refresh repository metadata with the new pkg binary before
-			# trying to upgrade any other package in stage 2.
-			local _pkg_update_ok=""
-			local _pkg_update_try=1
-			while [ ${_pkg_update_try} -le 3 ]; do
-				pkg_update force
+			# During boot-triggered stage 2 runs, network services may not be
+			# ready yet. Wait briefly for repository reachability before
+			# bootstrapping pkg.
+			if [ -n "${booting}" ]; then
+				wait_for_pkg_repo 24 5
+				if [ $? -ne 0 ]; then
+					_echo "WARNING: Repository is still unreachable after reboot; postponing stage 2 upgrade"
+					_exit 0
+				fi
+			fi
+
+			# Bootstrap pkg at phase 2 start so ABI/repository metadata
+			# changes are accepted before remaining upgrades.
+			local _bootstrap_try=1
+			local _bootstrap_ok=""
+			while [ ${_bootstrap_try} -le 6 ]; do
+				_exec "pkg-static bootstrap -f" \
+				    "Bootstrapping pkg due to ABI change" mute \
+				    ignore_result do_not_exit
 				if [ $? -eq 0 ]; then
-					_pkg_update_ok=1
+					_bootstrap_ok=1
 					break
 				fi
-				_debug "stage2 pkg_update attempt ${_pkg_update_try}/3 failed"
-				sleep 2
-				_pkg_update_try=$((_pkg_update_try + 1))
+				_debug "stage2 pkg bootstrap attempt ${_bootstrap_try}/6 failed"
+				sleep 5
+				_bootstrap_try=$((_bootstrap_try + 1))
 			done
-			if [ -z "${_pkg_update_ok}" ]; then
-				_echo "ERROR: Unable to update repository metadata after pkg upgrade"
+			if [ -z "${_bootstrap_ok}" ]; then
+				if [ -n "${booting}" ]; then
+					_echo "WARNING: Unable to bootstrap pkg during boot; postponing stage 2 upgrade"
+					_exit 0
+				fi
+				_echo "ERROR: Unable to bootstrap pkg at stage 2"
+				_exit 1
+			fi
+
+			pkg_update force
+			if [ $? -ne 0 ]; then
+				if [ -n "${booting}" ]; then
+					_echo "WARNING: Unable to update repository metadata during boot; postponing stage 2 upgrade"
+					_exit 0
+				fi
+				_echo "ERROR: Unable to update repository metadata after pkg bootstrap"
 				_exit 1
 			fi
 		fi

--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -1459,11 +1459,17 @@ check_upgrade() {
 	fi
 
 	if [ -n "${NEW_MAJOR}" -a "${action}" = "check" ]; then
-		_exec "pkg-static bootstrap -f" \
-		    "Bootstrapping pkg due to ABI change" mute \
-		    ignore_result do_not_exit
-		_debug "check_upgrade bootstrap complete, forcing repo metadata refresh"
-		pkg_update force mute _do_not_bootstrap
+		if [ -n "${PF_UPGRADE_CHECK_BOOTSTRAP}" ]; then
+			_debug "check_upgrade PF_UPGRADE_CHECK_BOOTSTRAP set, using legacy pkg bootstrap flow"
+			_exec "pkg-static bootstrap -f" \
+			    "Bootstrapping pkg due to ABI change" mute \
+			    ignore_result do_not_exit
+			_debug "check_upgrade bootstrap complete, forcing repo metadata refresh"
+			pkg_update force mute _do_not_bootstrap
+		else
+			_debug "check_upgrade skipping pkg bootstrap for NEW_MAJOR detection"
+			_debug "check_upgrade set PF_UPGRADE_CHECK_BOOTSTRAP=1 to enable legacy behavior"
+		fi
 
 		check_upgrade_current_repo_override "${_mute}" "${_skip_update}" \
 		    "${_meta_pkg}" "${_core_pkgs}"
@@ -2015,7 +2021,11 @@ else
 fi
 
 if [ "${action}" = "install" ]; then
-	pkg_upgrade_repo
+	if [ "${action_pkg}" = "${product}-upgrade" ]; then
+		_debug "install action for ${action_pkg}; skipping pkg_upgrade_repo to avoid premature pkg upgrade"
+	else
+		pkg_upgrade_repo
+	fi
 
 	new_php_pkg=$(_pkg rquery -U %dn $(get_meta_pkg_name) \
 	    | egrep '^php[0-9]{2}$')

--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -18,6 +18,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+DEBUG_DEFAULT=0
+
 usage() {
 	me=$(basename $0)
 	cat << EOD >&2
@@ -57,6 +59,44 @@ _echo() {
 	echo ${_n} "${@}" | tee -a ${logfile}
 }
 
+_debug() {
+	if [ -z "${debug_enabled}" ]; then
+		return 0
+	fi
+
+	local _ts
+	_ts=$(date "+%Y-%m-%d %H:%M:%S")
+	_echo "DEBUG ${_ts} ${*}"
+}
+
+_debug_file() {
+	if [ -z "${debug_enabled}" ]; then
+		return 0
+	fi
+
+	local _file="${1}"
+	local _ts
+	_ts=$(date "+%Y-%m-%d %H:%M:%S")
+
+	if [ -z "${_file}" ]; then
+		_echo "DEBUG ${_ts} file=(empty)"
+		return 0
+	fi
+
+	if [ ! -f "${_file}" ]; then
+		_echo "DEBUG ${_ts} file=${_file} (not found)"
+		return 0
+	fi
+
+	_echo "DEBUG ${_ts} file=${_file} (begin)"
+	while IFS= read -r _line; do
+		_ts=$(date "+%Y-%m-%d %H:%M:%S")
+		_echo "DEBUG ${_ts} file=${_file}: ${_line}"
+	done < "${_file}"
+	_ts=$(date "+%Y-%m-%d %H:%M:%S")
+	_echo "DEBUG ${_ts} file=${_file} (end)"
+}
+
 _exec() {
 	local _cmd="${1}"
 	local _msg="${2}"
@@ -73,6 +113,8 @@ _exec() {
 	if [ "${_mute}" != "mute" ]; then
 		_stdout=''
 	fi
+
+	_debug "exec cmd='${_cmd}' msg='${_msg}' mute='${_mute}'"
 
 	[ -n "${_msg}" ] \
 	    && _echo -n ">>> ${_msg}... "
@@ -100,10 +142,12 @@ _exec() {
 	if [ ${_result} -eq 0 -o -n "${_ignore_result}" ]; then
 		[ -n "${_stdout}" -a -n "${_msg}" ] \
 		    && _echo "done."
+		_debug "exec result=success code=${_result}"
 		return 0
 	else
 		[ -n "${_stdout}" -a -n "${_msg}" ] \
 		    && _echo "failed."
+		_debug "exec result=failure code=${_result}"
 		[ -n "${_do_not_exit}" ] \
 		    && return 1 \
 		    || _exit 1
@@ -307,6 +351,12 @@ abi_setup() {
 	ABI="${_repo_abi}"
 	ALTABI="${_repo_altabi}"
 
+	_debug "abi_setup freebsd_version=${_freebsd_version} arch=${arch} CUR_ABI=${CUR_ABI} CUR_ALTABI=${CUR_ALTABI}"
+	_debug "abi_setup repo_conf=${_pkg_repo_conf} repo_target=${_repo_abi_file} ABI=${ABI} ALTABI=${ALTABI}"
+	_debug "abi_setup repo_dir=/usr/local/share/${product}/pkg/repos"
+	_debug_file "/usr/local/share/${product}/pkg/repos/${product}-repo.conf"
+	_debug_file "/usr/local/share/${product}/pkg/repos/${product}-repo-previous.conf"
+
 	AUTH_CA="/etc/ssl/netgate-ca.pem"
 	AUTH_CERT="/etc/ssl/pfSense-repo-custom.cert"
 	AUTH_KEY="/etc/ssl/pfSense-repo-custom.key"
@@ -344,7 +394,8 @@ EOF
 		NEW_MAJOR=1
 	fi
 
-	if [ -n "${NEW_MAJOR}" -a "${action}" != "upgrade" ]; then
+	if [ -n "${NEW_MAJOR}" -a "${action}" != "upgrade" -a \
+	    "${action}" != "check" ]; then
 		ABI="${CUR_ABI}"
 		ALTABI="${CUR_ALTABI}"
 	else
@@ -355,6 +406,9 @@ EOF
 	OSVERSION=$(sysctl -n kern.osreldate)
 	echo "ABI=${ABI}" > /usr/local/etc/pkg.conf
 	echo "OSVERSION=${OSVERSION}" >> /usr/local/etc/pkg.conf
+
+	_debug "abi_setup pkg_abi=${_pkg_abi} reinstall_pkg=${reinstall_pkg:-0} NEW_MAJOR=${NEW_MAJOR:-0} OSVERSION=${OSVERSION} IGNORE_OSVERSION=${IGNORE_OSVERSION:-}"
+	_debug_file "/usr/local/etc/pkg.conf"
 
 	export CUR_ABI CUR_ALTABI ABI NEW_MAJOR
 }
@@ -378,6 +432,7 @@ get_pkg_repo_url() {
 	if [ -n "${_srv}" ]; then
 		local _n=$(host -t SRV _https._tcp.${_host} 2>/dev/null | wc -l)
 		if [ ${_n} -eq 0 ]; then
+			_debug "get_pkg_repo_url srv lookup failed host=${_host}"
 			return 1
 		fi
 
@@ -388,6 +443,7 @@ get_pkg_repo_url() {
 		_url=$(echo "${_url}" | sed "s,${_host},${_real_host},")
 	fi
 
+	_debug "get_pkg_repo_url url=${_url}"
 	echo "${_url}"
 }
 
@@ -402,6 +458,7 @@ pkg_update() {
 	    && _force=" -f"
 
 	if [ -z "${_force}" -a -n "${dont_update}" ]; then
+		_debug "pkg_update skipping due to dont_update"
 		return 0
 	fi
 
@@ -410,6 +467,8 @@ pkg_update() {
 
 	/usr/local/bin/php -r 'require_once("pkg-utils.inc");update_repos();'
 	abi_setup
+
+	_debug "pkg_update force='${_force}' mute='${_mute}' do_not_bootstrap='${_do_not_bootstrap}'"
 
 	_exec "pkg-static update${_force}" "Updating repositories metadata" \
 	    ${_mute} "" do_not_exit
@@ -423,6 +482,7 @@ pkg_update() {
 		# force to bootstrap pkg on local system
 		local _ver=$(_pkg query %v pkg)
 		local _cmp=$(_pkg version -t ${_ver} "1.13")
+		_debug "pkg_update bootstrap check pkg_version=${_ver} compare=${_cmp}"
 		if [ "${_cmp}" != "<" ]; then
 			return
 		fi
@@ -440,12 +500,26 @@ pkg_update() {
 
 		local _url=$(get_pkg_repo_url)
 		if [ $? -ne 0 ]; then
+			_debug "pkg_update failed to get repo url"
 			return
+		fi
+		_debug "pkg_update repo_url=${_url}"
+
+		if [ -n "${debug_enabled}" ]; then
+			local _meta_file
+			_meta_file=$(mktemp /tmp/pkg.meta.conf.XXXXXX) || _meta_file=""
+			if [ -n "${_meta_file}" ]; then
+				${_fetch_env} fetch ${_fetch_args} -o "${_meta_file}" \
+				    ${_url}/meta.conf >/dev/null 2>&1
+				_debug_file "${_meta_file}"
+				rm -f "${_meta_file}"
+			fi
 		fi
 
 		${_fetch_env} fetch ${_fetch_args} -o /dev/null \
 		    ${_url}/meta.conf >/dev/null 2>&1
 		if [ $? -eq 0 ]; then
+			_debug "pkg_update meta.conf detected, bootstrapping pkg"
 			_exec "${_pkg_binary} bootstrap -f" \
 			    "Bootstrap pkg due to meta version change"
 			pkg_update "${force}" "${_mute}" _do_not_bootstrap
@@ -456,6 +530,7 @@ pkg_update() {
 pkg_upgrade_repo() {
 	if [ -n "${reinstall_pkg}" ] \
 	    || [ -z "${NEW_MAJOR}" -a "$(compare_pkg_version pkg)" = "<" ]; then
+		_debug "pkg_upgrade_repo upgrading pkg reinstall_pkg=${reinstall_pkg:-0} NEW_MAJOR=${NEW_MAJOR:-0}"
 		pkg_unlock pkg
 		_exec "pkg-static upgrade${dont_update} pkg" "Upgrading pkg" \
 		    mute
@@ -466,6 +541,7 @@ pkg_upgrade_repo() {
 	local _repo_pkg="${product}-repo"
 
 	if ! is_pkg_installed ${_repo_pkg}; then
+		_debug "pkg_upgrade_repo installing ${_repo_pkg}"
 		_exec "pkg-static install${dont_update} ${_repo_pkg}" \
 		    "Installing ${_repo_pkg}" mute "" do_not_exit
 		if [ $? -ne 0 ]; then
@@ -494,6 +570,7 @@ pkg_upgrade_repo() {
 
 	cp /usr/local/etc/pkg/repos/${product}.conf /tmp/${product}.conf.copy
 	if !(is_ce && repo_is_plus_upgrade) ; then
+		_debug "pkg_upgrade_repo upgrading ${_repo_pkg} force='${_force}'"
 		_exec "pkg-static upgrade${dont_update}${_force} ${_repo_pkg}" \
 		    "Upgrading ${_repo_pkg}" mute
 	fi
@@ -519,6 +596,7 @@ upgrade_available() {
 	    | sed -e '/^$/d; /is locked and may not be modified/d' \
 	    | wc -l)
 
+	_debug "upgrade_available packages='${*}' lines=${_lines}"
 	test ${_lines} -gt 0
 	return $?
 }
@@ -666,9 +744,7 @@ pkg_upgrade() {
 	need_reboot=1
 	# First upgrade stage
 	if [ -z "${next_stage}" ]; then
-		if [ -f "${logfile}" ]; then
-			rm -f ${logfile}
-		fi
+		# Preserve existing logfile; do not delete
 
 		pkg_update force
 
@@ -1182,6 +1258,8 @@ compare_pkg_version_repo() {
 		_exit 1
 	fi
 
+	_debug "compare_pkg_version_repo pkg=${_pkg_name} local=${_lver} remote=${_rver} abi=${_abi}"
+	_debug "compare_pkg_version_repo rquery_cmd=env -u ABI -u ALTABI -u OSVERSION pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_db} -o REPO_CACHEDIR=${_repo_cache} -o ABI=${_abi} rquery -U %v ${_pkg_name}"
 	local _version=$(_pkg version -t ${_lver} ${_rver})
 
 	if [ $? -ne 0 ]; then
@@ -1228,14 +1306,19 @@ check_upgrade_repo_override() {
 	done
 
 	if [ -z "${_best_conf}" ]; then
+		_debug "check_upgrade_repo_override no repo override conf found"
 		return 1
 	fi
 
 	if [ -n "${_current_major}" -a "${_best_major}" -le "${_current_major}" ]; then
+		_debug "check_upgrade_repo_override best_major=${_best_major} current_major=${_current_major} skipping"
 		return 1
 	fi
 
 	get_repo_abi_values "${_best_conf}"
+
+	_debug "check_upgrade_repo_override using best_conf=${_best_conf} REPO_ABI=${REPO_ABI} REPO_ALTABI=${REPO_ALTABI}"
+	_debug_file "${_best_conf}"
 
 	local _repo_dir=$(prepare_repo_override_dir "${_best_conf}")
 	if [ -z "${_repo_dir}" ]; then
@@ -1274,6 +1357,7 @@ check_upgrade_repo_override() {
 
 		[ -z "${_new_version}" ] && continue
 
+		_debug "check_upgrade_repo_override package=${_package} new_version=${_new_version}"
 		[ -z "${_mute}" ] \
 		    && _echo \
 		    "${_new_version} version of ${product} is available"
@@ -1300,10 +1384,14 @@ check_upgrade_current_repo_override() {
 	fi
 
 	if [ -z "${_current_repo_target}" ]; then
+		_debug "check_upgrade_current_repo_override missing repo target"
 		return 1
 	fi
 
 	get_repo_abi_values "${_current_repo_target}"
+
+	_debug "check_upgrade_current_repo_override repo_conf=${_current_repo_target} REPO_ABI=${REPO_ABI} REPO_ALTABI=${REPO_ALTABI}"
+	_debug_file "${_current_repo_target}"
 
 	local _repo_dir=$(prepare_repo_override_dir "${_current_repo_target}")
 	if [ -z "${_repo_dir}" ]; then
@@ -1342,6 +1430,7 @@ check_upgrade_current_repo_override() {
 
 		[ -z "${_new_version}" ] && continue
 
+		_debug "check_upgrade_current_repo_override package=${_package} new_version=${_new_version}"
 		[ -z "${_mute}" ] \
 		    && _echo \
 		    "${_new_version} version of ${product} is available"
@@ -1361,9 +1450,11 @@ check_upgrade() {
 	    "%n ~ ${product}-kernel-* || %n ~ ${product}-base*" %n 2>/dev/null)
 	local _repo_behind=""
 
+	_debug "check_upgrade meta_pkg=${_meta_pkg} core_pkgs='${_core_pkgs}' NEW_MAJOR=${NEW_MAJOR:-0} action=${action}"
 	check_upgrade_current_repo_override "${_mute}" "${_skip_update}" \
 	    "${_meta_pkg}" "${_core_pkgs}"
 	if [ $? -eq 2 ]; then
+		_debug "check_upgrade current repo override has upgrade"
 		return 2
 	fi
 
@@ -1371,16 +1462,20 @@ check_upgrade() {
 		_exec "pkg-static bootstrap -f" \
 		    "Bootstrapping pkg due to ABI change" mute \
 		    ignore_result do_not_exit
+		_debug "check_upgrade bootstrap complete, forcing repo metadata refresh"
+		pkg_update force mute _do_not_bootstrap
 
 		check_upgrade_current_repo_override "${_mute}" "${_skip_update}" \
 		    "${_meta_pkg}" "${_core_pkgs}"
 		if [ $? -eq 2 ]; then
+			_debug "check_upgrade current repo override has upgrade after bootstrap"
 			return 2
 		fi
 
 		check_upgrade_repo_override "${_mute}" "${_skip_update}" \
 		    "${_meta_pkg}" "${_core_pkgs}"
 		if [ $? -eq 2 ]; then
+			_debug "check_upgrade repo override has upgrade"
 			return 2
 		fi
 
@@ -1390,6 +1485,7 @@ check_upgrade() {
 	fi
 
 	if [ -n "${NEW_MAJOR}" -a "${action}" != "upgrade" ]; then
+		_debug "check_upgrade NEW_MAJOR set and action not upgrade; returning up to date"
 		[ -z "${_mute}" ] \
 		    && _echo "Your system is up to date"
 		return 0
@@ -1419,15 +1515,18 @@ check_upgrade() {
 		_version_compare=$(compare_pkg_version ${_package})
 		case "${_version_compare}" in
 			=)
+				_debug "check_upgrade package=${_package} local=remote"
 				continue
 				;;
 			'>')
+				_debug "check_upgrade package=${_package} local newer"
 				_repo_behind=1
 				continue
 				;;
 		esac
 
 		local _new_version=$(_pkg rquery -U %v ${_package})
+		_debug "check_upgrade package=${_package} new_version=${_new_version}"
 		[ -z "${_mute}" ] \
 		    && _echo \
 		    "${_new_version} version of ${product} is available"
@@ -1437,6 +1536,7 @@ check_upgrade() {
 	check_upgrade_repo_override "${_mute}" "${_skip_update}" \
 	    "${_meta_pkg}" "${_core_pkgs}"
 	if [ $? -eq 2 ]; then
+		_debug "check_upgrade repo override has upgrade"
 		return 2
 	fi
 
@@ -1493,6 +1593,10 @@ compare_pkg_version() {
 		_exit 1
 	fi
 
+	local _pkg_ver=$(_pkg query %v pkg 2>/dev/null)
+	_debug "compare_pkg_version pkg=${_pkg_name} local=${_lver} remote=${_rver}"
+	_debug "compare_pkg_version rquery_cmd=pkg-static rquery -U %v ${_pkg_name}"
+	_debug "compare_pkg_version env ABI=${ABI} ALTABI=${ALTABI} OSVERSION=${OSVERSION} IGNORE_OSVERSION=${IGNORE_OSVERSION:-} PKG_VERSION=${_pkg_ver}"
 	local _version=$(_pkg version -t ${_lver} ${_rver})
 
 	if [ $? -ne 0 ]; then
@@ -1645,6 +1749,12 @@ validate_repo_conf() {
 			ln -sf ${pkg_repo_conf_path} ${pkg_repo_conf}
 		fi
 	fi
+
+	_debug "validate_repo_conf repo_conf_path=${pkg_repo_conf_path} repo_conf=${pkg_repo_conf}"
+	_debug "validate_repo_conf repo_dir=/usr/local/share/${product}/pkg/repos"
+	_debug_file "${pkg_repo_conf_path}"
+	_debug_file "/usr/local/share/${product}/pkg/repos/${product}-repo.conf"
+	_debug_file "/usr/local/share/${product}/pkg/repos/${product}-repo-previous.conf"
 }
 
 export LANG=C
@@ -1755,7 +1865,8 @@ while getopts 46b:cdfi:hp:l:nr:RuUy opt; do
 		c)
 			action="check"
 			;;
-		d)
+	d)
+			debug_enabled=1
 			stdout=''
 			;;
 		f)
@@ -1827,6 +1938,11 @@ elif [ -n "${force_ipv6}" ]; then
 	export IP_VERSION="6"
 fi
 
+if [ "${DEBUG_DEFAULT}" = "1" ]; then
+	debug_enabled=1
+	stdout=''
+fi
+
 # Flags used to determine if all packages must be reinstalled
 pkg_set_version="/usr/local/share/${product}/next_pkg_set_version"
 running_pkg_set_version="/usr/local/share/${product}/running_pkg_set_version"
@@ -1838,8 +1954,10 @@ if [ ! -f ${running_pkg_set_version} ]; then
 fi
 
 # Force debug if /cf/conf/upgrade_debug is present
-[ -f "/cf/conf/upgrade_debug" ] \
-    && stdout=''
+if [ -f "/cf/conf/upgrade_debug" ]; then
+	debug_enabled=1
+	stdout=''
+fi
 
 # Set default action when no parameter is set
 : ${action:="upgrade"}
@@ -1868,9 +1986,7 @@ if [ -n "${booting}" ]; then
 	export REPO_AUTOUPDATE=false
 fi
 
-if [ "${action}" != "upgrade" -a -f "${logfile}" ]; then
-	rm -f ${logfile}
-fi
+# Preserve existing logfile; do not delete
 
 progress_file=${logfile%.*}.json
 

--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -18,6 +18,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+DEBUG_DEFAULT=0
+
 usage() {
 	me=$(basename $0)
 	cat << EOD >&2
@@ -57,6 +59,44 @@ _echo() {
 	echo ${_n} "${@}" | tee -a ${logfile}
 }
 
+_debug() {
+	if [ -z "${debug_enabled}" ]; then
+		return 0
+	fi
+
+	local _ts
+	_ts=$(date "+%Y-%m-%d %H:%M:%S")
+	_echo "DEBUG ${_ts} ${*}"
+}
+
+_debug_file() {
+	if [ -z "${debug_enabled}" ]; then
+		return 0
+	fi
+
+	local _file="${1}"
+	local _ts
+	_ts=$(date "+%Y-%m-%d %H:%M:%S")
+
+	if [ -z "${_file}" ]; then
+		_echo "DEBUG ${_ts} file=(empty)"
+		return 0
+	fi
+
+	if [ ! -f "${_file}" ]; then
+		_echo "DEBUG ${_ts} file=${_file} (not found)"
+		return 0
+	fi
+
+	_echo "DEBUG ${_ts} file=${_file} (begin)"
+	while IFS= read -r _line; do
+		_ts=$(date "+%Y-%m-%d %H:%M:%S")
+		_echo "DEBUG ${_ts} file=${_file}: ${_line}"
+	done < "${_file}"
+	_ts=$(date "+%Y-%m-%d %H:%M:%S")
+	_echo "DEBUG ${_ts} file=${_file} (end)"
+}
+
 _exec() {
 	local _cmd="${1}"
 	local _msg="${2}"
@@ -73,6 +113,8 @@ _exec() {
 	if [ "${_mute}" != "mute" ]; then
 		_stdout=''
 	fi
+
+	_debug "exec cmd='${_cmd}' msg='${_msg}' mute='${_mute}'"
 
 	[ -n "${_msg}" ] \
 	    && _echo -n ">>> ${_msg}... "
@@ -100,10 +142,12 @@ _exec() {
 	if [ ${_result} -eq 0 -o -n "${_ignore_result}" ]; then
 		[ -n "${_stdout}" -a -n "${_msg}" ] \
 		    && _echo "done."
+		_debug "exec result=success code=${_result}"
 		return 0
 	else
 		[ -n "${_stdout}" -a -n "${_msg}" ] \
 		    && _echo "failed."
+		_debug "exec result=failure code=${_result}"
 		[ -n "${_do_not_exit}" ] \
 		    && return 1 \
 		    || _exit 1
@@ -307,6 +351,12 @@ abi_setup() {
 	ABI="${_repo_abi}"
 	ALTABI="${_repo_altabi}"
 
+	_debug "abi_setup freebsd_version=${_freebsd_version} arch=${arch} CUR_ABI=${CUR_ABI} CUR_ALTABI=${CUR_ALTABI}"
+	_debug "abi_setup repo_conf=${_pkg_repo_conf} repo_target=${_repo_abi_file} ABI=${ABI} ALTABI=${ALTABI}"
+	_debug "abi_setup repo_dir=/usr/local/share/${product}/pkg/repos"
+	_debug_file "/usr/local/share/${product}/pkg/repos/${product}-repo.conf"
+	_debug_file "/usr/local/share/${product}/pkg/repos/${product}-repo-previous.conf"
+
 	AUTH_CA="/etc/ssl/netgate-ca.pem"
 	AUTH_CERT="/etc/ssl/pfSense-repo-custom.cert"
 	AUTH_KEY="/etc/ssl/pfSense-repo-custom.key"
@@ -344,7 +394,8 @@ EOF
 		NEW_MAJOR=1
 	fi
 
-	if [ -n "${NEW_MAJOR}" -a "${action}" != "upgrade" ]; then
+	if [ -n "${NEW_MAJOR}" -a "${action}" != "upgrade" -a \
+	    "${action}" != "check" ]; then
 		ABI="${CUR_ABI}"
 		ALTABI="${CUR_ALTABI}"
 	else
@@ -355,6 +406,9 @@ EOF
 	OSVERSION=$(sysctl -n kern.osreldate)
 	echo "ABI=${ABI}" > /usr/local/etc/pkg.conf
 	echo "OSVERSION=${OSVERSION}" >> /usr/local/etc/pkg.conf
+
+	_debug "abi_setup pkg_abi=${_pkg_abi} reinstall_pkg=${reinstall_pkg:-0} NEW_MAJOR=${NEW_MAJOR:-0} OSVERSION=${OSVERSION} IGNORE_OSVERSION=${IGNORE_OSVERSION:-}"
+	_debug_file "/usr/local/etc/pkg.conf"
 
 	export CUR_ABI CUR_ALTABI ABI NEW_MAJOR
 }
@@ -378,6 +432,7 @@ get_pkg_repo_url() {
 	if [ -n "${_srv}" ]; then
 		local _n=$(host -t SRV _https._tcp.${_host} 2>/dev/null | wc -l)
 		if [ ${_n} -eq 0 ]; then
+			_debug "get_pkg_repo_url srv lookup failed host=${_host}"
 			return 1
 		fi
 
@@ -388,6 +443,7 @@ get_pkg_repo_url() {
 		_url=$(echo "${_url}" | sed "s,${_host},${_real_host},")
 	fi
 
+	_debug "get_pkg_repo_url url=${_url}"
 	echo "${_url}"
 }
 
@@ -402,6 +458,7 @@ pkg_update() {
 	    && _force=" -f"
 
 	if [ -z "${_force}" -a -n "${dont_update}" ]; then
+		_debug "pkg_update skipping due to dont_update"
 		return 0
 	fi
 
@@ -410,6 +467,8 @@ pkg_update() {
 
 	/usr/local/bin/php -r 'require_once("pkg-utils.inc");update_repos();'
 	abi_setup
+
+	_debug "pkg_update force='${_force}' mute='${_mute}' do_not_bootstrap='${_do_not_bootstrap}'"
 
 	_exec "pkg-static update${_force}" "Updating repositories metadata" \
 	    ${_mute} "" do_not_exit
@@ -423,6 +482,7 @@ pkg_update() {
 		# force to bootstrap pkg on local system
 		local _ver=$(_pkg query %v pkg)
 		local _cmp=$(_pkg version -t ${_ver} "1.13")
+		_debug "pkg_update bootstrap check pkg_version=${_ver} compare=${_cmp}"
 		if [ "${_cmp}" != "<" ]; then
 			return
 		fi
@@ -440,12 +500,26 @@ pkg_update() {
 
 		local _url=$(get_pkg_repo_url)
 		if [ $? -ne 0 ]; then
+			_debug "pkg_update failed to get repo url"
 			return
+		fi
+		_debug "pkg_update repo_url=${_url}"
+
+		if [ -n "${debug_enabled}" ]; then
+			local _meta_file
+			_meta_file=$(mktemp /tmp/pkg.meta.conf.XXXXXX) || _meta_file=""
+			if [ -n "${_meta_file}" ]; then
+				${_fetch_env} fetch ${_fetch_args} -o "${_meta_file}" \
+				    ${_url}/meta.conf >/dev/null 2>&1
+				_debug_file "${_meta_file}"
+				rm -f "${_meta_file}"
+			fi
 		fi
 
 		${_fetch_env} fetch ${_fetch_args} -o /dev/null \
 		    ${_url}/meta.conf >/dev/null 2>&1
 		if [ $? -eq 0 ]; then
+			_debug "pkg_update meta.conf detected, bootstrapping pkg"
 			_exec "${_pkg_binary} bootstrap -f" \
 			    "Bootstrap pkg due to meta version change"
 			pkg_update "${force}" "${_mute}" _do_not_bootstrap
@@ -456,6 +530,7 @@ pkg_update() {
 pkg_upgrade_repo() {
 	if [ -n "${reinstall_pkg}" ] \
 	    || [ -z "${NEW_MAJOR}" -a "$(compare_pkg_version pkg)" = "<" ]; then
+		_debug "pkg_upgrade_repo upgrading pkg reinstall_pkg=${reinstall_pkg:-0} NEW_MAJOR=${NEW_MAJOR:-0}"
 		pkg_unlock pkg
 		_exec "pkg-static upgrade${dont_update} pkg" "Upgrading pkg" \
 		    mute
@@ -466,6 +541,7 @@ pkg_upgrade_repo() {
 	local _repo_pkg="${product}-repo"
 
 	if ! is_pkg_installed ${_repo_pkg}; then
+		_debug "pkg_upgrade_repo installing ${_repo_pkg}"
 		_exec "pkg-static install${dont_update} ${_repo_pkg}" \
 		    "Installing ${_repo_pkg}" mute "" do_not_exit
 		if [ $? -ne 0 ]; then
@@ -494,6 +570,7 @@ pkg_upgrade_repo() {
 
 	cp /usr/local/etc/pkg/repos/${product}.conf /tmp/${product}.conf.copy
 	if !(is_ce && repo_is_plus_upgrade) ; then
+		_debug "pkg_upgrade_repo upgrading ${_repo_pkg} force='${_force}'"
 		_exec "pkg-static upgrade${dont_update}${_force} ${_repo_pkg}" \
 		    "Upgrading ${_repo_pkg}" mute
 	fi
@@ -519,6 +596,7 @@ upgrade_available() {
 	    | sed -e '/^$/d; /is locked and may not be modified/d' \
 	    | wc -l)
 
+	_debug "upgrade_available packages='${*}' lines=${_lines}"
 	test ${_lines} -gt 0
 	return $?
 }
@@ -666,9 +744,7 @@ pkg_upgrade() {
 	need_reboot=1
 	# First upgrade stage
 	if [ -z "${next_stage}" ]; then
-		if [ -f "${logfile}" ]; then
-			rm -f ${logfile}
-		fi
+		# Preserve existing logfile; do not delete
 
 		pkg_update force
 
@@ -1182,6 +1258,8 @@ compare_pkg_version_repo() {
 		_exit 1
 	fi
 
+	_debug "compare_pkg_version_repo pkg=${_pkg_name} local=${_lver} remote=${_rver} abi=${_abi}"
+	_debug "compare_pkg_version_repo rquery_cmd=env -u ABI -u ALTABI -u OSVERSION pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_db} -o REPO_CACHEDIR=${_repo_cache} -o ABI=${_abi} rquery -U %v ${_pkg_name}"
 	local _version=$(_pkg version -t ${_lver} ${_rver})
 
 	if [ $? -ne 0 ]; then
@@ -1228,14 +1306,19 @@ check_upgrade_repo_override() {
 	done
 
 	if [ -z "${_best_conf}" ]; then
+		_debug "check_upgrade_repo_override no repo override conf found"
 		return 1
 	fi
 
 	if [ -n "${_current_major}" -a "${_best_major}" -le "${_current_major}" ]; then
+		_debug "check_upgrade_repo_override best_major=${_best_major} current_major=${_current_major} skipping"
 		return 1
 	fi
 
 	get_repo_abi_values "${_best_conf}"
+
+	_debug "check_upgrade_repo_override using best_conf=${_best_conf} REPO_ABI=${REPO_ABI} REPO_ALTABI=${REPO_ALTABI}"
+	_debug_file "${_best_conf}"
 
 	local _repo_dir=$(prepare_repo_override_dir "${_best_conf}")
 	if [ -z "${_repo_dir}" ]; then
@@ -1274,6 +1357,7 @@ check_upgrade_repo_override() {
 
 		[ -z "${_new_version}" ] && continue
 
+		_debug "check_upgrade_repo_override package=${_package} new_version=${_new_version}"
 		[ -z "${_mute}" ] \
 		    && _echo \
 		    "${_new_version} version of ${product} is available"
@@ -1300,10 +1384,14 @@ check_upgrade_current_repo_override() {
 	fi
 
 	if [ -z "${_current_repo_target}" ]; then
+		_debug "check_upgrade_current_repo_override missing repo target"
 		return 1
 	fi
 
 	get_repo_abi_values "${_current_repo_target}"
+
+	_debug "check_upgrade_current_repo_override repo_conf=${_current_repo_target} REPO_ABI=${REPO_ABI} REPO_ALTABI=${REPO_ALTABI}"
+	_debug_file "${_current_repo_target}"
 
 	local _repo_dir=$(prepare_repo_override_dir "${_current_repo_target}")
 	if [ -z "${_repo_dir}" ]; then
@@ -1342,6 +1430,7 @@ check_upgrade_current_repo_override() {
 
 		[ -z "${_new_version}" ] && continue
 
+		_debug "check_upgrade_current_repo_override package=${_package} new_version=${_new_version}"
 		[ -z "${_mute}" ] \
 		    && _echo \
 		    "${_new_version} version of ${product} is available"
@@ -1361,9 +1450,11 @@ check_upgrade() {
 	    "%n ~ ${product}-kernel-* || %n ~ ${product}-base*" %n 2>/dev/null)
 	local _repo_behind=""
 
+	_debug "check_upgrade meta_pkg=${_meta_pkg} core_pkgs='${_core_pkgs}' NEW_MAJOR=${NEW_MAJOR:-0} action=${action}"
 	check_upgrade_current_repo_override "${_mute}" "${_skip_update}" \
 	    "${_meta_pkg}" "${_core_pkgs}"
 	if [ $? -eq 2 ]; then
+		_debug "check_upgrade current repo override has upgrade"
 		return 2
 	fi
 
@@ -1375,12 +1466,14 @@ check_upgrade() {
 		check_upgrade_current_repo_override "${_mute}" "${_skip_update}" \
 		    "${_meta_pkg}" "${_core_pkgs}"
 		if [ $? -eq 2 ]; then
+			_debug "check_upgrade current repo override has upgrade after bootstrap"
 			return 2
 		fi
 
 		check_upgrade_repo_override "${_mute}" "${_skip_update}" \
 		    "${_meta_pkg}" "${_core_pkgs}"
 		if [ $? -eq 2 ]; then
+			_debug "check_upgrade repo override has upgrade"
 			return 2
 		fi
 
@@ -1390,6 +1483,7 @@ check_upgrade() {
 	fi
 
 	if [ -n "${NEW_MAJOR}" -a "${action}" != "upgrade" ]; then
+		_debug "check_upgrade NEW_MAJOR set and action not upgrade; returning up to date"
 		[ -z "${_mute}" ] \
 		    && _echo "Your system is up to date"
 		return 0
@@ -1419,15 +1513,18 @@ check_upgrade() {
 		_version_compare=$(compare_pkg_version ${_package})
 		case "${_version_compare}" in
 			=)
+				_debug "check_upgrade package=${_package} local=remote"
 				continue
 				;;
 			'>')
+				_debug "check_upgrade package=${_package} local newer"
 				_repo_behind=1
 				continue
 				;;
 		esac
 
 		local _new_version=$(_pkg rquery -U %v ${_package})
+		_debug "check_upgrade package=${_package} new_version=${_new_version}"
 		[ -z "${_mute}" ] \
 		    && _echo \
 		    "${_new_version} version of ${product} is available"
@@ -1437,6 +1534,7 @@ check_upgrade() {
 	check_upgrade_repo_override "${_mute}" "${_skip_update}" \
 	    "${_meta_pkg}" "${_core_pkgs}"
 	if [ $? -eq 2 ]; then
+		_debug "check_upgrade repo override has upgrade"
 		return 2
 	fi
 
@@ -1493,6 +1591,8 @@ compare_pkg_version() {
 		_exit 1
 	fi
 
+	_debug "compare_pkg_version pkg=${_pkg_name} local=${_lver} remote=${_rver}"
+	_debug "compare_pkg_version rquery_cmd=pkg-static rquery -U %v ${_pkg_name}"
 	local _version=$(_pkg version -t ${_lver} ${_rver})
 
 	if [ $? -ne 0 ]; then
@@ -1645,6 +1745,12 @@ validate_repo_conf() {
 			ln -sf ${pkg_repo_conf_path} ${pkg_repo_conf}
 		fi
 	fi
+
+	_debug "validate_repo_conf repo_conf_path=${pkg_repo_conf_path} repo_conf=${pkg_repo_conf}"
+	_debug "validate_repo_conf repo_dir=/usr/local/share/${product}/pkg/repos"
+	_debug_file "${pkg_repo_conf_path}"
+	_debug_file "/usr/local/share/${product}/pkg/repos/${product}-repo.conf"
+	_debug_file "/usr/local/share/${product}/pkg/repos/${product}-repo-previous.conf"
 }
 
 export LANG=C
@@ -1755,7 +1861,8 @@ while getopts 46b:cdfi:hp:l:nr:RuUy opt; do
 		c)
 			action="check"
 			;;
-		d)
+	d)
+			debug_enabled=1
 			stdout=''
 			;;
 		f)
@@ -1827,6 +1934,11 @@ elif [ -n "${force_ipv6}" ]; then
 	export IP_VERSION="6"
 fi
 
+if [ "${DEBUG_DEFAULT}" = "1" ]; then
+	debug_enabled=1
+	stdout=''
+fi
+
 # Flags used to determine if all packages must be reinstalled
 pkg_set_version="/usr/local/share/${product}/next_pkg_set_version"
 running_pkg_set_version="/usr/local/share/${product}/running_pkg_set_version"
@@ -1838,8 +1950,10 @@ if [ ! -f ${running_pkg_set_version} ]; then
 fi
 
 # Force debug if /cf/conf/upgrade_debug is present
-[ -f "/cf/conf/upgrade_debug" ] \
-    && stdout=''
+if [ -f "/cf/conf/upgrade_debug" ]; then
+	debug_enabled=1
+	stdout=''
+fi
 
 # Set default action when no parameter is set
 : ${action:="upgrade"}
@@ -1868,9 +1982,7 @@ if [ -n "${booting}" ]; then
 	export REPO_AUTOUPDATE=false
 fi
 
-if [ "${action}" != "upgrade" -a -f "${logfile}" ]; then
-	rm -f ${logfile}
-fi
+# Preserve existing logfile; do not delete
 
 progress_file=${logfile%.*}.json
 

--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -18,6 +18,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+DEBUG_DEFAULT=0
+
 usage() {
 	me=$(basename $0)
 	cat << EOD >&2
@@ -57,6 +59,16 @@ _echo() {
 	echo ${_n} "${@}" | tee -a ${logfile}
 }
 
+_debug() {
+	if [ -z "${debug_enabled}" ]; then
+		return 0
+	fi
+
+	local _ts
+	_ts=$(date "+%Y-%m-%d %H:%M:%S")
+	_echo "DEBUG ${_ts} ${*}"
+}
+
 _exec() {
 	local _cmd="${1}"
 	local _msg="${2}"
@@ -73,6 +85,8 @@ _exec() {
 	if [ "${_mute}" != "mute" ]; then
 		_stdout=''
 	fi
+
+	_debug "exec cmd='${_cmd}' msg='${_msg}' mute='${_mute}'"
 
 	[ -n "${_msg}" ] \
 	    && _echo -n ">>> ${_msg}... "
@@ -100,10 +114,12 @@ _exec() {
 	if [ ${_result} -eq 0 -o -n "${_ignore_result}" ]; then
 		[ -n "${_stdout}" -a -n "${_msg}" ] \
 		    && _echo "done."
+		_debug "exec result=success code=${_result}"
 		return 0
 	else
 		[ -n "${_stdout}" -a -n "${_msg}" ] \
 		    && _echo "failed."
+		_debug "exec result=failure code=${_result}"
 		[ -n "${_do_not_exit}" ] \
 		    && return 1 \
 		    || _exit 1
@@ -307,6 +323,9 @@ abi_setup() {
 	ABI="${_repo_abi}"
 	ALTABI="${_repo_altabi}"
 
+	_debug "abi_setup freebsd_version=${_freebsd_version} arch=${arch} CUR_ABI=${CUR_ABI} CUR_ALTABI=${CUR_ALTABI}"
+	_debug "abi_setup repo_conf=${_pkg_repo_conf} repo_target=${_repo_abi_file} ABI=${ABI} ALTABI=${ALTABI}"
+
 	AUTH_CA="/etc/ssl/netgate-ca.pem"
 	AUTH_CERT="/etc/ssl/pfSense-repo-custom.cert"
 	AUTH_KEY="/etc/ssl/pfSense-repo-custom.key"
@@ -356,6 +375,8 @@ EOF
 	echo "ABI=${ABI}" > /usr/local/etc/pkg.conf
 	echo "OSVERSION=${OSVERSION}" >> /usr/local/etc/pkg.conf
 
+	_debug "abi_setup pkg_abi=${_pkg_abi} reinstall_pkg=${reinstall_pkg:-0} NEW_MAJOR=${NEW_MAJOR:-0} OSVERSION=${OSVERSION}"
+
 	export CUR_ABI CUR_ALTABI ABI NEW_MAJOR
 }
 
@@ -378,6 +399,7 @@ get_pkg_repo_url() {
 	if [ -n "${_srv}" ]; then
 		local _n=$(host -t SRV _https._tcp.${_host} 2>/dev/null | wc -l)
 		if [ ${_n} -eq 0 ]; then
+			_debug "get_pkg_repo_url srv lookup failed host=${_host}"
 			return 1
 		fi
 
@@ -388,6 +410,7 @@ get_pkg_repo_url() {
 		_url=$(echo "${_url}" | sed "s,${_host},${_real_host},")
 	fi
 
+	_debug "get_pkg_repo_url url=${_url}"
 	echo "${_url}"
 }
 
@@ -402,6 +425,7 @@ pkg_update() {
 	    && _force=" -f"
 
 	if [ -z "${_force}" -a -n "${dont_update}" ]; then
+		_debug "pkg_update skipping due to dont_update"
 		return 0
 	fi
 
@@ -410,6 +434,8 @@ pkg_update() {
 
 	/usr/local/bin/php -r 'require_once("pkg-utils.inc");update_repos();'
 	abi_setup
+
+	_debug "pkg_update force='${_force}' mute='${_mute}' do_not_bootstrap='${_do_not_bootstrap}'"
 
 	_exec "pkg-static update${_force}" "Updating repositories metadata" \
 	    ${_mute} "" do_not_exit
@@ -423,6 +449,7 @@ pkg_update() {
 		# force to bootstrap pkg on local system
 		local _ver=$(_pkg query %v pkg)
 		local _cmp=$(_pkg version -t ${_ver} "1.13")
+		_debug "pkg_update bootstrap check pkg_version=${_ver} compare=${_cmp}"
 		if [ "${_cmp}" != "<" ]; then
 			return
 		fi
@@ -440,12 +467,14 @@ pkg_update() {
 
 		local _url=$(get_pkg_repo_url)
 		if [ $? -ne 0 ]; then
+			_debug "pkg_update failed to get repo url"
 			return
 		fi
 
 		${_fetch_env} fetch ${_fetch_args} -o /dev/null \
 		    ${_url}/meta.conf >/dev/null 2>&1
 		if [ $? -eq 0 ]; then
+			_debug "pkg_update meta.conf detected, bootstrapping pkg"
 			_exec "${_pkg_binary} bootstrap -f" \
 			    "Bootstrap pkg due to meta version change"
 			pkg_update "${force}" "${_mute}" _do_not_bootstrap
@@ -456,6 +485,7 @@ pkg_update() {
 pkg_upgrade_repo() {
 	if [ -n "${reinstall_pkg}" ] \
 	    || [ -z "${NEW_MAJOR}" -a "$(compare_pkg_version pkg)" = "<" ]; then
+		_debug "pkg_upgrade_repo upgrading pkg reinstall_pkg=${reinstall_pkg:-0} NEW_MAJOR=${NEW_MAJOR:-0}"
 		pkg_unlock pkg
 		_exec "pkg-static upgrade${dont_update} pkg" "Upgrading pkg" \
 		    mute
@@ -466,6 +496,7 @@ pkg_upgrade_repo() {
 	local _repo_pkg="${product}-repo"
 
 	if ! is_pkg_installed ${_repo_pkg}; then
+		_debug "pkg_upgrade_repo installing ${_repo_pkg}"
 		_exec "pkg-static install${dont_update} ${_repo_pkg}" \
 		    "Installing ${_repo_pkg}" mute "" do_not_exit
 		if [ $? -ne 0 ]; then
@@ -494,6 +525,7 @@ pkg_upgrade_repo() {
 
 	cp /usr/local/etc/pkg/repos/${product}.conf /tmp/${product}.conf.copy
 	if !(is_ce && repo_is_plus_upgrade) ; then
+		_debug "pkg_upgrade_repo upgrading ${_repo_pkg} force='${_force}'"
 		_exec "pkg-static upgrade${dont_update}${_force} ${_repo_pkg}" \
 		    "Upgrading ${_repo_pkg}" mute
 	fi
@@ -519,6 +551,7 @@ upgrade_available() {
 	    | sed -e '/^$/d; /is locked and may not be modified/d' \
 	    | wc -l)
 
+	_debug "upgrade_available packages='${*}' lines=${_lines}"
 	test ${_lines} -gt 0
 	return $?
 }
@@ -1182,6 +1215,7 @@ compare_pkg_version_repo() {
 		_exit 1
 	fi
 
+	_debug "compare_pkg_version_repo pkg=${_pkg_name} local=${_lver} remote=${_rver} abi=${_abi}"
 	local _version=$(_pkg version -t ${_lver} ${_rver})
 
 	if [ $? -ne 0 ]; then
@@ -1228,14 +1262,18 @@ check_upgrade_repo_override() {
 	done
 
 	if [ -z "${_best_conf}" ]; then
+		_debug "check_upgrade_repo_override no repo override conf found"
 		return 1
 	fi
 
 	if [ -n "${_current_major}" -a "${_best_major}" -le "${_current_major}" ]; then
+		_debug "check_upgrade_repo_override best_major=${_best_major} current_major=${_current_major} skipping"
 		return 1
 	fi
 
 	get_repo_abi_values "${_best_conf}"
+
+	_debug "check_upgrade_repo_override using best_conf=${_best_conf} REPO_ABI=${REPO_ABI} REPO_ALTABI=${REPO_ALTABI}"
 
 	local _repo_dir=$(prepare_repo_override_dir "${_best_conf}")
 	if [ -z "${_repo_dir}" ]; then
@@ -1274,6 +1312,7 @@ check_upgrade_repo_override() {
 
 		[ -z "${_new_version}" ] && continue
 
+		_debug "check_upgrade_repo_override package=${_package} new_version=${_new_version}"
 		[ -z "${_mute}" ] \
 		    && _echo \
 		    "${_new_version} version of ${product} is available"
@@ -1300,10 +1339,13 @@ check_upgrade_current_repo_override() {
 	fi
 
 	if [ -z "${_current_repo_target}" ]; then
+		_debug "check_upgrade_current_repo_override missing repo target"
 		return 1
 	fi
 
 	get_repo_abi_values "${_current_repo_target}"
+
+	_debug "check_upgrade_current_repo_override repo_conf=${_current_repo_target} REPO_ABI=${REPO_ABI} REPO_ALTABI=${REPO_ALTABI}"
 
 	local _repo_dir=$(prepare_repo_override_dir "${_current_repo_target}")
 	if [ -z "${_repo_dir}" ]; then
@@ -1342,6 +1384,7 @@ check_upgrade_current_repo_override() {
 
 		[ -z "${_new_version}" ] && continue
 
+		_debug "check_upgrade_current_repo_override package=${_package} new_version=${_new_version}"
 		[ -z "${_mute}" ] \
 		    && _echo \
 		    "${_new_version} version of ${product} is available"
@@ -1361,9 +1404,11 @@ check_upgrade() {
 	    "%n ~ ${product}-kernel-* || %n ~ ${product}-base*" %n 2>/dev/null)
 	local _repo_behind=""
 
+	_debug "check_upgrade meta_pkg=${_meta_pkg} core_pkgs='${_core_pkgs}' NEW_MAJOR=${NEW_MAJOR:-0} action=${action}"
 	check_upgrade_current_repo_override "${_mute}" "${_skip_update}" \
 	    "${_meta_pkg}" "${_core_pkgs}"
 	if [ $? -eq 2 ]; then
+		_debug "check_upgrade current repo override has upgrade"
 		return 2
 	fi
 
@@ -1375,12 +1420,14 @@ check_upgrade() {
 		check_upgrade_current_repo_override "${_mute}" "${_skip_update}" \
 		    "${_meta_pkg}" "${_core_pkgs}"
 		if [ $? -eq 2 ]; then
+			_debug "check_upgrade current repo override has upgrade after bootstrap"
 			return 2
 		fi
 
 		check_upgrade_repo_override "${_mute}" "${_skip_update}" \
 		    "${_meta_pkg}" "${_core_pkgs}"
 		if [ $? -eq 2 ]; then
+			_debug "check_upgrade repo override has upgrade"
 			return 2
 		fi
 
@@ -1390,6 +1437,7 @@ check_upgrade() {
 	fi
 
 	if [ -n "${NEW_MAJOR}" -a "${action}" != "upgrade" ]; then
+		_debug "check_upgrade NEW_MAJOR set and action not upgrade; returning up to date"
 		[ -z "${_mute}" ] \
 		    && _echo "Your system is up to date"
 		return 0
@@ -1419,15 +1467,18 @@ check_upgrade() {
 		_version_compare=$(compare_pkg_version ${_package})
 		case "${_version_compare}" in
 			=)
+				_debug "check_upgrade package=${_package} local=remote"
 				continue
 				;;
 			'>')
+				_debug "check_upgrade package=${_package} local newer"
 				_repo_behind=1
 				continue
 				;;
 		esac
 
 		local _new_version=$(_pkg rquery -U %v ${_package})
+		_debug "check_upgrade package=${_package} new_version=${_new_version}"
 		[ -z "${_mute}" ] \
 		    && _echo \
 		    "${_new_version} version of ${product} is available"
@@ -1437,6 +1488,7 @@ check_upgrade() {
 	check_upgrade_repo_override "${_mute}" "${_skip_update}" \
 	    "${_meta_pkg}" "${_core_pkgs}"
 	if [ $? -eq 2 ]; then
+		_debug "check_upgrade repo override has upgrade"
 		return 2
 	fi
 
@@ -1493,6 +1545,7 @@ compare_pkg_version() {
 		_exit 1
 	fi
 
+	_debug "compare_pkg_version pkg=${_pkg_name} local=${_lver} remote=${_rver}"
 	local _version=$(_pkg version -t ${_lver} ${_rver})
 
 	if [ $? -ne 0 ]; then
@@ -1645,6 +1698,8 @@ validate_repo_conf() {
 			ln -sf ${pkg_repo_conf_path} ${pkg_repo_conf}
 		fi
 	fi
+
+	_debug "validate_repo_conf repo_conf_path=${pkg_repo_conf_path} repo_conf=${pkg_repo_conf}"
 }
 
 export LANG=C
@@ -1755,7 +1810,8 @@ while getopts 46b:cdfi:hp:l:nr:RuUy opt; do
 		c)
 			action="check"
 			;;
-		d)
+	d)
+			debug_enabled=1
 			stdout=''
 			;;
 		f)
@@ -1827,6 +1883,11 @@ elif [ -n "${force_ipv6}" ]; then
 	export IP_VERSION="6"
 fi
 
+if [ "${DEBUG_DEFAULT}" = "1" ]; then
+	debug_enabled=1
+	stdout=''
+fi
+
 # Flags used to determine if all packages must be reinstalled
 pkg_set_version="/usr/local/share/${product}/next_pkg_set_version"
 running_pkg_set_version="/usr/local/share/${product}/running_pkg_set_version"
@@ -1838,8 +1899,10 @@ if [ ! -f ${running_pkg_set_version} ]; then
 fi
 
 # Force debug if /cf/conf/upgrade_debug is present
-[ -f "/cf/conf/upgrade_debug" ] \
-    && stdout=''
+if [ -f "/cf/conf/upgrade_debug" ]; then
+	debug_enabled=1
+	stdout=''
+fi
 
 # Set default action when no parameter is set
 : ${action:="upgrade"}

--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -1240,13 +1240,13 @@ compare_pkg_version_repo() {
 	local _repo_db="${_repo_dir}/db"
 	mkdir -p "${_repo_cache}" "${_repo_db}"
 
-	local _rver=$(env -u ABI -u ALTABI -u OSVERSION \
+	local _rver=$(env IGNORE_OSVERSION=yes -u ABI -u ALTABI -u OSVERSION \
 	    pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_db} \
 	    -o REPO_CACHEDIR=${_repo_cache} -o ABI=${_abi} \
 	    rquery -U %v ${_pkg_name})
 
 	if [ -z "${_rver}" ]; then
-		_rver=$(env -u ABI -u ALTABI -u OSVERSION \
+		_rver=$(env IGNORE_OSVERSION=yes -u ABI -u ALTABI -u OSVERSION \
 		    pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_db} \
 		    -o REPO_CACHEDIR=${_repo_cache} -o ABI=${_abi} \
 		    rquery %v ${_pkg_name})
@@ -1259,7 +1259,7 @@ compare_pkg_version_repo() {
 	fi
 
 	_debug "compare_pkg_version_repo pkg=${_pkg_name} local=${_lver} remote=${_rver} abi=${_abi}"
-	_debug "compare_pkg_version_repo rquery_cmd=env -u ABI -u ALTABI -u OSVERSION pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_db} -o REPO_CACHEDIR=${_repo_cache} -o ABI=${_abi} rquery -U %v ${_pkg_name}"
+	_debug "compare_pkg_version_repo rquery_cmd=env IGNORE_OSVERSION=yes -u ABI -u ALTABI -u OSVERSION pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_db} -o REPO_CACHEDIR=${_repo_cache} -o ABI=${_abi} rquery -U %v ${_pkg_name}"
 	local _version=$(_pkg version -t ${_lver} ${_rver})
 
 	if [ $? -ne 0 ]; then
@@ -1326,7 +1326,7 @@ check_upgrade_repo_override() {
 	fi
 
 	if [ -z "${_skip_update}" -a -z "${dont_update}" ]; then
-		env -u ABI -u ALTABI -u OSVERSION \
+		env IGNORE_OSVERSION=yes -u ABI -u ALTABI -u OSVERSION \
 		    pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_dir}/db \
 		    -o REPO_CACHEDIR=${_repo_dir}/cache -o ABI=${REPO_ABI} \
 		    update -f >/dev/null 2>&1
@@ -1342,13 +1342,13 @@ check_upgrade_repo_override() {
 				;;
 		esac
 
-		local _new_version=$(env -u ABI -u ALTABI -u OSVERSION \
+		local _new_version=$(env IGNORE_OSVERSION=yes -u ABI -u ALTABI -u OSVERSION \
 		    pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_dir}/db \
 		    -o REPO_CACHEDIR=${_repo_dir}/cache -o ABI=${REPO_ABI} \
 		    rquery -U %v ${_package})
 
 		if [ -z "${_new_version}" ]; then
-			_new_version=$(env -u ABI -u ALTABI -u OSVERSION \
+			_new_version=$(env IGNORE_OSVERSION=yes -u ABI -u ALTABI -u OSVERSION \
 			    pkg-static -o REPOS_DIR=${_repo_dir} \
 			    -o PKG_DBDIR=${_repo_dir}/db \
 			    -o REPO_CACHEDIR=${_repo_dir}/cache -o ABI=${REPO_ABI} \
@@ -1399,7 +1399,7 @@ check_upgrade_current_repo_override() {
 	fi
 
 	if [ -z "${_skip_update}" -a -z "${dont_update}" ]; then
-		env -u ABI -u ALTABI -u OSVERSION \
+		env IGNORE_OSVERSION=yes -u ABI -u ALTABI -u OSVERSION \
 		    pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_dir}/db \
 		    -o REPO_CACHEDIR=${_repo_dir}/cache -o ABI=${REPO_ABI} \
 		    update -f >/dev/null 2>&1
@@ -1415,13 +1415,13 @@ check_upgrade_current_repo_override() {
 				;;
 		esac
 
-		local _new_version=$(env -u ABI -u ALTABI -u OSVERSION \
+		local _new_version=$(env IGNORE_OSVERSION=yes -u ABI -u ALTABI -u OSVERSION \
 		    pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_dir}/db \
 		    -o REPO_CACHEDIR=${_repo_dir}/cache -o ABI=${REPO_ABI} \
 		    rquery -U %v ${_package})
 
 		if [ -z "${_new_version}" ]; then
-			_new_version=$(env -u ABI -u ALTABI -u OSVERSION \
+			_new_version=$(env IGNORE_OSVERSION=yes -u ABI -u ALTABI -u OSVERSION \
 			    pkg-static -o REPOS_DIR=${_repo_dir} \
 			    -o PKG_DBDIR=${_repo_dir}/db \
 			    -o REPO_CACHEDIR=${_repo_dir}/cache -o ABI=${REPO_ABI} \

--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -1038,6 +1038,10 @@ pkg_upgrade() {
 				_exec "pkg-static install -f pkg" \
 				    "Reinstalling pkg due to ABI change"
 
+				# Refresh repository metadata with the new pkg binary
+				# before trying to upgrade core packages on stage 2.
+				pkg_update force
+
 				# Upgrade core packages
 				_exec "pkg-static upgrade -r ${product}-core" \
 				    "Upgrading necessary core packages"
@@ -1459,11 +1463,17 @@ check_upgrade() {
 	fi
 
 	if [ -n "${NEW_MAJOR}" -a "${action}" = "check" ]; then
-		_exec "pkg-static bootstrap -f" \
-		    "Bootstrapping pkg due to ABI change" mute \
-		    ignore_result do_not_exit
-		_debug "check_upgrade bootstrap complete, forcing repo metadata refresh"
-		pkg_update force mute _do_not_bootstrap
+		if [ -n "${PF_UPGRADE_CHECK_BOOTSTRAP}" ]; then
+			_debug "check_upgrade PF_UPGRADE_CHECK_BOOTSTRAP set, using legacy pkg bootstrap flow"
+			_exec "pkg-static bootstrap -f" \
+			    "Bootstrapping pkg due to ABI change" mute \
+			    ignore_result do_not_exit
+			_debug "check_upgrade bootstrap complete, forcing repo metadata refresh"
+			pkg_update force mute _do_not_bootstrap
+		else
+			_debug "check_upgrade skipping pkg bootstrap for NEW_MAJOR detection"
+			_debug "check_upgrade set PF_UPGRADE_CHECK_BOOTSTRAP=1 to enable legacy behavior"
+		fi
 
 		check_upgrade_current_repo_override "${_mute}" "${_skip_update}" \
 		    "${_meta_pkg}" "${_core_pkgs}"
@@ -2015,7 +2025,11 @@ else
 fi
 
 if [ "${action}" = "install" ]; then
-	pkg_upgrade_repo
+	if [ "${action_pkg}" = "${product}-upgrade" ]; then
+		_debug "install action for ${action_pkg}; skipping pkg_upgrade_repo to avoid premature pkg upgrade"
+	else
+		pkg_upgrade_repo
+	fi
 
 	new_php_pkg=$(_pkg rquery -U %dn $(get_meta_pkg_name) \
 	    | egrep '^php[0-9]{2}$')

--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -18,6 +18,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+DEBUG_DEFAULT=0
+
 usage() {
 	me=$(basename $0)
 	cat << EOD >&2
@@ -57,6 +59,42 @@ _echo() {
 	echo ${_n} "${@}" | tee -a ${logfile}
 }
 
+_debug() {
+	if [ -z "${debug_enabled}" ]; then
+		return 0
+	fi
+
+	local _ts
+	_ts=$(date "+%Y-%m-%d %H:%M:%S")
+	_echo "DEBUG ${_ts} ${*}"
+}
+
+_debug_file() {
+	if [ -z "${debug_enabled}" ]; then
+		return 0
+	fi
+
+	local _file="${1}"
+	local _ts
+	_ts=$(date "+%Y-%m-%d %H:%M:%S")
+
+	if [ -z "${_file}" ]; then
+		_echo "DEBUG ${_ts} file=(empty)"
+		return 0
+	fi
+
+	if [ ! -f "${_file}" ]; then
+		_echo "DEBUG ${_ts} file=${_file} (not found)"
+		return 0
+	fi
+
+	_echo "DEBUG ${_ts} file=${_file} (begin)"
+	while IFS= read -r _line; do
+		_echo "DEBUG ${_ts} file=${_file}: ${_line}"
+	done < "${_file}"
+	_echo "DEBUG ${_ts} file=${_file} (end)"
+}
+
 _exec() {
 	local _cmd="${1}"
 	local _msg="${2}"
@@ -73,6 +111,8 @@ _exec() {
 	if [ "${_mute}" != "mute" ]; then
 		_stdout=''
 	fi
+
+	_debug "exec cmd='${_cmd}' msg='${_msg}' mute='${_mute}'"
 
 	[ -n "${_msg}" ] \
 	    && _echo -n ">>> ${_msg}... "
@@ -100,10 +140,12 @@ _exec() {
 	if [ ${_result} -eq 0 -o -n "${_ignore_result}" ]; then
 		[ -n "${_stdout}" -a -n "${_msg}" ] \
 		    && _echo "done."
+		_debug "exec result=success code=${_result}"
 		return 0
 	else
 		[ -n "${_stdout}" -a -n "${_msg}" ] \
 		    && _echo "failed."
+		_debug "exec result=failure code=${_result}"
 		[ -n "${_do_not_exit}" ] \
 		    && return 1 \
 		    || _exit 1
@@ -307,6 +349,10 @@ abi_setup() {
 	ABI="${_repo_abi}"
 	ALTABI="${_repo_altabi}"
 
+	_debug "abi_setup freebsd_version=${_freebsd_version} arch=${arch} CUR_ABI=${CUR_ABI} CUR_ALTABI=${CUR_ALTABI}"
+	_debug "abi_setup repo_conf=${_pkg_repo_conf} repo_target=${_repo_abi_file} ABI=${ABI} ALTABI=${ALTABI}"
+	_debug "abi_setup repo_dir=/usr/local/share/${product}/pkg/repos"
+
 	AUTH_CA="/etc/ssl/netgate-ca.pem"
 	AUTH_CERT="/etc/ssl/pfSense-repo-custom.cert"
 	AUTH_KEY="/etc/ssl/pfSense-repo-custom.key"
@@ -356,6 +402,9 @@ EOF
 	echo "ABI=${ABI}" > /usr/local/etc/pkg.conf
 	echo "OSVERSION=${OSVERSION}" >> /usr/local/etc/pkg.conf
 
+	_debug "abi_setup pkg_abi=${_pkg_abi} reinstall_pkg=${reinstall_pkg:-0} NEW_MAJOR=${NEW_MAJOR:-0} OSVERSION=${OSVERSION}"
+	_debug_file "/usr/local/etc/pkg.conf"
+
 	export CUR_ABI CUR_ALTABI ABI NEW_MAJOR
 }
 
@@ -378,6 +427,7 @@ get_pkg_repo_url() {
 	if [ -n "${_srv}" ]; then
 		local _n=$(host -t SRV _https._tcp.${_host} 2>/dev/null | wc -l)
 		if [ ${_n} -eq 0 ]; then
+			_debug "get_pkg_repo_url srv lookup failed host=${_host}"
 			return 1
 		fi
 
@@ -388,6 +438,7 @@ get_pkg_repo_url() {
 		_url=$(echo "${_url}" | sed "s,${_host},${_real_host},")
 	fi
 
+	_debug "get_pkg_repo_url url=${_url}"
 	echo "${_url}"
 }
 
@@ -402,6 +453,7 @@ pkg_update() {
 	    && _force=" -f"
 
 	if [ -z "${_force}" -a -n "${dont_update}" ]; then
+		_debug "pkg_update skipping due to dont_update"
 		return 0
 	fi
 
@@ -410,6 +462,8 @@ pkg_update() {
 
 	/usr/local/bin/php -r 'require_once("pkg-utils.inc");update_repos();'
 	abi_setup
+
+	_debug "pkg_update force='${_force}' mute='${_mute}' do_not_bootstrap='${_do_not_bootstrap}'"
 
 	_exec "pkg-static update${_force}" "Updating repositories metadata" \
 	    ${_mute} "" do_not_exit
@@ -423,6 +477,7 @@ pkg_update() {
 		# force to bootstrap pkg on local system
 		local _ver=$(_pkg query %v pkg)
 		local _cmp=$(_pkg version -t ${_ver} "1.13")
+		_debug "pkg_update bootstrap check pkg_version=${_ver} compare=${_cmp}"
 		if [ "${_cmp}" != "<" ]; then
 			return
 		fi
@@ -440,12 +495,14 @@ pkg_update() {
 
 		local _url=$(get_pkg_repo_url)
 		if [ $? -ne 0 ]; then
+			_debug "pkg_update failed to get repo url"
 			return
 		fi
 
 		${_fetch_env} fetch ${_fetch_args} -o /dev/null \
 		    ${_url}/meta.conf >/dev/null 2>&1
 		if [ $? -eq 0 ]; then
+			_debug "pkg_update meta.conf detected, bootstrapping pkg"
 			_exec "${_pkg_binary} bootstrap -f" \
 			    "Bootstrap pkg due to meta version change"
 			pkg_update "${force}" "${_mute}" _do_not_bootstrap
@@ -456,6 +513,7 @@ pkg_update() {
 pkg_upgrade_repo() {
 	if [ -n "${reinstall_pkg}" ] \
 	    || [ -z "${NEW_MAJOR}" -a "$(compare_pkg_version pkg)" = "<" ]; then
+		_debug "pkg_upgrade_repo upgrading pkg reinstall_pkg=${reinstall_pkg:-0} NEW_MAJOR=${NEW_MAJOR:-0}"
 		pkg_unlock pkg
 		_exec "pkg-static upgrade${dont_update} pkg" "Upgrading pkg" \
 		    mute
@@ -466,6 +524,7 @@ pkg_upgrade_repo() {
 	local _repo_pkg="${product}-repo"
 
 	if ! is_pkg_installed ${_repo_pkg}; then
+		_debug "pkg_upgrade_repo installing ${_repo_pkg}"
 		_exec "pkg-static install${dont_update} ${_repo_pkg}" \
 		    "Installing ${_repo_pkg}" mute "" do_not_exit
 		if [ $? -ne 0 ]; then
@@ -494,6 +553,7 @@ pkg_upgrade_repo() {
 
 	cp /usr/local/etc/pkg/repos/${product}.conf /tmp/${product}.conf.copy
 	if !(is_ce && repo_is_plus_upgrade) ; then
+		_debug "pkg_upgrade_repo upgrading ${_repo_pkg} force='${_force}'"
 		_exec "pkg-static upgrade${dont_update}${_force} ${_repo_pkg}" \
 		    "Upgrading ${_repo_pkg}" mute
 	fi
@@ -519,6 +579,7 @@ upgrade_available() {
 	    | sed -e '/^$/d; /is locked and may not be modified/d' \
 	    | wc -l)
 
+	_debug "upgrade_available packages='${*}' lines=${_lines}"
 	test ${_lines} -gt 0
 	return $?
 }
@@ -1182,6 +1243,8 @@ compare_pkg_version_repo() {
 		_exit 1
 	fi
 
+	_debug "compare_pkg_version_repo pkg=${_pkg_name} local=${_lver} remote=${_rver} abi=${_abi}"
+	_debug "compare_pkg_version_repo rquery_cmd=env -u ABI -u ALTABI -u OSVERSION pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_db} -o REPO_CACHEDIR=${_repo_cache} -o ABI=${_abi} rquery -U %v ${_pkg_name}"
 	local _version=$(_pkg version -t ${_lver} ${_rver})
 
 	if [ $? -ne 0 ]; then
@@ -1228,14 +1291,19 @@ check_upgrade_repo_override() {
 	done
 
 	if [ -z "${_best_conf}" ]; then
+		_debug "check_upgrade_repo_override no repo override conf found"
 		return 1
 	fi
 
 	if [ -n "${_current_major}" -a "${_best_major}" -le "${_current_major}" ]; then
+		_debug "check_upgrade_repo_override best_major=${_best_major} current_major=${_current_major} skipping"
 		return 1
 	fi
 
 	get_repo_abi_values "${_best_conf}"
+
+	_debug "check_upgrade_repo_override using best_conf=${_best_conf} REPO_ABI=${REPO_ABI} REPO_ALTABI=${REPO_ALTABI}"
+	_debug_file "${_best_conf}"
 
 	local _repo_dir=$(prepare_repo_override_dir "${_best_conf}")
 	if [ -z "${_repo_dir}" ]; then
@@ -1274,6 +1342,7 @@ check_upgrade_repo_override() {
 
 		[ -z "${_new_version}" ] && continue
 
+		_debug "check_upgrade_repo_override package=${_package} new_version=${_new_version}"
 		[ -z "${_mute}" ] \
 		    && _echo \
 		    "${_new_version} version of ${product} is available"
@@ -1300,10 +1369,14 @@ check_upgrade_current_repo_override() {
 	fi
 
 	if [ -z "${_current_repo_target}" ]; then
+		_debug "check_upgrade_current_repo_override missing repo target"
 		return 1
 	fi
 
 	get_repo_abi_values "${_current_repo_target}"
+
+	_debug "check_upgrade_current_repo_override repo_conf=${_current_repo_target} REPO_ABI=${REPO_ABI} REPO_ALTABI=${REPO_ALTABI}"
+	_debug_file "${_current_repo_target}"
 
 	local _repo_dir=$(prepare_repo_override_dir "${_current_repo_target}")
 	if [ -z "${_repo_dir}" ]; then
@@ -1342,6 +1415,7 @@ check_upgrade_current_repo_override() {
 
 		[ -z "${_new_version}" ] && continue
 
+		_debug "check_upgrade_current_repo_override package=${_package} new_version=${_new_version}"
 		[ -z "${_mute}" ] \
 		    && _echo \
 		    "${_new_version} version of ${product} is available"
@@ -1361,9 +1435,11 @@ check_upgrade() {
 	    "%n ~ ${product}-kernel-* || %n ~ ${product}-base*" %n 2>/dev/null)
 	local _repo_behind=""
 
+	_debug "check_upgrade meta_pkg=${_meta_pkg} core_pkgs='${_core_pkgs}' NEW_MAJOR=${NEW_MAJOR:-0} action=${action}"
 	check_upgrade_current_repo_override "${_mute}" "${_skip_update}" \
 	    "${_meta_pkg}" "${_core_pkgs}"
 	if [ $? -eq 2 ]; then
+		_debug "check_upgrade current repo override has upgrade"
 		return 2
 	fi
 
@@ -1375,12 +1451,14 @@ check_upgrade() {
 		check_upgrade_current_repo_override "${_mute}" "${_skip_update}" \
 		    "${_meta_pkg}" "${_core_pkgs}"
 		if [ $? -eq 2 ]; then
+			_debug "check_upgrade current repo override has upgrade after bootstrap"
 			return 2
 		fi
 
 		check_upgrade_repo_override "${_mute}" "${_skip_update}" \
 		    "${_meta_pkg}" "${_core_pkgs}"
 		if [ $? -eq 2 ]; then
+			_debug "check_upgrade repo override has upgrade"
 			return 2
 		fi
 
@@ -1390,6 +1468,7 @@ check_upgrade() {
 	fi
 
 	if [ -n "${NEW_MAJOR}" -a "${action}" != "upgrade" ]; then
+		_debug "check_upgrade NEW_MAJOR set and action not upgrade; returning up to date"
 		[ -z "${_mute}" ] \
 		    && _echo "Your system is up to date"
 		return 0
@@ -1419,15 +1498,18 @@ check_upgrade() {
 		_version_compare=$(compare_pkg_version ${_package})
 		case "${_version_compare}" in
 			=)
+				_debug "check_upgrade package=${_package} local=remote"
 				continue
 				;;
 			'>')
+				_debug "check_upgrade package=${_package} local newer"
 				_repo_behind=1
 				continue
 				;;
 		esac
 
 		local _new_version=$(_pkg rquery -U %v ${_package})
+		_debug "check_upgrade package=${_package} new_version=${_new_version}"
 		[ -z "${_mute}" ] \
 		    && _echo \
 		    "${_new_version} version of ${product} is available"
@@ -1437,6 +1519,7 @@ check_upgrade() {
 	check_upgrade_repo_override "${_mute}" "${_skip_update}" \
 	    "${_meta_pkg}" "${_core_pkgs}"
 	if [ $? -eq 2 ]; then
+		_debug "check_upgrade repo override has upgrade"
 		return 2
 	fi
 
@@ -1493,6 +1576,8 @@ compare_pkg_version() {
 		_exit 1
 	fi
 
+	_debug "compare_pkg_version pkg=${_pkg_name} local=${_lver} remote=${_rver}"
+	_debug "compare_pkg_version rquery_cmd=pkg-static rquery -U %v ${_pkg_name}"
 	local _version=$(_pkg version -t ${_lver} ${_rver})
 
 	if [ $? -ne 0 ]; then
@@ -1645,6 +1730,10 @@ validate_repo_conf() {
 			ln -sf ${pkg_repo_conf_path} ${pkg_repo_conf}
 		fi
 	fi
+
+	_debug "validate_repo_conf repo_conf_path=${pkg_repo_conf_path} repo_conf=${pkg_repo_conf}"
+	_debug "validate_repo_conf repo_dir=/usr/local/share/${product}/pkg/repos"
+	_debug_file "${pkg_repo_conf_path}"
 }
 
 export LANG=C
@@ -1755,7 +1844,8 @@ while getopts 46b:cdfi:hp:l:nr:RuUy opt; do
 		c)
 			action="check"
 			;;
-		d)
+	d)
+			debug_enabled=1
 			stdout=''
 			;;
 		f)
@@ -1827,6 +1917,11 @@ elif [ -n "${force_ipv6}" ]; then
 	export IP_VERSION="6"
 fi
 
+if [ "${DEBUG_DEFAULT}" = "1" ]; then
+	debug_enabled=1
+	stdout=''
+fi
+
 # Flags used to determine if all packages must be reinstalled
 pkg_set_version="/usr/local/share/${product}/next_pkg_set_version"
 running_pkg_set_version="/usr/local/share/${product}/running_pkg_set_version"
@@ -1838,8 +1933,10 @@ if [ ! -f ${running_pkg_set_version} ]; then
 fi
 
 # Force debug if /cf/conf/upgrade_debug is present
-[ -f "/cf/conf/upgrade_debug" ] \
-    && stdout=''
+if [ -f "/cf/conf/upgrade_debug" ]; then
+	debug_enabled=1
+	stdout=''
+fi
 
 # Set default action when no parameter is set
 : ${action:="upgrade"}

--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -1459,11 +1459,17 @@ check_upgrade() {
 	fi
 
 	if [ -n "${NEW_MAJOR}" -a "${action}" = "check" ]; then
-		_exec "pkg-static bootstrap -f" \
-		    "Bootstrapping pkg due to ABI change" mute \
-		    ignore_result do_not_exit
-		_debug "check_upgrade bootstrap complete, forcing repo metadata refresh"
-		pkg_update force mute _do_not_bootstrap
+		if [ -n "${PF_UPGRADE_CHECK_BOOTSTRAP}" ]; then
+			_debug "check_upgrade PF_UPGRADE_CHECK_BOOTSTRAP set, using legacy pkg bootstrap flow"
+			_exec "pkg-static bootstrap -f" \
+			    "Bootstrapping pkg due to ABI change" mute \
+			    ignore_result do_not_exit
+			_debug "check_upgrade bootstrap complete, forcing repo metadata refresh"
+			pkg_update force mute _do_not_bootstrap
+		else
+			_debug "check_upgrade skipping pkg bootstrap for NEW_MAJOR detection"
+			_debug "check_upgrade set PF_UPGRADE_CHECK_BOOTSTRAP=1 to enable legacy behavior"
+		fi
 
 		check_upgrade_current_repo_override "${_mute}" "${_skip_update}" \
 		    "${_meta_pkg}" "${_core_pkgs}"

--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -454,77 +454,81 @@ pkg_update() {
 
 	local _pkg_binary="/usr/sbin/pkg"
 
-	[ "${1}" = "force" ] \
-	    && _force=" -f"
+	[ "${1}" = "force" ] 	    && _force=" -f"
 
 	if [ -z "${_force}" -a -n "${dont_update}" ]; then
 		_debug "pkg_update skipping due to dont_update"
 		return 0
 	fi
 
-	[ "${2}" = "mute" ] \
-	    && _mute="mute"
+	[ "${2}" = "mute" ] 	    && _mute="mute"
 
 	/usr/local/bin/php -r 'require_once("pkg-utils.inc");update_repos();'
 	abi_setup
 
 	_debug "pkg_update force='${_force}' mute='${_mute}' do_not_bootstrap='${_do_not_bootstrap}'"
 
-	_exec "pkg-static update${_force}" "Updating repositories metadata" \
-	    ${_mute} "" do_not_exit
+	_exec "pkg-static update${_force}" "Updating repositories metadata" 	    ${_mute} "" do_not_exit
 
-	if [ $? -ne 0 -a -z "${_do_not_bootstrap}" ]; then
-		# Since pkg version 1.13 it moved to use repository metadata
-		# version 2, which cannot be processed by older pkg binaries
-		#
-		# Detect if remote repository has a meta.conf file available,
-		# what indicates it is using meta version 2, and in this case
-		# force to bootstrap pkg on local system
-		local _ver=$(_pkg query %v pkg)
-		local _cmp=$(_pkg version -t ${_ver} "1.13")
-		_debug "pkg_update bootstrap check pkg_version=${_ver} compare=${_cmp}"
-		if [ "${_cmp}" != "<" ]; then
-			return
-		fi
+	local _update_rc=$?
+	if [ ${_update_rc} -eq 0 ]; then
+		return 0
+	fi
 
-		# Make fetch to work with thoth
-		local _fetch_env=""
-		local _fetch_args=""
-		if [ "${arch}" = "aarch64" ]; then
-			_fetch_env="env OPENSSL_CONF=/etc/thoth/openssl.cnf"
-			_fetch_args="--cert=/etc/thoth/device.pem"
-			_fetch_args="${_fetch_args} --key=/etc/thoth/key.pem"
-			_fetch_args="${_fetch_args} --ca-cert=/etc/thoth/ca.pem"
-			_pkg_binary="/usr/local/sbin/pkg-static"
-		fi
+	if [ -n "${_do_not_bootstrap}" ]; then
+		return ${_update_rc}
+	fi
 
-		local _url=$(get_pkg_repo_url)
-		if [ $? -ne 0 ]; then
-			_debug "pkg_update failed to get repo url"
-			return
-		fi
-		_debug "pkg_update repo_url=${_url}"
+	# Since pkg version 1.13 it moved to use repository metadata
+	# version 2, which cannot be processed by older pkg binaries
+	#
+	# Detect if remote repository has a meta.conf file available,
+	# what indicates it is using meta version 2, and in this case
+	# force to bootstrap pkg on local system
+	local _ver=$(_pkg query %v pkg)
+	local _cmp=$(_pkg version -t ${_ver} "1.13")
+	_debug "pkg_update bootstrap check pkg_version=${_ver} compare=${_cmp}"
+	if [ "${_cmp}" != "<" ]; then
+		return ${_update_rc}
+	fi
 
-		if [ -n "${debug_enabled}" ]; then
-			local _meta_file
-			_meta_file=$(mktemp /tmp/pkg.meta.conf.XXXXXX) || _meta_file=""
-			if [ -n "${_meta_file}" ]; then
-				${_fetch_env} fetch ${_fetch_args} -o "${_meta_file}" \
-				    ${_url}/meta.conf >/dev/null 2>&1
-				_debug_file "${_meta_file}"
-				rm -f "${_meta_file}"
-			fi
-		fi
+	# Make fetch to work with thoth
+	local _fetch_env=""
+	local _fetch_args=""
+	if [ "${arch}" = "aarch64" ]; then
+		_fetch_env="env OPENSSL_CONF=/etc/thoth/openssl.cnf"
+		_fetch_args="--cert=/etc/thoth/device.pem"
+		_fetch_args="${_fetch_args} --key=/etc/thoth/key.pem"
+		_fetch_args="${_fetch_args} --ca-cert=/etc/thoth/ca.pem"
+		_pkg_binary="/usr/local/sbin/pkg-static"
+	fi
 
-		${_fetch_env} fetch ${_fetch_args} -o /dev/null \
-		    ${_url}/meta.conf >/dev/null 2>&1
-		if [ $? -eq 0 ]; then
-			_debug "pkg_update meta.conf detected, bootstrapping pkg"
-			_exec "${_pkg_binary} bootstrap -f" \
-			    "Bootstrap pkg due to meta version change"
-			pkg_update "${force}" "${_mute}" _do_not_bootstrap
+	local _url=$(get_pkg_repo_url)
+	if [ $? -ne 0 ]; then
+		_debug "pkg_update failed to get repo url"
+		return ${_update_rc}
+	fi
+	_debug "pkg_update repo_url=${_url}"
+
+	if [ -n "${debug_enabled}" ]; then
+		local _meta_file
+		_meta_file=$(mktemp /tmp/pkg.meta.conf.XXXXXX) || _meta_file=""
+		if [ -n "${_meta_file}" ]; then
+			${_fetch_env} fetch ${_fetch_args} -o "${_meta_file}" 			    ${_url}/meta.conf >/dev/null 2>&1
+			_debug_file "${_meta_file}"
+			rm -f "${_meta_file}"
 		fi
 	fi
+
+	${_fetch_env} fetch ${_fetch_args} -o /dev/null 	    ${_url}/meta.conf >/dev/null 2>&1
+	if [ $? -eq 0 ]; then
+		_debug "pkg_update meta.conf detected, bootstrapping pkg"
+		_exec "${_pkg_binary} bootstrap -f" 		    "Bootstrap pkg due to meta version change"
+		pkg_update "${force}" "${_mute}" _do_not_bootstrap
+		return $?
+	fi
+
+	return ${_update_rc}
 }
 
 pkg_upgrade_repo() {
@@ -1038,6 +1042,25 @@ pkg_upgrade() {
 				_exec "pkg-static install -f pkg" \
 				    "Reinstalling pkg due to ABI change"
 
+				# Refresh repository metadata with the new pkg binary
+				# before trying to upgrade core packages on stage 2.
+				local _pkg_update_ok=""
+				local _pkg_update_try=1
+				while [ ${_pkg_update_try} -le 3 ]; do
+					pkg_update force
+					if [ $? -eq 0 ]; then
+						_pkg_update_ok=1
+						break
+					fi
+					_debug "stage2 pkg_update attempt ${_pkg_update_try}/3 failed"
+					sleep 2
+					_pkg_update_try=$((_pkg_update_try + 1))
+				done
+				if [ -z "${_pkg_update_ok}" ]; then
+					_echo "ERROR: Unable to update repository metadata after pkg upgrade"
+					_exit 1
+				fi
+
 				# Upgrade core packages
 				_exec "pkg-static upgrade -r ${product}-core" \
 				    "Upgrading necessary core packages"
@@ -1459,11 +1482,17 @@ check_upgrade() {
 	fi
 
 	if [ -n "${NEW_MAJOR}" -a "${action}" = "check" ]; then
-		_exec "pkg-static bootstrap -f" \
-		    "Bootstrapping pkg due to ABI change" mute \
-		    ignore_result do_not_exit
-		_debug "check_upgrade bootstrap complete, forcing repo metadata refresh"
-		pkg_update force mute _do_not_bootstrap
+		if [ -n "${PF_UPGRADE_CHECK_BOOTSTRAP}" ]; then
+			_debug "check_upgrade PF_UPGRADE_CHECK_BOOTSTRAP set, using legacy pkg bootstrap flow"
+			_exec "pkg-static bootstrap -f" \
+			    "Bootstrapping pkg due to ABI change" mute \
+			    ignore_result do_not_exit
+			_debug "check_upgrade bootstrap complete, forcing repo metadata refresh"
+			pkg_update force mute _do_not_bootstrap
+		else
+			_debug "check_upgrade skipping pkg bootstrap for NEW_MAJOR detection"
+			_debug "check_upgrade set PF_UPGRADE_CHECK_BOOTSTRAP=1 to enable legacy behavior"
+		fi
 
 		check_upgrade_current_repo_override "${_mute}" "${_skip_update}" \
 		    "${_meta_pkg}" "${_core_pkgs}"
@@ -2015,7 +2044,11 @@ else
 fi
 
 if [ "${action}" = "install" ]; then
-	pkg_upgrade_repo
+	if [ "${action_pkg}" = "${product}-upgrade" ]; then
+		_debug "install action for ${action_pkg}; skipping pkg_upgrade_repo to avoid premature pkg upgrade"
+	else
+		pkg_upgrade_repo
+	fi
 
 	new_php_pkg=$(_pkg rquery -U %dn $(get_meta_pkg_name) \
 	    | egrep '^php[0-9]{2}$')

--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -18,6 +18,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+DEBUG_DEFAULT=0
+
 usage() {
 	me=$(basename $0)
 	cat << EOD >&2
@@ -57,6 +59,44 @@ _echo() {
 	echo ${_n} "${@}" | tee -a ${logfile}
 }
 
+_debug() {
+	if [ -z "${debug_enabled}" ]; then
+		return 0
+	fi
+
+	local _ts
+	_ts=$(date "+%Y-%m-%d %H:%M:%S")
+	_echo "DEBUG ${_ts} ${*}"
+}
+
+_debug_file() {
+	if [ -z "${debug_enabled}" ]; then
+		return 0
+	fi
+
+	local _file="${1}"
+	local _ts
+	_ts=$(date "+%Y-%m-%d %H:%M:%S")
+
+	if [ -z "${_file}" ]; then
+		_echo "DEBUG ${_ts} file=(empty)"
+		return 0
+	fi
+
+	if [ ! -f "${_file}" ]; then
+		_echo "DEBUG ${_ts} file=${_file} (not found)"
+		return 0
+	fi
+
+	_echo "DEBUG ${_ts} file=${_file} (begin)"
+	while IFS= read -r _line; do
+		_ts=$(date "+%Y-%m-%d %H:%M:%S")
+		_echo "DEBUG ${_ts} file=${_file}: ${_line}"
+	done < "${_file}"
+	_ts=$(date "+%Y-%m-%d %H:%M:%S")
+	_echo "DEBUG ${_ts} file=${_file} (end)"
+}
+
 _exec() {
 	local _cmd="${1}"
 	local _msg="${2}"
@@ -73,6 +113,8 @@ _exec() {
 	if [ "${_mute}" != "mute" ]; then
 		_stdout=''
 	fi
+
+	_debug "exec cmd='${_cmd}' msg='${_msg}' mute='${_mute}'"
 
 	[ -n "${_msg}" ] \
 	    && _echo -n ">>> ${_msg}... "
@@ -100,10 +142,12 @@ _exec() {
 	if [ ${_result} -eq 0 -o -n "${_ignore_result}" ]; then
 		[ -n "${_stdout}" -a -n "${_msg}" ] \
 		    && _echo "done."
+		_debug "exec result=success code=${_result}"
 		return 0
 	else
 		[ -n "${_stdout}" -a -n "${_msg}" ] \
 		    && _echo "failed."
+		_debug "exec result=failure code=${_result}"
 		[ -n "${_do_not_exit}" ] \
 		    && return 1 \
 		    || _exit 1
@@ -307,6 +351,12 @@ abi_setup() {
 	ABI="${_repo_abi}"
 	ALTABI="${_repo_altabi}"
 
+	_debug "abi_setup freebsd_version=${_freebsd_version} arch=${arch} CUR_ABI=${CUR_ABI} CUR_ALTABI=${CUR_ALTABI}"
+	_debug "abi_setup repo_conf=${_pkg_repo_conf} repo_target=${_repo_abi_file} ABI=${ABI} ALTABI=${ALTABI}"
+	_debug "abi_setup repo_dir=/usr/local/share/${product}/pkg/repos"
+	_debug_file "/usr/local/share/${product}/pkg/repos/${product}-repo.conf"
+	_debug_file "/usr/local/share/${product}/pkg/repos/${product}-repo-previous.conf"
+
 	AUTH_CA="/etc/ssl/netgate-ca.pem"
 	AUTH_CERT="/etc/ssl/pfSense-repo-custom.cert"
 	AUTH_KEY="/etc/ssl/pfSense-repo-custom.key"
@@ -356,6 +406,9 @@ EOF
 	echo "ABI=${ABI}" > /usr/local/etc/pkg.conf
 	echo "OSVERSION=${OSVERSION}" >> /usr/local/etc/pkg.conf
 
+	_debug "abi_setup pkg_abi=${_pkg_abi} reinstall_pkg=${reinstall_pkg:-0} NEW_MAJOR=${NEW_MAJOR:-0} OSVERSION=${OSVERSION}"
+	_debug_file "/usr/local/etc/pkg.conf"
+
 	export CUR_ABI CUR_ALTABI ABI NEW_MAJOR
 }
 
@@ -378,6 +431,7 @@ get_pkg_repo_url() {
 	if [ -n "${_srv}" ]; then
 		local _n=$(host -t SRV _https._tcp.${_host} 2>/dev/null | wc -l)
 		if [ ${_n} -eq 0 ]; then
+			_debug "get_pkg_repo_url srv lookup failed host=${_host}"
 			return 1
 		fi
 
@@ -388,6 +442,7 @@ get_pkg_repo_url() {
 		_url=$(echo "${_url}" | sed "s,${_host},${_real_host},")
 	fi
 
+	_debug "get_pkg_repo_url url=${_url}"
 	echo "${_url}"
 }
 
@@ -402,6 +457,7 @@ pkg_update() {
 	    && _force=" -f"
 
 	if [ -z "${_force}" -a -n "${dont_update}" ]; then
+		_debug "pkg_update skipping due to dont_update"
 		return 0
 	fi
 
@@ -410,6 +466,8 @@ pkg_update() {
 
 	/usr/local/bin/php -r 'require_once("pkg-utils.inc");update_repos();'
 	abi_setup
+
+	_debug "pkg_update force='${_force}' mute='${_mute}' do_not_bootstrap='${_do_not_bootstrap}'"
 
 	_exec "pkg-static update${_force}" "Updating repositories metadata" \
 	    ${_mute} "" do_not_exit
@@ -423,6 +481,7 @@ pkg_update() {
 		# force to bootstrap pkg on local system
 		local _ver=$(_pkg query %v pkg)
 		local _cmp=$(_pkg version -t ${_ver} "1.13")
+		_debug "pkg_update bootstrap check pkg_version=${_ver} compare=${_cmp}"
 		if [ "${_cmp}" != "<" ]; then
 			return
 		fi
@@ -440,12 +499,26 @@ pkg_update() {
 
 		local _url=$(get_pkg_repo_url)
 		if [ $? -ne 0 ]; then
+			_debug "pkg_update failed to get repo url"
 			return
+		fi
+		_debug "pkg_update repo_url=${_url}"
+
+		if [ -n "${debug_enabled}" ]; then
+			local _meta_file
+			_meta_file=$(mktemp /tmp/pkg.meta.conf.XXXXXX) || _meta_file=""
+			if [ -n "${_meta_file}" ]; then
+				${_fetch_env} fetch ${_fetch_args} -o "${_meta_file}" \
+				    ${_url}/meta.conf >/dev/null 2>&1
+				_debug_file "${_meta_file}"
+				rm -f "${_meta_file}"
+			fi
 		fi
 
 		${_fetch_env} fetch ${_fetch_args} -o /dev/null \
 		    ${_url}/meta.conf >/dev/null 2>&1
 		if [ $? -eq 0 ]; then
+			_debug "pkg_update meta.conf detected, bootstrapping pkg"
 			_exec "${_pkg_binary} bootstrap -f" \
 			    "Bootstrap pkg due to meta version change"
 			pkg_update "${force}" "${_mute}" _do_not_bootstrap
@@ -456,6 +529,7 @@ pkg_update() {
 pkg_upgrade_repo() {
 	if [ -n "${reinstall_pkg}" ] \
 	    || [ -z "${NEW_MAJOR}" -a "$(compare_pkg_version pkg)" = "<" ]; then
+		_debug "pkg_upgrade_repo upgrading pkg reinstall_pkg=${reinstall_pkg:-0} NEW_MAJOR=${NEW_MAJOR:-0}"
 		pkg_unlock pkg
 		_exec "pkg-static upgrade${dont_update} pkg" "Upgrading pkg" \
 		    mute
@@ -466,6 +540,7 @@ pkg_upgrade_repo() {
 	local _repo_pkg="${product}-repo"
 
 	if ! is_pkg_installed ${_repo_pkg}; then
+		_debug "pkg_upgrade_repo installing ${_repo_pkg}"
 		_exec "pkg-static install${dont_update} ${_repo_pkg}" \
 		    "Installing ${_repo_pkg}" mute "" do_not_exit
 		if [ $? -ne 0 ]; then
@@ -494,6 +569,7 @@ pkg_upgrade_repo() {
 
 	cp /usr/local/etc/pkg/repos/${product}.conf /tmp/${product}.conf.copy
 	if !(is_ce && repo_is_plus_upgrade) ; then
+		_debug "pkg_upgrade_repo upgrading ${_repo_pkg} force='${_force}'"
 		_exec "pkg-static upgrade${dont_update}${_force} ${_repo_pkg}" \
 		    "Upgrading ${_repo_pkg}" mute
 	fi
@@ -519,6 +595,7 @@ upgrade_available() {
 	    | sed -e '/^$/d; /is locked and may not be modified/d' \
 	    | wc -l)
 
+	_debug "upgrade_available packages='${*}' lines=${_lines}"
 	test ${_lines} -gt 0
 	return $?
 }
@@ -666,9 +743,7 @@ pkg_upgrade() {
 	need_reboot=1
 	# First upgrade stage
 	if [ -z "${next_stage}" ]; then
-		if [ -f "${logfile}" ]; then
-			rm -f ${logfile}
-		fi
+		# Preserve existing logfile; do not delete
 
 		pkg_update force
 
@@ -1182,6 +1257,8 @@ compare_pkg_version_repo() {
 		_exit 1
 	fi
 
+	_debug "compare_pkg_version_repo pkg=${_pkg_name} local=${_lver} remote=${_rver} abi=${_abi}"
+	_debug "compare_pkg_version_repo rquery_cmd=env -u ABI -u ALTABI -u OSVERSION pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_db} -o REPO_CACHEDIR=${_repo_cache} -o ABI=${_abi} rquery -U %v ${_pkg_name}"
 	local _version=$(_pkg version -t ${_lver} ${_rver})
 
 	if [ $? -ne 0 ]; then
@@ -1228,14 +1305,19 @@ check_upgrade_repo_override() {
 	done
 
 	if [ -z "${_best_conf}" ]; then
+		_debug "check_upgrade_repo_override no repo override conf found"
 		return 1
 	fi
 
 	if [ -n "${_current_major}" -a "${_best_major}" -le "${_current_major}" ]; then
+		_debug "check_upgrade_repo_override best_major=${_best_major} current_major=${_current_major} skipping"
 		return 1
 	fi
 
 	get_repo_abi_values "${_best_conf}"
+
+	_debug "check_upgrade_repo_override using best_conf=${_best_conf} REPO_ABI=${REPO_ABI} REPO_ALTABI=${REPO_ALTABI}"
+	_debug_file "${_best_conf}"
 
 	local _repo_dir=$(prepare_repo_override_dir "${_best_conf}")
 	if [ -z "${_repo_dir}" ]; then
@@ -1274,6 +1356,7 @@ check_upgrade_repo_override() {
 
 		[ -z "${_new_version}" ] && continue
 
+		_debug "check_upgrade_repo_override package=${_package} new_version=${_new_version}"
 		[ -z "${_mute}" ] \
 		    && _echo \
 		    "${_new_version} version of ${product} is available"
@@ -1300,10 +1383,14 @@ check_upgrade_current_repo_override() {
 	fi
 
 	if [ -z "${_current_repo_target}" ]; then
+		_debug "check_upgrade_current_repo_override missing repo target"
 		return 1
 	fi
 
 	get_repo_abi_values "${_current_repo_target}"
+
+	_debug "check_upgrade_current_repo_override repo_conf=${_current_repo_target} REPO_ABI=${REPO_ABI} REPO_ALTABI=${REPO_ALTABI}"
+	_debug_file "${_current_repo_target}"
 
 	local _repo_dir=$(prepare_repo_override_dir "${_current_repo_target}")
 	if [ -z "${_repo_dir}" ]; then
@@ -1342,6 +1429,7 @@ check_upgrade_current_repo_override() {
 
 		[ -z "${_new_version}" ] && continue
 
+		_debug "check_upgrade_current_repo_override package=${_package} new_version=${_new_version}"
 		[ -z "${_mute}" ] \
 		    && _echo \
 		    "${_new_version} version of ${product} is available"
@@ -1361,9 +1449,11 @@ check_upgrade() {
 	    "%n ~ ${product}-kernel-* || %n ~ ${product}-base*" %n 2>/dev/null)
 	local _repo_behind=""
 
+	_debug "check_upgrade meta_pkg=${_meta_pkg} core_pkgs='${_core_pkgs}' NEW_MAJOR=${NEW_MAJOR:-0} action=${action}"
 	check_upgrade_current_repo_override "${_mute}" "${_skip_update}" \
 	    "${_meta_pkg}" "${_core_pkgs}"
 	if [ $? -eq 2 ]; then
+		_debug "check_upgrade current repo override has upgrade"
 		return 2
 	fi
 
@@ -1375,12 +1465,14 @@ check_upgrade() {
 		check_upgrade_current_repo_override "${_mute}" "${_skip_update}" \
 		    "${_meta_pkg}" "${_core_pkgs}"
 		if [ $? -eq 2 ]; then
+			_debug "check_upgrade current repo override has upgrade after bootstrap"
 			return 2
 		fi
 
 		check_upgrade_repo_override "${_mute}" "${_skip_update}" \
 		    "${_meta_pkg}" "${_core_pkgs}"
 		if [ $? -eq 2 ]; then
+			_debug "check_upgrade repo override has upgrade"
 			return 2
 		fi
 
@@ -1390,6 +1482,7 @@ check_upgrade() {
 	fi
 
 	if [ -n "${NEW_MAJOR}" -a "${action}" != "upgrade" ]; then
+		_debug "check_upgrade NEW_MAJOR set and action not upgrade; returning up to date"
 		[ -z "${_mute}" ] \
 		    && _echo "Your system is up to date"
 		return 0
@@ -1419,15 +1512,18 @@ check_upgrade() {
 		_version_compare=$(compare_pkg_version ${_package})
 		case "${_version_compare}" in
 			=)
+				_debug "check_upgrade package=${_package} local=remote"
 				continue
 				;;
 			'>')
+				_debug "check_upgrade package=${_package} local newer"
 				_repo_behind=1
 				continue
 				;;
 		esac
 
 		local _new_version=$(_pkg rquery -U %v ${_package})
+		_debug "check_upgrade package=${_package} new_version=${_new_version}"
 		[ -z "${_mute}" ] \
 		    && _echo \
 		    "${_new_version} version of ${product} is available"
@@ -1437,6 +1533,7 @@ check_upgrade() {
 	check_upgrade_repo_override "${_mute}" "${_skip_update}" \
 	    "${_meta_pkg}" "${_core_pkgs}"
 	if [ $? -eq 2 ]; then
+		_debug "check_upgrade repo override has upgrade"
 		return 2
 	fi
 
@@ -1493,6 +1590,8 @@ compare_pkg_version() {
 		_exit 1
 	fi
 
+	_debug "compare_pkg_version pkg=${_pkg_name} local=${_lver} remote=${_rver}"
+	_debug "compare_pkg_version rquery_cmd=pkg-static rquery -U %v ${_pkg_name}"
 	local _version=$(_pkg version -t ${_lver} ${_rver})
 
 	if [ $? -ne 0 ]; then
@@ -1645,6 +1744,12 @@ validate_repo_conf() {
 			ln -sf ${pkg_repo_conf_path} ${pkg_repo_conf}
 		fi
 	fi
+
+	_debug "validate_repo_conf repo_conf_path=${pkg_repo_conf_path} repo_conf=${pkg_repo_conf}"
+	_debug "validate_repo_conf repo_dir=/usr/local/share/${product}/pkg/repos"
+	_debug_file "${pkg_repo_conf_path}"
+	_debug_file "/usr/local/share/${product}/pkg/repos/${product}-repo.conf"
+	_debug_file "/usr/local/share/${product}/pkg/repos/${product}-repo-previous.conf"
 }
 
 export LANG=C
@@ -1755,7 +1860,8 @@ while getopts 46b:cdfi:hp:l:nr:RuUy opt; do
 		c)
 			action="check"
 			;;
-		d)
+	d)
+			debug_enabled=1
 			stdout=''
 			;;
 		f)
@@ -1827,6 +1933,11 @@ elif [ -n "${force_ipv6}" ]; then
 	export IP_VERSION="6"
 fi
 
+if [ "${DEBUG_DEFAULT}" = "1" ]; then
+	debug_enabled=1
+	stdout=''
+fi
+
 # Flags used to determine if all packages must be reinstalled
 pkg_set_version="/usr/local/share/${product}/next_pkg_set_version"
 running_pkg_set_version="/usr/local/share/${product}/running_pkg_set_version"
@@ -1838,8 +1949,10 @@ if [ ! -f ${running_pkg_set_version} ]; then
 fi
 
 # Force debug if /cf/conf/upgrade_debug is present
-[ -f "/cf/conf/upgrade_debug" ] \
-    && stdout=''
+if [ -f "/cf/conf/upgrade_debug" ]; then
+	debug_enabled=1
+	stdout=''
+fi
 
 # Set default action when no parameter is set
 : ${action:="upgrade"}
@@ -1868,9 +1981,7 @@ if [ -n "${booting}" ]; then
 	export REPO_AUTOUPDATE=false
 fi
 
-if [ "${action}" != "upgrade" -a -f "${logfile}" ]; then
-	rm -f ${logfile}
-fi
+# Preserve existing logfile; do not delete
 
 progress_file=${logfile%.*}.json
 

--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -1240,13 +1240,13 @@ compare_pkg_version_repo() {
 	local _repo_db="${_repo_dir}/db"
 	mkdir -p "${_repo_cache}" "${_repo_db}"
 
-	local _rver=$(env -u ABI -u ALTABI -u OSVERSION \
+	local _rver=$(env -u ABI -u ALTABI -u OSVERSION IGNORE_OSVERSION=yes \
 	    pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_db} \
 	    -o REPO_CACHEDIR=${_repo_cache} -o ABI=${_abi} \
 	    rquery -U %v ${_pkg_name})
 
 	if [ -z "${_rver}" ]; then
-		_rver=$(env -u ABI -u ALTABI -u OSVERSION \
+		_rver=$(env -u ABI -u ALTABI -u OSVERSION IGNORE_OSVERSION=yes \
 		    pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_db} \
 		    -o REPO_CACHEDIR=${_repo_cache} -o ABI=${_abi} \
 		    rquery %v ${_pkg_name})
@@ -1259,7 +1259,7 @@ compare_pkg_version_repo() {
 	fi
 
 	_debug "compare_pkg_version_repo pkg=${_pkg_name} local=${_lver} remote=${_rver} abi=${_abi}"
-	_debug "compare_pkg_version_repo rquery_cmd=env -u ABI -u ALTABI -u OSVERSION pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_db} -o REPO_CACHEDIR=${_repo_cache} -o ABI=${_abi} rquery -U %v ${_pkg_name}"
+	_debug "compare_pkg_version_repo rquery_cmd=env -u ABI -u ALTABI -u OSVERSION IGNORE_OSVERSION=yes pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_db} -o REPO_CACHEDIR=${_repo_cache} -o ABI=${_abi} rquery -U %v ${_pkg_name}"
 	local _version=$(_pkg version -t ${_lver} ${_rver})
 
 	if [ $? -ne 0 ]; then
@@ -1326,7 +1326,7 @@ check_upgrade_repo_override() {
 	fi
 
 	if [ -z "${_skip_update}" -a -z "${dont_update}" ]; then
-		env -u ABI -u ALTABI -u OSVERSION \
+		env -u ABI -u ALTABI -u OSVERSION IGNORE_OSVERSION=yes \
 		    pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_dir}/db \
 		    -o REPO_CACHEDIR=${_repo_dir}/cache -o ABI=${REPO_ABI} \
 		    update -f >/dev/null 2>&1
@@ -1342,13 +1342,13 @@ check_upgrade_repo_override() {
 				;;
 		esac
 
-		local _new_version=$(env -u ABI -u ALTABI -u OSVERSION \
+		local _new_version=$(env -u ABI -u ALTABI -u OSVERSION IGNORE_OSVERSION=yes \
 		    pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_dir}/db \
 		    -o REPO_CACHEDIR=${_repo_dir}/cache -o ABI=${REPO_ABI} \
 		    rquery -U %v ${_package})
 
 		if [ -z "${_new_version}" ]; then
-			_new_version=$(env -u ABI -u ALTABI -u OSVERSION \
+			_new_version=$(env -u ABI -u ALTABI -u OSVERSION IGNORE_OSVERSION=yes \
 			    pkg-static -o REPOS_DIR=${_repo_dir} \
 			    -o PKG_DBDIR=${_repo_dir}/db \
 			    -o REPO_CACHEDIR=${_repo_dir}/cache -o ABI=${REPO_ABI} \
@@ -1399,7 +1399,7 @@ check_upgrade_current_repo_override() {
 	fi
 
 	if [ -z "${_skip_update}" -a -z "${dont_update}" ]; then
-		env -u ABI -u ALTABI -u OSVERSION \
+		env -u ABI -u ALTABI -u OSVERSION IGNORE_OSVERSION=yes \
 		    pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_dir}/db \
 		    -o REPO_CACHEDIR=${_repo_dir}/cache -o ABI=${REPO_ABI} \
 		    update -f >/dev/null 2>&1
@@ -1415,13 +1415,13 @@ check_upgrade_current_repo_override() {
 				;;
 		esac
 
-		local _new_version=$(env -u ABI -u ALTABI -u OSVERSION \
+		local _new_version=$(env -u ABI -u ALTABI -u OSVERSION IGNORE_OSVERSION=yes \
 		    pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_dir}/db \
 		    -o REPO_CACHEDIR=${_repo_dir}/cache -o ABI=${REPO_ABI} \
 		    rquery -U %v ${_package})
 
 		if [ -z "${_new_version}" ]; then
-			_new_version=$(env -u ABI -u ALTABI -u OSVERSION \
+			_new_version=$(env -u ABI -u ALTABI -u OSVERSION IGNORE_OSVERSION=yes \
 			    pkg-static -o REPOS_DIR=${_repo_dir} \
 			    -o PKG_DBDIR=${_repo_dir}/db \
 			    -o REPO_CACHEDIR=${_repo_dir}/cache -o ABI=${REPO_ABI} \

--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -18,6 +18,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+DEBUG_DEFAULT=0
+
 usage() {
 	me=$(basename $0)
 	cat << EOD >&2
@@ -57,6 +59,44 @@ _echo() {
 	echo ${_n} "${@}" | tee -a ${logfile}
 }
 
+_debug() {
+	if [ -z "${debug_enabled}" ]; then
+		return 0
+	fi
+
+	local _ts
+	_ts=$(date "+%Y-%m-%d %H:%M:%S")
+	_echo "DEBUG ${_ts} ${*}"
+}
+
+_debug_file() {
+	if [ -z "${debug_enabled}" ]; then
+		return 0
+	fi
+
+	local _file="${1}"
+	local _ts
+	_ts=$(date "+%Y-%m-%d %H:%M:%S")
+
+	if [ -z "${_file}" ]; then
+		_echo "DEBUG ${_ts} file=(empty)"
+		return 0
+	fi
+
+	if [ ! -f "${_file}" ]; then
+		_echo "DEBUG ${_ts} file=${_file} (not found)"
+		return 0
+	fi
+
+	_echo "DEBUG ${_ts} file=${_file} (begin)"
+	while IFS= read -r _line; do
+		_ts=$(date "+%Y-%m-%d %H:%M:%S")
+		_echo "DEBUG ${_ts} file=${_file}: ${_line}"
+	done < "${_file}"
+	_ts=$(date "+%Y-%m-%d %H:%M:%S")
+	_echo "DEBUG ${_ts} file=${_file} (end)"
+}
+
 _exec() {
 	local _cmd="${1}"
 	local _msg="${2}"
@@ -73,6 +113,8 @@ _exec() {
 	if [ "${_mute}" != "mute" ]; then
 		_stdout=''
 	fi
+
+	_debug "exec cmd='${_cmd}' msg='${_msg}' mute='${_mute}'"
 
 	[ -n "${_msg}" ] \
 	    && _echo -n ">>> ${_msg}... "
@@ -100,10 +142,12 @@ _exec() {
 	if [ ${_result} -eq 0 -o -n "${_ignore_result}" ]; then
 		[ -n "${_stdout}" -a -n "${_msg}" ] \
 		    && _echo "done."
+		_debug "exec result=success code=${_result}"
 		return 0
 	else
 		[ -n "${_stdout}" -a -n "${_msg}" ] \
 		    && _echo "failed."
+		_debug "exec result=failure code=${_result}"
 		[ -n "${_do_not_exit}" ] \
 		    && return 1 \
 		    || _exit 1
@@ -307,6 +351,12 @@ abi_setup() {
 	ABI="${_repo_abi}"
 	ALTABI="${_repo_altabi}"
 
+	_debug "abi_setup freebsd_version=${_freebsd_version} arch=${arch} CUR_ABI=${CUR_ABI} CUR_ALTABI=${CUR_ALTABI}"
+	_debug "abi_setup repo_conf=${_pkg_repo_conf} repo_target=${_repo_abi_file} ABI=${ABI} ALTABI=${ALTABI}"
+	_debug "abi_setup repo_dir=/usr/local/share/${product}/pkg/repos"
+	_debug_file "/usr/local/share/${product}/pkg/repos/${product}-repo.conf"
+	_debug_file "/usr/local/share/${product}/pkg/repos/${product}-repo-previous.conf"
+
 	AUTH_CA="/etc/ssl/netgate-ca.pem"
 	AUTH_CERT="/etc/ssl/pfSense-repo-custom.cert"
 	AUTH_KEY="/etc/ssl/pfSense-repo-custom.key"
@@ -344,7 +394,8 @@ EOF
 		NEW_MAJOR=1
 	fi
 
-	if [ -n "${NEW_MAJOR}" -a "${action}" != "upgrade" ]; then
+	if [ -n "${NEW_MAJOR}" -a "${action}" != "upgrade" -a \
+	    "${action}" != "check" ]; then
 		ABI="${CUR_ABI}"
 		ALTABI="${CUR_ALTABI}"
 	else
@@ -355,6 +406,9 @@ EOF
 	OSVERSION=$(sysctl -n kern.osreldate)
 	echo "ABI=${ABI}" > /usr/local/etc/pkg.conf
 	echo "OSVERSION=${OSVERSION}" >> /usr/local/etc/pkg.conf
+
+	_debug "abi_setup pkg_abi=${_pkg_abi} reinstall_pkg=${reinstall_pkg:-0} NEW_MAJOR=${NEW_MAJOR:-0} OSVERSION=${OSVERSION} IGNORE_OSVERSION=${IGNORE_OSVERSION:-}"
+	_debug_file "/usr/local/etc/pkg.conf"
 
 	export CUR_ABI CUR_ALTABI ABI NEW_MAJOR
 }
@@ -378,6 +432,7 @@ get_pkg_repo_url() {
 	if [ -n "${_srv}" ]; then
 		local _n=$(host -t SRV _https._tcp.${_host} 2>/dev/null | wc -l)
 		if [ ${_n} -eq 0 ]; then
+			_debug "get_pkg_repo_url srv lookup failed host=${_host}"
 			return 1
 		fi
 
@@ -388,6 +443,7 @@ get_pkg_repo_url() {
 		_url=$(echo "${_url}" | sed "s,${_host},${_real_host},")
 	fi
 
+	_debug "get_pkg_repo_url url=${_url}"
 	echo "${_url}"
 }
 
@@ -402,6 +458,7 @@ pkg_update() {
 	    && _force=" -f"
 
 	if [ -z "${_force}" -a -n "${dont_update}" ]; then
+		_debug "pkg_update skipping due to dont_update"
 		return 0
 	fi
 
@@ -410,6 +467,8 @@ pkg_update() {
 
 	/usr/local/bin/php -r 'require_once("pkg-utils.inc");update_repos();'
 	abi_setup
+
+	_debug "pkg_update force='${_force}' mute='${_mute}' do_not_bootstrap='${_do_not_bootstrap}'"
 
 	_exec "pkg-static update${_force}" "Updating repositories metadata" \
 	    ${_mute} "" do_not_exit
@@ -423,6 +482,7 @@ pkg_update() {
 		# force to bootstrap pkg on local system
 		local _ver=$(_pkg query %v pkg)
 		local _cmp=$(_pkg version -t ${_ver} "1.13")
+		_debug "pkg_update bootstrap check pkg_version=${_ver} compare=${_cmp}"
 		if [ "${_cmp}" != "<" ]; then
 			return
 		fi
@@ -440,12 +500,26 @@ pkg_update() {
 
 		local _url=$(get_pkg_repo_url)
 		if [ $? -ne 0 ]; then
+			_debug "pkg_update failed to get repo url"
 			return
+		fi
+		_debug "pkg_update repo_url=${_url}"
+
+		if [ -n "${debug_enabled}" ]; then
+			local _meta_file
+			_meta_file=$(mktemp /tmp/pkg.meta.conf.XXXXXX) || _meta_file=""
+			if [ -n "${_meta_file}" ]; then
+				${_fetch_env} fetch ${_fetch_args} -o "${_meta_file}" \
+				    ${_url}/meta.conf >/dev/null 2>&1
+				_debug_file "${_meta_file}"
+				rm -f "${_meta_file}"
+			fi
 		fi
 
 		${_fetch_env} fetch ${_fetch_args} -o /dev/null \
 		    ${_url}/meta.conf >/dev/null 2>&1
 		if [ $? -eq 0 ]; then
+			_debug "pkg_update meta.conf detected, bootstrapping pkg"
 			_exec "${_pkg_binary} bootstrap -f" \
 			    "Bootstrap pkg due to meta version change"
 			pkg_update "${force}" "${_mute}" _do_not_bootstrap
@@ -456,6 +530,7 @@ pkg_update() {
 pkg_upgrade_repo() {
 	if [ -n "${reinstall_pkg}" ] \
 	    || [ -z "${NEW_MAJOR}" -a "$(compare_pkg_version pkg)" = "<" ]; then
+		_debug "pkg_upgrade_repo upgrading pkg reinstall_pkg=${reinstall_pkg:-0} NEW_MAJOR=${NEW_MAJOR:-0}"
 		pkg_unlock pkg
 		_exec "pkg-static upgrade${dont_update} pkg" "Upgrading pkg" \
 		    mute
@@ -466,6 +541,7 @@ pkg_upgrade_repo() {
 	local _repo_pkg="${product}-repo"
 
 	if ! is_pkg_installed ${_repo_pkg}; then
+		_debug "pkg_upgrade_repo installing ${_repo_pkg}"
 		_exec "pkg-static install${dont_update} ${_repo_pkg}" \
 		    "Installing ${_repo_pkg}" mute "" do_not_exit
 		if [ $? -ne 0 ]; then
@@ -494,6 +570,7 @@ pkg_upgrade_repo() {
 
 	cp /usr/local/etc/pkg/repos/${product}.conf /tmp/${product}.conf.copy
 	if !(is_ce && repo_is_plus_upgrade) ; then
+		_debug "pkg_upgrade_repo upgrading ${_repo_pkg} force='${_force}'"
 		_exec "pkg-static upgrade${dont_update}${_force} ${_repo_pkg}" \
 		    "Upgrading ${_repo_pkg}" mute
 	fi
@@ -519,6 +596,7 @@ upgrade_available() {
 	    | sed -e '/^$/d; /is locked and may not be modified/d' \
 	    | wc -l)
 
+	_debug "upgrade_available packages='${*}' lines=${_lines}"
 	test ${_lines} -gt 0
 	return $?
 }
@@ -666,9 +744,7 @@ pkg_upgrade() {
 	need_reboot=1
 	# First upgrade stage
 	if [ -z "${next_stage}" ]; then
-		if [ -f "${logfile}" ]; then
-			rm -f ${logfile}
-		fi
+		# Preserve existing logfile; do not delete
 
 		pkg_update force
 
@@ -1182,6 +1258,8 @@ compare_pkg_version_repo() {
 		_exit 1
 	fi
 
+	_debug "compare_pkg_version_repo pkg=${_pkg_name} local=${_lver} remote=${_rver} abi=${_abi}"
+	_debug "compare_pkg_version_repo rquery_cmd=env -u ABI -u ALTABI -u OSVERSION pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_db} -o REPO_CACHEDIR=${_repo_cache} -o ABI=${_abi} rquery -U %v ${_pkg_name}"
 	local _version=$(_pkg version -t ${_lver} ${_rver})
 
 	if [ $? -ne 0 ]; then
@@ -1228,14 +1306,19 @@ check_upgrade_repo_override() {
 	done
 
 	if [ -z "${_best_conf}" ]; then
+		_debug "check_upgrade_repo_override no repo override conf found"
 		return 1
 	fi
 
 	if [ -n "${_current_major}" -a "${_best_major}" -le "${_current_major}" ]; then
+		_debug "check_upgrade_repo_override best_major=${_best_major} current_major=${_current_major} skipping"
 		return 1
 	fi
 
 	get_repo_abi_values "${_best_conf}"
+
+	_debug "check_upgrade_repo_override using best_conf=${_best_conf} REPO_ABI=${REPO_ABI} REPO_ALTABI=${REPO_ALTABI}"
+	_debug_file "${_best_conf}"
 
 	local _repo_dir=$(prepare_repo_override_dir "${_best_conf}")
 	if [ -z "${_repo_dir}" ]; then
@@ -1274,6 +1357,7 @@ check_upgrade_repo_override() {
 
 		[ -z "${_new_version}" ] && continue
 
+		_debug "check_upgrade_repo_override package=${_package} new_version=${_new_version}"
 		[ -z "${_mute}" ] \
 		    && _echo \
 		    "${_new_version} version of ${product} is available"
@@ -1300,10 +1384,14 @@ check_upgrade_current_repo_override() {
 	fi
 
 	if [ -z "${_current_repo_target}" ]; then
+		_debug "check_upgrade_current_repo_override missing repo target"
 		return 1
 	fi
 
 	get_repo_abi_values "${_current_repo_target}"
+
+	_debug "check_upgrade_current_repo_override repo_conf=${_current_repo_target} REPO_ABI=${REPO_ABI} REPO_ALTABI=${REPO_ALTABI}"
+	_debug_file "${_current_repo_target}"
 
 	local _repo_dir=$(prepare_repo_override_dir "${_current_repo_target}")
 	if [ -z "${_repo_dir}" ]; then
@@ -1342,6 +1430,7 @@ check_upgrade_current_repo_override() {
 
 		[ -z "${_new_version}" ] && continue
 
+		_debug "check_upgrade_current_repo_override package=${_package} new_version=${_new_version}"
 		[ -z "${_mute}" ] \
 		    && _echo \
 		    "${_new_version} version of ${product} is available"
@@ -1361,9 +1450,11 @@ check_upgrade() {
 	    "%n ~ ${product}-kernel-* || %n ~ ${product}-base*" %n 2>/dev/null)
 	local _repo_behind=""
 
+	_debug "check_upgrade meta_pkg=${_meta_pkg} core_pkgs='${_core_pkgs}' NEW_MAJOR=${NEW_MAJOR:-0} action=${action}"
 	check_upgrade_current_repo_override "${_mute}" "${_skip_update}" \
 	    "${_meta_pkg}" "${_core_pkgs}"
 	if [ $? -eq 2 ]; then
+		_debug "check_upgrade current repo override has upgrade"
 		return 2
 	fi
 
@@ -1371,16 +1462,20 @@ check_upgrade() {
 		_exec "pkg-static bootstrap -f" \
 		    "Bootstrapping pkg due to ABI change" mute \
 		    ignore_result do_not_exit
+		_debug "check_upgrade bootstrap complete, forcing repo metadata refresh"
+		pkg_update force mute _do_not_bootstrap
 
 		check_upgrade_current_repo_override "${_mute}" "${_skip_update}" \
 		    "${_meta_pkg}" "${_core_pkgs}"
 		if [ $? -eq 2 ]; then
+			_debug "check_upgrade current repo override has upgrade after bootstrap"
 			return 2
 		fi
 
 		check_upgrade_repo_override "${_mute}" "${_skip_update}" \
 		    "${_meta_pkg}" "${_core_pkgs}"
 		if [ $? -eq 2 ]; then
+			_debug "check_upgrade repo override has upgrade"
 			return 2
 		fi
 
@@ -1390,6 +1485,7 @@ check_upgrade() {
 	fi
 
 	if [ -n "${NEW_MAJOR}" -a "${action}" != "upgrade" ]; then
+		_debug "check_upgrade NEW_MAJOR set and action not upgrade; returning up to date"
 		[ -z "${_mute}" ] \
 		    && _echo "Your system is up to date"
 		return 0
@@ -1419,15 +1515,18 @@ check_upgrade() {
 		_version_compare=$(compare_pkg_version ${_package})
 		case "${_version_compare}" in
 			=)
+				_debug "check_upgrade package=${_package} local=remote"
 				continue
 				;;
 			'>')
+				_debug "check_upgrade package=${_package} local newer"
 				_repo_behind=1
 				continue
 				;;
 		esac
 
 		local _new_version=$(_pkg rquery -U %v ${_package})
+		_debug "check_upgrade package=${_package} new_version=${_new_version}"
 		[ -z "${_mute}" ] \
 		    && _echo \
 		    "${_new_version} version of ${product} is available"
@@ -1437,6 +1536,7 @@ check_upgrade() {
 	check_upgrade_repo_override "${_mute}" "${_skip_update}" \
 	    "${_meta_pkg}" "${_core_pkgs}"
 	if [ $? -eq 2 ]; then
+		_debug "check_upgrade repo override has upgrade"
 		return 2
 	fi
 
@@ -1493,6 +1593,8 @@ compare_pkg_version() {
 		_exit 1
 	fi
 
+	_debug "compare_pkg_version pkg=${_pkg_name} local=${_lver} remote=${_rver}"
+	_debug "compare_pkg_version rquery_cmd=pkg-static rquery -U %v ${_pkg_name}"
 	local _version=$(_pkg version -t ${_lver} ${_rver})
 
 	if [ $? -ne 0 ]; then
@@ -1645,6 +1747,12 @@ validate_repo_conf() {
 			ln -sf ${pkg_repo_conf_path} ${pkg_repo_conf}
 		fi
 	fi
+
+	_debug "validate_repo_conf repo_conf_path=${pkg_repo_conf_path} repo_conf=${pkg_repo_conf}"
+	_debug "validate_repo_conf repo_dir=/usr/local/share/${product}/pkg/repos"
+	_debug_file "${pkg_repo_conf_path}"
+	_debug_file "/usr/local/share/${product}/pkg/repos/${product}-repo.conf"
+	_debug_file "/usr/local/share/${product}/pkg/repos/${product}-repo-previous.conf"
 }
 
 export LANG=C
@@ -1755,7 +1863,8 @@ while getopts 46b:cdfi:hp:l:nr:RuUy opt; do
 		c)
 			action="check"
 			;;
-		d)
+	d)
+			debug_enabled=1
 			stdout=''
 			;;
 		f)
@@ -1827,6 +1936,11 @@ elif [ -n "${force_ipv6}" ]; then
 	export IP_VERSION="6"
 fi
 
+if [ "${DEBUG_DEFAULT}" = "1" ]; then
+	debug_enabled=1
+	stdout=''
+fi
+
 # Flags used to determine if all packages must be reinstalled
 pkg_set_version="/usr/local/share/${product}/next_pkg_set_version"
 running_pkg_set_version="/usr/local/share/${product}/running_pkg_set_version"
@@ -1838,8 +1952,10 @@ if [ ! -f ${running_pkg_set_version} ]; then
 fi
 
 # Force debug if /cf/conf/upgrade_debug is present
-[ -f "/cf/conf/upgrade_debug" ] \
-    && stdout=''
+if [ -f "/cf/conf/upgrade_debug" ]; then
+	debug_enabled=1
+	stdout=''
+fi
 
 # Set default action when no parameter is set
 : ${action:="upgrade"}
@@ -1868,9 +1984,7 @@ if [ -n "${booting}" ]; then
 	export REPO_AUTOUPDATE=false
 fi
 
-if [ "${action}" != "upgrade" -a -f "${logfile}" ]; then
-	rm -f ${logfile}
-fi
+# Preserve existing logfile; do not delete
 
 progress_file=${logfile%.*}.json
 

--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -293,23 +293,19 @@ abi_setup() {
 	fi
 
 	local _repo_abi_file=$(readlink ${_pkg_repo_conf})
+	local _repo_abi="${CUR_ABI}"
+	local _repo_altabi="${CUR_ALTABI}"
 
 	if [ -f ${_repo_abi_file%%.conf}.abi ]; then
-		ABI=$(cat ${_repo_abi_file%%.conf}.abi)
-	else
-		ABI=${CUR_ABI}
+		_repo_abi=$(cat ${_repo_abi_file%%.conf}.abi)
 	fi
 
 	if [ -f ${_repo_abi_file%%.conf}.altabi ]; then
-		ALTABI=$(cat ${_repo_abi_file%%.conf}.altabi)
-	else
-		ALTABI=${CUR_ALTABI}
+		_repo_altabi=$(cat ${_repo_abi_file%%.conf}.altabi)
 	fi
 
-	# Make sure pkg.conf is set properly so GUI can work
-	OSVERSION=$(sysctl -n kern.osreldate)
-	echo "ABI=${ABI}" > /usr/local/etc/pkg.conf
-	echo "OSVERSION=${OSVERSION}" >> /usr/local/etc/pkg.conf
+	ABI="${_repo_abi}"
+	ALTABI="${_repo_altabi}"
 
 	AUTH_CA="/etc/ssl/netgate-ca.pem"
 	AUTH_CERT="/etc/ssl/pfSense-repo-custom.cert"
@@ -342,14 +338,25 @@ EOF
 		reinstall_pkg=1
 	fi
 
-	if [ "${CUR_ABI}" = "${ABI}" -o "${CUR_ABI}" = "${ALTABI}" ] ; then
+	if [ "${CUR_ABI}" = "${_repo_abi}" -o "${CUR_ABI}" = "${_repo_altabi}" ] ; then
 		NEW_MAJOR=""
 	else
 		NEW_MAJOR=1
-		export IGNORE_OSVERSION=yes
 	fi
 
-	export CUR_ABI CUR_ALTABI ABI ALTABI NEW_MAJOR
+	if [ -n "${NEW_MAJOR}" -a "${action}" != "upgrade" ]; then
+		ABI="${CUR_ABI}"
+		ALTABI="${CUR_ALTABI}"
+	else
+		[ -n "${NEW_MAJOR}" ] && export IGNORE_OSVERSION=yes
+	fi
+
+	# Make sure pkg.conf is set properly so GUI can work
+	OSVERSION=$(sysctl -n kern.osreldate)
+	echo "ABI=${ABI}" > /usr/local/etc/pkg.conf
+	echo "OSVERSION=${OSVERSION}" >> /usr/local/etc/pkg.conf
+
+	export CUR_ABI CUR_ALTABI ABI NEW_MAJOR
 }
 
 get_pkg_repo_url() {
@@ -1134,7 +1141,6 @@ compare_pkg_version_repo() {
 	local _pkg_name="${1}"
 	local _repo_dir="${2}"
 	local _abi="${3}"
-	local _altabi="${4}"
 
 	if [ -z "${_pkg_name}" ]; then
 		echo '!'
@@ -1154,12 +1160,20 @@ compare_pkg_version_repo() {
 		_exit 1
 	fi
 
-	local _rver=$(pkg-static -o REPOS_DIR=${_repo_dir} \
-	    -o ABI=${_abi} -o ALTABI=${_altabi} rquery -U %v ${_pkg_name})
+	local _repo_cache="${_repo_dir}/cache"
+	local _repo_db="${_repo_dir}/db"
+	mkdir -p "${_repo_cache}" "${_repo_db}"
+
+	local _rver=$(env -u ABI -u ALTABI -u OSVERSION \
+	    pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_db} \
+	    -o REPO_CACHEDIR=${_repo_cache} -o ABI=${_abi} \
+	    rquery -U %v ${_pkg_name})
 
 	if [ -z "${_rver}" ]; then
-		_rver=$(pkg-static -o REPOS_DIR=${_repo_dir} \
-		    -o ABI=${_abi} -o ALTABI=${_altabi} rquery %v ${_pkg_name})
+		_rver=$(env -u ABI -u ALTABI -u OSVERSION \
+		    pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_db} \
+		    -o REPO_CACHEDIR=${_repo_cache} -o ABI=${_abi} \
+		    rquery %v ${_pkg_name})
 	fi
 
 	if [ -z "${_rver}" ]; then
@@ -1229,8 +1243,10 @@ check_upgrade_repo_override() {
 	fi
 
 	if [ -z "${_skip_update}" -a -z "${dont_update}" ]; then
-		pkg-static -o REPOS_DIR=${_repo_dir} -o ABI=${REPO_ABI} \
-		    -o ALTABI=${REPO_ALTABI} update -f >/dev/null 2>&1
+		env -u ABI -u ALTABI -u OSVERSION \
+		    pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_dir}/db \
+		    -o REPO_CACHEDIR=${_repo_dir}/cache -o ABI=${REPO_ABI} \
+		    update -f >/dev/null 2>&1
 	fi
 
 	for _package in ${_meta_pkg} ${_core_pkgs}; do
@@ -1243,15 +1259,88 @@ check_upgrade_repo_override() {
 				;;
 		esac
 
-		local _new_version=$(pkg-static -o REPOS_DIR=${_repo_dir} \
-		    -o ABI=${REPO_ABI} -o ALTABI=${REPO_ALTABI} \
+		local _new_version=$(env -u ABI -u ALTABI -u OSVERSION \
+		    pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_dir}/db \
+		    -o REPO_CACHEDIR=${_repo_dir}/cache -o ABI=${REPO_ABI} \
 		    rquery -U %v ${_package})
 
 		if [ -z "${_new_version}" ]; then
-			_new_version=$(pkg-static -o REPOS_DIR=${_repo_dir} \
-			    -o ABI=${REPO_ABI} -o ALTABI=${REPO_ALTABI} \
+			_new_version=$(env -u ABI -u ALTABI -u OSVERSION \
+			    pkg-static -o REPOS_DIR=${_repo_dir} \
+			    -o PKG_DBDIR=${_repo_dir}/db \
+			    -o REPO_CACHEDIR=${_repo_dir}/cache -o ABI=${REPO_ABI} \
 			    rquery %v ${_package})
 		fi
+
+		[ -z "${_new_version}" ] && continue
+
+		[ -z "${_mute}" ] \
+		    && _echo \
+		    "${_new_version} version of ${product} is available"
+		cleanup_repo_override_dir "${_repo_dir}"
+		return 2
+	done
+
+	cleanup_repo_override_dir "${_repo_dir}"
+	return 1
+}
+
+check_upgrade_current_repo_override() {
+	local _mute="${1}"
+	local _skip_update="${2}"
+	local _meta_pkg="${3}"
+	local _core_pkgs="${4}"
+	local _current_repo_conf="/usr/local/etc/pkg/repos/${product}.conf"
+	local _current_repo_target=""
+
+	if [ -L "${_current_repo_conf}" ]; then
+		_current_repo_target=$(readlink ${_current_repo_conf})
+	elif [ -f "${_current_repo_conf}" ]; then
+		_current_repo_target="${_current_repo_conf}"
+	fi
+
+	if [ -z "${_current_repo_target}" ]; then
+		return 1
+	fi
+
+	get_repo_abi_values "${_current_repo_target}"
+
+	local _repo_dir=$(prepare_repo_override_dir "${_current_repo_target}")
+	if [ -z "${_repo_dir}" ]; then
+		return 1
+	fi
+
+	if [ -z "${_skip_update}" -a -z "${dont_update}" ]; then
+		env -u ABI -u ALTABI -u OSVERSION \
+		    pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_dir}/db \
+		    -o REPO_CACHEDIR=${_repo_dir}/cache -o ABI=${REPO_ABI} \
+		    update -f >/dev/null 2>&1
+	fi
+
+	for _package in ${_meta_pkg} ${_core_pkgs}; do
+		local _version_compare=$(compare_pkg_version_repo ${_package} \
+		    ${_repo_dir} ${REPO_ABI} ${REPO_ALTABI})
+
+		case "${_version_compare}" in
+			=|'>')
+				continue
+				;;
+		esac
+
+		local _new_version=$(env -u ABI -u ALTABI -u OSVERSION \
+		    pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_dir}/db \
+		    -o REPO_CACHEDIR=${_repo_dir}/cache -o ABI=${REPO_ABI} \
+		    rquery -U %v ${_package})
+
+		if [ -z "${_new_version}" ]; then
+			_new_version=$(env -u ABI -u ALTABI -u OSVERSION \
+			    pkg-static -o REPOS_DIR=${_repo_dir} \
+			    -o PKG_DBDIR=${_repo_dir}/db \
+			    -o REPO_CACHEDIR=${_repo_dir}/cache -o ABI=${REPO_ABI} \
+			    rquery %v ${_package})
+		fi
+
+		[ -z "${_new_version}" ] && continue
 
 		[ -z "${_mute}" ] \
 		    && _echo \
@@ -1271,6 +1360,18 @@ check_upgrade() {
 	local _core_pkgs=$(pkg-static query -e \
 	    "%n ~ ${product}-kernel-* || %n ~ ${product}-base*" %n 2>/dev/null)
 	local _repo_behind=""
+
+	check_upgrade_current_repo_override "${_mute}" "${_skip_update}" \
+	    "${_meta_pkg}" "${_core_pkgs}"
+	if [ $? -eq 2 ]; then
+		return 2
+	fi
+
+	if [ -n "${NEW_MAJOR}" -a "${action}" != "upgrade" ]; then
+		[ -z "${_mute}" ] \
+		    && _echo "Your system is up to date"
+		return 0
+	fi
 
 	# Do not upgrade while wg interfaces are assigned
 	if sed '/<interfaces>/,/<\/interfaces>/!d' /cf/conf/config.xml \

--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -293,18 +293,19 @@ abi_setup() {
 	fi
 
 	local _repo_abi_file=$(readlink ${_pkg_repo_conf})
+	local _repo_abi="${CUR_ABI}"
+	local _repo_altabi="${CUR_ALTABI}"
 
 	if [ -f ${_repo_abi_file%%.conf}.abi ]; then
-		ABI=$(cat ${_repo_abi_file%%.conf}.abi)
-	else
-		ABI=${CUR_ABI}
+		_repo_abi=$(cat ${_repo_abi_file%%.conf}.abi)
 	fi
 
 	if [ -f ${_repo_abi_file%%.conf}.altabi ]; then
-		ALTABI=$(cat ${_repo_abi_file%%.conf}.altabi)
-	else
-		ALTABI=${CUR_ALTABI}
+		_repo_altabi=$(cat ${_repo_abi_file%%.conf}.altabi)
 	fi
+
+	ABI="${_repo_abi}"
+	ALTABI="${_repo_altabi}"
 
 	# Make sure pkg.conf is set properly so GUI can work
 	OSVERSION=$(sysctl -n kern.osreldate)
@@ -342,11 +343,17 @@ EOF
 		reinstall_pkg=1
 	fi
 
-	if [ "${CUR_ABI}" = "${ABI}" -o "${CUR_ABI}" = "${ALTABI}" ] ; then
+	if [ "${CUR_ABI}" = "${_repo_abi}" -o "${CUR_ABI}" = "${_repo_altabi}" ] ; then
 		NEW_MAJOR=""
 	else
 		NEW_MAJOR=1
-		export IGNORE_OSVERSION=yes
+	fi
+
+	if [ -n "${NEW_MAJOR}" -a "${action}" != "upgrade" ]; then
+		ABI="${CUR_ABI}"
+		ALTABI="${CUR_ALTABI}"
+	else
+		[ -n "${NEW_MAJOR}" ] && export IGNORE_OSVERSION=yes
 	fi
 
 	export CUR_ABI CUR_ALTABI ABI ALTABI NEW_MAJOR

--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -293,23 +293,19 @@ abi_setup() {
 	fi
 
 	local _repo_abi_file=$(readlink ${_pkg_repo_conf})
+	local _repo_abi="${CUR_ABI}"
+	local _repo_altabi="${CUR_ALTABI}"
 
 	if [ -f ${_repo_abi_file%%.conf}.abi ]; then
-		ABI=$(cat ${_repo_abi_file%%.conf}.abi)
-	else
-		ABI=${CUR_ABI}
+		_repo_abi=$(cat ${_repo_abi_file%%.conf}.abi)
 	fi
 
 	if [ -f ${_repo_abi_file%%.conf}.altabi ]; then
-		ALTABI=$(cat ${_repo_abi_file%%.conf}.altabi)
-	else
-		ALTABI=${CUR_ALTABI}
+		_repo_altabi=$(cat ${_repo_abi_file%%.conf}.altabi)
 	fi
 
-	# Make sure pkg.conf is set properly so GUI can work
-	OSVERSION=$(sysctl -n kern.osreldate)
-	echo "ABI=${ABI}" > /usr/local/etc/pkg.conf
-	echo "OSVERSION=${OSVERSION}" >> /usr/local/etc/pkg.conf
+	ABI="${_repo_abi}"
+	ALTABI="${_repo_altabi}"
 
 	AUTH_CA="/etc/ssl/netgate-ca.pem"
 	AUTH_CERT="/etc/ssl/pfSense-repo-custom.cert"
@@ -342,12 +338,24 @@ EOF
 		reinstall_pkg=1
 	fi
 
-	if [ "${CUR_ABI}" = "${ABI}" -o "${CUR_ABI}" = "${ALTABI}" ] ; then
+	if [ "${CUR_ABI}" = "${_repo_abi}" -o "${CUR_ABI}" = "${_repo_altabi}" ] ; then
 		NEW_MAJOR=""
 	else
 		NEW_MAJOR=1
-		export IGNORE_OSVERSION=yes
 	fi
+
+	if [ -n "${NEW_MAJOR}" -a "${action}" != "upgrade" ]; then
+		ABI="${CUR_ABI}"
+		ALTABI="${CUR_ALTABI}"
+	else
+		[ -n "${NEW_MAJOR}" ] && export IGNORE_OSVERSION=yes
+	fi
+
+	# Make sure pkg.conf is set properly so GUI can work
+	OSVERSION=$(sysctl -n kern.osreldate)
+	echo "ABI=${ABI}" > /usr/local/etc/pkg.conf
+	echo "OSVERSION=${OSVERSION}" >> /usr/local/etc/pkg.conf
+	[ -n "${ALTABI}" ] && echo "ALTABI=${ALTABI}" >> /usr/local/etc/pkg.conf
 
 	export CUR_ABI CUR_ALTABI ABI ALTABI NEW_MAJOR
 }
@@ -1154,11 +1162,17 @@ compare_pkg_version_repo() {
 		_exit 1
 	fi
 
-	local _rver=$(pkg-static -o REPOS_DIR=${_repo_dir} \
+	local _repo_cache="${_repo_dir}/cache"
+	mkdir -p "${_repo_cache}"
+
+	local _rver=$(env -u ABI -u ALTABI -u OSVERSION \
+	    pkg-static -o REPOS_DIR=${_repo_dir} -o REPO_CACHEDIR=${_repo_cache} \
 	    -o ABI=${_abi} -o ALTABI=${_altabi} rquery -U %v ${_pkg_name})
 
 	if [ -z "${_rver}" ]; then
-		_rver=$(pkg-static -o REPOS_DIR=${_repo_dir} \
+		_rver=$(env -u ABI -u ALTABI -u OSVERSION \
+		    pkg-static -o REPOS_DIR=${_repo_dir} \
+		    -o REPO_CACHEDIR=${_repo_cache} \
 		    -o ABI=${_abi} -o ALTABI=${_altabi} rquery %v ${_pkg_name})
 	fi
 
@@ -1229,8 +1243,11 @@ check_upgrade_repo_override() {
 	fi
 
 	if [ -z "${_skip_update}" -a -z "${dont_update}" ]; then
-		pkg-static -o REPOS_DIR=${_repo_dir} -o ABI=${REPO_ABI} \
-		    -o ALTABI=${REPO_ALTABI} update -f >/dev/null 2>&1
+		env -u ABI -u ALTABI -u OSVERSION \
+		    pkg-static -o REPOS_DIR=${_repo_dir} \
+		    -o REPO_CACHEDIR=${_repo_dir}/cache \
+		    -o ABI=${REPO_ABI} -o ALTABI=${REPO_ALTABI} \
+		    update -f >/dev/null 2>&1
 	fi
 
 	for _package in ${_meta_pkg} ${_core_pkgs}; do
@@ -1243,15 +1260,91 @@ check_upgrade_repo_override() {
 				;;
 		esac
 
-		local _new_version=$(pkg-static -o REPOS_DIR=${_repo_dir} \
+		local _new_version=$(env -u ABI -u ALTABI -u OSVERSION \
+		    pkg-static -o REPOS_DIR=${_repo_dir} \
+		    -o REPO_CACHEDIR=${_repo_dir}/cache \
 		    -o ABI=${REPO_ABI} -o ALTABI=${REPO_ALTABI} \
 		    rquery -U %v ${_package})
 
 		if [ -z "${_new_version}" ]; then
-			_new_version=$(pkg-static -o REPOS_DIR=${_repo_dir} \
+			_new_version=$(env -u ABI -u ALTABI -u OSVERSION \
+			    pkg-static -o REPOS_DIR=${_repo_dir} \
+			    -o REPO_CACHEDIR=${_repo_dir}/cache \
 			    -o ABI=${REPO_ABI} -o ALTABI=${REPO_ALTABI} \
 			    rquery %v ${_package})
 		fi
+
+		[ -z "${_new_version}" ] && continue
+
+		[ -z "${_mute}" ] \
+		    && _echo \
+		    "${_new_version} version of ${product} is available"
+		cleanup_repo_override_dir "${_repo_dir}"
+		return 2
+	done
+
+	cleanup_repo_override_dir "${_repo_dir}"
+	return 1
+}
+
+check_upgrade_current_repo_override() {
+	local _mute="${1}"
+	local _skip_update="${2}"
+	local _meta_pkg="${3}"
+	local _core_pkgs="${4}"
+	local _current_repo_conf="/usr/local/etc/pkg/repos/${product}.conf"
+	local _current_repo_target=""
+
+	if [ -L "${_current_repo_conf}" ]; then
+		_current_repo_target=$(readlink ${_current_repo_conf})
+	elif [ -f "${_current_repo_conf}" ]; then
+		_current_repo_target="${_current_repo_conf}"
+	fi
+
+	if [ -z "${_current_repo_target}" ]; then
+		return 1
+	fi
+
+	get_repo_abi_values "${_current_repo_target}"
+
+	local _repo_dir=$(prepare_repo_override_dir "${_current_repo_target}")
+	if [ -z "${_repo_dir}" ]; then
+		return 1
+	fi
+
+	if [ -z "${_skip_update}" -a -z "${dont_update}" ]; then
+		env -u ABI -u ALTABI -u OSVERSION \
+		    pkg-static -o REPOS_DIR=${_repo_dir} \
+		    -o REPO_CACHEDIR=${_repo_dir}/cache \
+		    -o ABI=${REPO_ABI} -o ALTABI=${REPO_ALTABI} \
+		    update -f >/dev/null 2>&1
+	fi
+
+	for _package in ${_meta_pkg} ${_core_pkgs}; do
+		local _version_compare=$(compare_pkg_version_repo ${_package} \
+		    ${_repo_dir} ${REPO_ABI} ${REPO_ALTABI})
+
+		case "${_version_compare}" in
+			=|'>')
+				continue
+				;;
+		esac
+
+		local _new_version=$(env -u ABI -u ALTABI -u OSVERSION \
+		    pkg-static -o REPOS_DIR=${_repo_dir} \
+		    -o REPO_CACHEDIR=${_repo_dir}/cache \
+		    -o ABI=${REPO_ABI} -o ALTABI=${REPO_ALTABI} \
+		    rquery -U %v ${_package})
+
+		if [ -z "${_new_version}" ]; then
+			_new_version=$(env -u ABI -u ALTABI -u OSVERSION \
+			    pkg-static -o REPOS_DIR=${_repo_dir} \
+			    -o REPO_CACHEDIR=${_repo_dir}/cache \
+			    -o ABI=${REPO_ABI} -o ALTABI=${REPO_ALTABI} \
+			    rquery %v ${_package})
+		fi
+
+		[ -z "${_new_version}" ] && continue
 
 		[ -z "${_mute}" ] \
 		    && _echo \
@@ -1271,6 +1364,17 @@ check_upgrade() {
 	local _core_pkgs=$(pkg-static query -e \
 	    "%n ~ ${product}-kernel-* || %n ~ ${product}-base*" %n 2>/dev/null)
 	local _repo_behind=""
+
+	if [ -n "${NEW_MAJOR}" -a "${action}" != "upgrade" ]; then
+		check_upgrade_current_repo_override "${_mute}" "${_skip_update}" \
+		    "${_meta_pkg}" "${_core_pkgs}"
+		if [ $? -eq 2 ]; then
+			return 2
+		fi
+		[ -z "${_mute}" ] \
+		    && _echo "Your system is up to date"
+		return 0
+	fi
 
 	# Do not upgrade while wg interfaces are assigned
 	if sed '/<interfaces>/,/<\/interfaces>/!d' /cf/conf/config.xml \

--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -293,23 +293,19 @@ abi_setup() {
 	fi
 
 	local _repo_abi_file=$(readlink ${_pkg_repo_conf})
+	local _repo_abi="${CUR_ABI}"
+	local _repo_altabi="${CUR_ALTABI}"
 
 	if [ -f ${_repo_abi_file%%.conf}.abi ]; then
-		ABI=$(cat ${_repo_abi_file%%.conf}.abi)
-	else
-		ABI=${CUR_ABI}
+		_repo_abi=$(cat ${_repo_abi_file%%.conf}.abi)
 	fi
 
 	if [ -f ${_repo_abi_file%%.conf}.altabi ]; then
-		ALTABI=$(cat ${_repo_abi_file%%.conf}.altabi)
-	else
-		ALTABI=${CUR_ALTABI}
+		_repo_altabi=$(cat ${_repo_abi_file%%.conf}.altabi)
 	fi
 
-	# Make sure pkg.conf is set properly so GUI can work
-	OSVERSION=$(sysctl -n kern.osreldate)
-	echo "ABI=${ABI}" > /usr/local/etc/pkg.conf
-	echo "OSVERSION=${OSVERSION}" >> /usr/local/etc/pkg.conf
+	ABI="${_repo_abi}"
+	ALTABI="${_repo_altabi}"
 
 	AUTH_CA="/etc/ssl/netgate-ca.pem"
 	AUTH_CERT="/etc/ssl/pfSense-repo-custom.cert"
@@ -342,12 +338,24 @@ EOF
 		reinstall_pkg=1
 	fi
 
-	if [ "${CUR_ABI}" = "${ABI}" -o "${CUR_ABI}" = "${ALTABI}" ] ; then
+	if [ "${CUR_ABI}" = "${_repo_abi}" -o "${CUR_ABI}" = "${_repo_altabi}" ] ; then
 		NEW_MAJOR=""
 	else
 		NEW_MAJOR=1
-		export IGNORE_OSVERSION=yes
 	fi
+
+	if [ -n "${NEW_MAJOR}" -a "${action}" != "upgrade" ]; then
+		ABI="${CUR_ABI}"
+		ALTABI="${CUR_ALTABI}"
+	else
+		[ -n "${NEW_MAJOR}" ] && export IGNORE_OSVERSION=yes
+	fi
+
+	# Make sure pkg.conf is set properly so GUI can work
+	OSVERSION=$(sysctl -n kern.osreldate)
+	echo "ABI=${ABI}" > /usr/local/etc/pkg.conf
+	echo "OSVERSION=${OSVERSION}" >> /usr/local/etc/pkg.conf
+	[ -n "${ALTABI}" ] && echo "ALTABI=${ALTABI}" >> /usr/local/etc/pkg.conf
 
 	export CUR_ABI CUR_ALTABI ABI ALTABI NEW_MAJOR
 }
@@ -1264,6 +1272,67 @@ check_upgrade_repo_override() {
 	return 1
 }
 
+check_upgrade_current_repo_override() {
+	local _mute="${1}"
+	local _skip_update="${2}"
+	local _meta_pkg="${3}"
+	local _core_pkgs="${4}"
+	local _current_repo_conf="/usr/local/etc/pkg/repos/${product}.conf"
+	local _current_repo_target=""
+
+	if [ -L "${_current_repo_conf}" ]; then
+		_current_repo_target=$(readlink ${_current_repo_conf})
+	elif [ -f "${_current_repo_conf}" ]; then
+		_current_repo_target="${_current_repo_conf}"
+	fi
+
+	if [ -z "${_current_repo_target}" ]; then
+		return 1
+	fi
+
+	get_repo_abi_values "${_current_repo_target}"
+
+	local _repo_dir=$(prepare_repo_override_dir "${_current_repo_target}")
+	if [ -z "${_repo_dir}" ]; then
+		return 1
+	fi
+
+	if [ -z "${_skip_update}" -a -z "${dont_update}" ]; then
+		pkg-static -o REPOS_DIR=${_repo_dir} -o ABI=${REPO_ABI} \
+		    -o ALTABI=${REPO_ALTABI} update -f >/dev/null 2>&1
+	fi
+
+	for _package in ${_meta_pkg} ${_core_pkgs}; do
+		local _version_compare=$(compare_pkg_version_repo ${_package} \
+		    ${_repo_dir} ${REPO_ABI} ${REPO_ALTABI})
+
+		case "${_version_compare}" in
+			=|'>')
+				continue
+				;;
+		esac
+
+		local _new_version=$(pkg-static -o REPOS_DIR=${_repo_dir} \
+		    -o ABI=${REPO_ABI} -o ALTABI=${REPO_ALTABI} \
+		    rquery -U %v ${_package})
+
+		if [ -z "${_new_version}" ]; then
+			_new_version=$(pkg-static -o REPOS_DIR=${_repo_dir} \
+			    -o ABI=${REPO_ABI} -o ALTABI=${REPO_ALTABI} \
+			    rquery %v ${_package})
+		fi
+
+		[ -z "${_mute}" ] \
+		    && _echo \
+		    "${_new_version} version of ${product} is available"
+		cleanup_repo_override_dir "${_repo_dir}"
+		return 2
+	done
+
+	cleanup_repo_override_dir "${_repo_dir}"
+	return 1
+}
+
 check_upgrade() {
 	local _mute="$1"
 	local _skip_update="$2"
@@ -1271,6 +1340,17 @@ check_upgrade() {
 	local _core_pkgs=$(pkg-static query -e \
 	    "%n ~ ${product}-kernel-* || %n ~ ${product}-base*" %n 2>/dev/null)
 	local _repo_behind=""
+
+	if [ -n "${NEW_MAJOR}" -a "${action}" != "upgrade" ]; then
+		check_upgrade_current_repo_override "${_mute}" "${_skip_update}" \
+		    "${_meta_pkg}" "${_core_pkgs}"
+		if [ $? -eq 2 ]; then
+			return 2
+		fi
+		[ -z "${_mute}" ] \
+		    && _echo "Your system is up to date"
+		return 0
+	fi
 
 	# Do not upgrade while wg interfaces are assigned
 	if sed '/<interfaces>/,/<\/interfaces>/!d' /cf/conf/config.xml \

--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -293,23 +293,19 @@ abi_setup() {
 	fi
 
 	local _repo_abi_file=$(readlink ${_pkg_repo_conf})
+	local _repo_abi="${CUR_ABI}"
+	local _repo_altabi="${CUR_ALTABI}"
 
 	if [ -f ${_repo_abi_file%%.conf}.abi ]; then
-		ABI=$(cat ${_repo_abi_file%%.conf}.abi)
-	else
-		ABI=${CUR_ABI}
+		_repo_abi=$(cat ${_repo_abi_file%%.conf}.abi)
 	fi
 
 	if [ -f ${_repo_abi_file%%.conf}.altabi ]; then
-		ALTABI=$(cat ${_repo_abi_file%%.conf}.altabi)
-	else
-		ALTABI=${CUR_ALTABI}
+		_repo_altabi=$(cat ${_repo_abi_file%%.conf}.altabi)
 	fi
 
-	# Make sure pkg.conf is set properly so GUI can work
-	OSVERSION=$(sysctl -n kern.osreldate)
-	echo "ABI=${ABI}" > /usr/local/etc/pkg.conf
-	echo "OSVERSION=${OSVERSION}" >> /usr/local/etc/pkg.conf
+	ABI="${_repo_abi}"
+	ALTABI="${_repo_altabi}"
 
 	AUTH_CA="/etc/ssl/netgate-ca.pem"
 	AUTH_CERT="/etc/ssl/pfSense-repo-custom.cert"
@@ -342,12 +338,24 @@ EOF
 		reinstall_pkg=1
 	fi
 
-	if [ "${CUR_ABI}" = "${ABI}" -o "${CUR_ABI}" = "${ALTABI}" ] ; then
+	if [ "${CUR_ABI}" = "${_repo_abi}" -o "${CUR_ABI}" = "${_repo_altabi}" ] ; then
 		NEW_MAJOR=""
 	else
 		NEW_MAJOR=1
-		export IGNORE_OSVERSION=yes
 	fi
+
+	if [ -n "${NEW_MAJOR}" -a "${action}" != "upgrade" ]; then
+		ABI="${CUR_ABI}"
+		ALTABI="${CUR_ALTABI}"
+	else
+		[ -n "${NEW_MAJOR}" ] && export IGNORE_OSVERSION=yes
+	fi
+
+	# Make sure pkg.conf is set properly so GUI can work
+	OSVERSION=$(sysctl -n kern.osreldate)
+	echo "ABI=${ABI}" > /usr/local/etc/pkg.conf
+	echo "OSVERSION=${OSVERSION}" >> /usr/local/etc/pkg.conf
+	[ -n "${ALTABI}" ] && echo "ALTABI=${ALTABI}" >> /usr/local/etc/pkg.conf
 
 	export CUR_ABI CUR_ALTABI ABI ALTABI NEW_MAJOR
 }
@@ -1134,7 +1142,6 @@ compare_pkg_version_repo() {
 	local _pkg_name="${1}"
 	local _repo_dir="${2}"
 	local _abi="${3}"
-	local _altabi="${4}"
 
 	if [ -z "${_pkg_name}" ]; then
 		echo '!'
@@ -1154,12 +1161,20 @@ compare_pkg_version_repo() {
 		_exit 1
 	fi
 
-	local _rver=$(pkg-static -o REPOS_DIR=${_repo_dir} \
-	    -o ABI=${_abi} -o ALTABI=${_altabi} rquery -U %v ${_pkg_name})
+	local _repo_cache="${_repo_dir}/cache"
+	local _repo_db="${_repo_dir}/db"
+	mkdir -p "${_repo_cache}" "${_repo_db}"
+
+	local _rver=$(env -u ABI -u ALTABI -u OSVERSION \
+	    pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_db} \
+	    -o REPO_CACHEDIR=${_repo_cache} -o ABI=${_abi} \
+	    rquery -U %v ${_pkg_name})
 
 	if [ -z "${_rver}" ]; then
-		_rver=$(pkg-static -o REPOS_DIR=${_repo_dir} \
-		    -o ABI=${_abi} -o ALTABI=${_altabi} rquery %v ${_pkg_name})
+		_rver=$(env -u ABI -u ALTABI -u OSVERSION \
+		    pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_db} \
+		    -o REPO_CACHEDIR=${_repo_cache} -o ABI=${_abi} \
+		    rquery %v ${_pkg_name})
 	fi
 
 	if [ -z "${_rver}" ]; then
@@ -1229,8 +1244,10 @@ check_upgrade_repo_override() {
 	fi
 
 	if [ -z "${_skip_update}" -a -z "${dont_update}" ]; then
-		pkg-static -o REPOS_DIR=${_repo_dir} -o ABI=${REPO_ABI} \
-		    -o ALTABI=${REPO_ALTABI} update -f >/dev/null 2>&1
+		env -u ABI -u ALTABI -u OSVERSION \
+		    pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_dir}/db \
+		    -o REPO_CACHEDIR=${_repo_dir}/cache -o ABI=${REPO_ABI} \
+		    update -f >/dev/null 2>&1
 	fi
 
 	for _package in ${_meta_pkg} ${_core_pkgs}; do
@@ -1243,15 +1260,88 @@ check_upgrade_repo_override() {
 				;;
 		esac
 
-		local _new_version=$(pkg-static -o REPOS_DIR=${_repo_dir} \
-		    -o ABI=${REPO_ABI} -o ALTABI=${REPO_ALTABI} \
+		local _new_version=$(env -u ABI -u ALTABI -u OSVERSION \
+		    pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_dir}/db \
+		    -o REPO_CACHEDIR=${_repo_dir}/cache -o ABI=${REPO_ABI} \
 		    rquery -U %v ${_package})
 
 		if [ -z "${_new_version}" ]; then
-			_new_version=$(pkg-static -o REPOS_DIR=${_repo_dir} \
-			    -o ABI=${REPO_ABI} -o ALTABI=${REPO_ALTABI} \
+			_new_version=$(env -u ABI -u ALTABI -u OSVERSION \
+			    pkg-static -o REPOS_DIR=${_repo_dir} \
+			    -o PKG_DBDIR=${_repo_dir}/db \
+			    -o REPO_CACHEDIR=${_repo_dir}/cache -o ABI=${REPO_ABI} \
 			    rquery %v ${_package})
 		fi
+
+		[ -z "${_new_version}" ] && continue
+
+		[ -z "${_mute}" ] \
+		    && _echo \
+		    "${_new_version} version of ${product} is available"
+		cleanup_repo_override_dir "${_repo_dir}"
+		return 2
+	done
+
+	cleanup_repo_override_dir "${_repo_dir}"
+	return 1
+}
+
+check_upgrade_current_repo_override() {
+	local _mute="${1}"
+	local _skip_update="${2}"
+	local _meta_pkg="${3}"
+	local _core_pkgs="${4}"
+	local _current_repo_conf="/usr/local/etc/pkg/repos/${product}.conf"
+	local _current_repo_target=""
+
+	if [ -L "${_current_repo_conf}" ]; then
+		_current_repo_target=$(readlink ${_current_repo_conf})
+	elif [ -f "${_current_repo_conf}" ]; then
+		_current_repo_target="${_current_repo_conf}"
+	fi
+
+	if [ -z "${_current_repo_target}" ]; then
+		return 1
+	fi
+
+	get_repo_abi_values "${_current_repo_target}"
+
+	local _repo_dir=$(prepare_repo_override_dir "${_current_repo_target}")
+	if [ -z "${_repo_dir}" ]; then
+		return 1
+	fi
+
+	if [ -z "${_skip_update}" -a -z "${dont_update}" ]; then
+		env -u ABI -u ALTABI -u OSVERSION \
+		    pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_dir}/db \
+		    -o REPO_CACHEDIR=${_repo_dir}/cache -o ABI=${REPO_ABI} \
+		    update -f >/dev/null 2>&1
+	fi
+
+	for _package in ${_meta_pkg} ${_core_pkgs}; do
+		local _version_compare=$(compare_pkg_version_repo ${_package} \
+		    ${_repo_dir} ${REPO_ABI} ${REPO_ALTABI})
+
+		case "${_version_compare}" in
+			=|'>')
+				continue
+				;;
+		esac
+
+		local _new_version=$(env -u ABI -u ALTABI -u OSVERSION \
+		    pkg-static -o REPOS_DIR=${_repo_dir} -o PKG_DBDIR=${_repo_dir}/db \
+		    -o REPO_CACHEDIR=${_repo_dir}/cache -o ABI=${REPO_ABI} \
+		    rquery -U %v ${_package})
+
+		if [ -z "${_new_version}" ]; then
+			_new_version=$(env -u ABI -u ALTABI -u OSVERSION \
+			    pkg-static -o REPOS_DIR=${_repo_dir} \
+			    -o PKG_DBDIR=${_repo_dir}/db \
+			    -o REPO_CACHEDIR=${_repo_dir}/cache -o ABI=${REPO_ABI} \
+			    rquery %v ${_package})
+		fi
+
+		[ -z "${_new_version}" ] && continue
 
 		[ -z "${_mute}" ] \
 		    && _echo \
@@ -1271,6 +1361,17 @@ check_upgrade() {
 	local _core_pkgs=$(pkg-static query -e \
 	    "%n ~ ${product}-kernel-* || %n ~ ${product}-base*" %n 2>/dev/null)
 	local _repo_behind=""
+
+	if [ -n "${NEW_MAJOR}" -a "${action}" != "upgrade" ]; then
+		check_upgrade_current_repo_override "${_mute}" "${_skip_update}" \
+		    "${_meta_pkg}" "${_core_pkgs}"
+		if [ $? -eq 2 ]; then
+			return 2
+		fi
+		[ -z "${_mute}" ] \
+		    && _echo "Your system is up to date"
+		return 0
+	fi
 
 	# Do not upgrade while wg interfaces are assigned
 	if sed '/<interfaces>/,/<\/interfaces>/!d' /cf/conf/config.xml \

--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -1367,6 +1367,28 @@ check_upgrade() {
 		return 2
 	fi
 
+	if [ -n "${NEW_MAJOR}" -a "${action}" = "check" ]; then
+		_exec "pkg-static bootstrap -f" \
+		    "Bootstrapping pkg due to ABI change" mute \
+		    ignore_result do_not_exit
+
+		check_upgrade_current_repo_override "${_mute}" "${_skip_update}" \
+		    "${_meta_pkg}" "${_core_pkgs}"
+		if [ $? -eq 2 ]; then
+			return 2
+		fi
+
+		check_upgrade_repo_override "${_mute}" "${_skip_update}" \
+		    "${_meta_pkg}" "${_core_pkgs}"
+		if [ $? -eq 2 ]; then
+			return 2
+		fi
+
+		[ -z "${_mute}" ] \
+		    && _echo "Your system is up to date"
+		return 0
+	fi
+
 	if [ -n "${NEW_MAJOR}" -a "${action}" != "upgrade" ]; then
 		[ -z "${_mute}" ] \
 		    && _echo "Your system is up to date"

--- a/sysutils/pfSense-upgrade/pkg-descr
+++ b/sysutils/pfSense-upgrade/pkg-descr
@@ -1,3 +1,3 @@
 pfSense upgrade script
 
-WWW: https://www.pfsense.org/
+WWW: https://kontrol.com.br


### PR DESCRIPTION
### Motivation
- Stage 2 upgrades were aborting immediately after reboot when network/DNS were not yet ready, as seen in repository reachability errors in the provided logs. 
- The intent is to treat those cases as transient boot-time conditions and postpone stage 2 instead of failing fatally.

### Description
- Add a `wait_for_pkg_repo()` helper that repeatedly fetches the repo `meta.conf` with short timeouts and supports thoth-specific fetch env/args on `aarch64`.
- During NEW_MAJOR stage 2, call `wait_for_pkg_repo` when running under the `booting` flag and return success (`_exit 0`) to postpone stage 2 if the repo remains unreachable.
- Convert the stage-2 bootstrap/update logic to retry `pkg-static bootstrap -f` and `pkg_update` and, when those operations fail only during boot, log a `WARNING` and postpone stage 2 instead of exiting with error, and bump `PORTREVISION` to `3`.

### Testing
- Ran a shell syntax check `sh -n sysutils/pfSense-upgrade/files/Kontrol-upgrade` which completed successfully. 
- Verified the inserted warning messages are present by searching for the new `postponing stage 2`/`postponing stage 2 upgrade` strings, which were found.
- Performed a static validation of the top-level `Makefile` change to ensure `PORTREVISION` was updated to `3`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ca1e730f4832eb2fe9c5dcfaddba6)