### PR TITLE
sysutils/pfSense-upgrade: add detailed DEBUG traces across upgrade flow

### DIFF
--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -19,6 +19,8 @@ LOCK_FILE=${LOCK_FILE:-/tmp/${UPGRADE_NAME}.lock}
 CACHE_ROOT=${CACHE_ROOT:-/var/cache/${PRODUCT_NAME}-upgrade}
 LOG_FILE=${LOG_FILE:-/cf/conf/upgrade_log.txt}
 JSON_PROGRESS=${JSON_PROGRESS:-${LOG_FILE%.*}.json}
+DEBUG_LOG_FILE=${DEBUG_LOG_FILE:-${LOG_FILE%.*}.debug.log}
+DEBUG_ENABLED=${DEBUG_ENABLED:-1}
 MANIFEST_FILE=""
 TXID=""
 CURRENT_STAGE=""
@@ -61,6 +63,35 @@ log() {
 	echo "$(date -u +%FT%TZ) $*" | tee -a "${LOG_FILE}"
 }
 
+debug() {
+	[ "${DEBUG_ENABLED}" = "1" ] || return 0
+	mkdir -p "$(dirname "${DEBUG_LOG_FILE}")" "${STATE_DIR}"
+	printf '%s [DEBUG] stage=%s txid=%s pid=%s mode=%s %s\n' \
+		"$(date -u +%FT%TZ)" \
+		"${CURRENT_STAGE:-none}" \
+		"${TXID:-none}" \
+		"$$" \
+		"${MODE:-bootstrap}" \
+		"$*" >> "${DEBUG_LOG_FILE}"
+}
+
+debug_kv() {
+	_key=$1
+	_val=$2
+	debug "${_key}=${_val}"
+}
+
+run_cmd() {
+	debug "running command: $*"
+	if "$@"; then
+		debug "command succeeded: $*"
+		return 0
+	fi
+	_rc=$?
+	debug "command failed rc=${_rc}: $*"
+	return ${_rc}
+}
+
 log_json() {
 	stage=${1}
 	status=${2}
@@ -73,7 +104,9 @@ log_json() {
 state_get() {
 	_key=$1
 	[ -f "${STATE_FILE}" ] || return 1
-	awk -F= -v k="${_key}" '$1==k {print substr($0, index($0,"=")+1)}' "${STATE_FILE}" | tail -n 1
+	_val=$(awk -F= -v k="${_key}" '$1==k {print substr($0, index($0,"=")+1)}' "${STATE_FILE}" | tail -n 1)
+	debug_kv "state_get.${_key}" "${_val:-<unset>}"
+	printf '%s\n' "${_val}"
 }
 
 state_set() {
@@ -87,6 +120,7 @@ state_set() {
 	else
 		echo "${_key}=${_val}" >> "${STATE_FILE}"
 	fi
+	debug_kv "state_set.${_key}" "${_val}"
 }
 
 state_checksum() {
@@ -104,10 +138,12 @@ retry_cmd() {
 	_delay=2
 	_i=1
 	while :; do
-		if "$@"; then
+		debug "retry_cmd attempt=${_i}/${_retries} command=$*"
+		if run_cmd "$@"; then
 			return 0
 		fi
 		[ ${_i} -ge ${_retries} ] && return 1
+		debug "retry_cmd sleeping ${_delay}s before retry"
 		sleep ${_delay}
 		_delay=$((_delay * 2))
 		_i=$((_i + 1))
@@ -115,12 +151,14 @@ retry_cmd() {
 }
 
 ensure_tx() {
+	debug "ensure_tx start"
 	TXID=$(state_get txid 2>/dev/null || true)
 	if [ -z "${TXID}" ]; then
 		TXID=$(date +%Y%m%d%H%M%S)-$$
 		state_set txid "${TXID}"
 	fi
 	MANIFEST_FILE="${CACHE_ROOT}/${TXID}/manifest.txt"
+	debug_kv "manifest_file" "${MANIFEST_FILE}"
 }
 
 current_abi() {
@@ -138,26 +176,38 @@ target_abi() {
 }
 
 validate_repo_trust() {
+	debug "validate_repo_trust using ${PKG_REPO_CONF}"
 	[ -f "${PKG_REPO_CONF}" ] || { log "ERROR: missing repo config ${PKG_REPO_CONF}"; return 1; }
 	grep -Eq 'fingerprints|signature_type' "${PKG_REPO_CONF}" || {
 		log "ERROR: repository signature configuration not found in ${PKG_REPO_CONF}"
 		return 1
 	}
+	debug "validate_repo_trust succeeded"
 }
 
 refresh_repo() {
+	debug "refresh_repo start"
 	retry_cmd 3 pkg-static update -f
 }
 
 discover_upgrade() {
 	log "Running stage0 discovery"
 	CURRENT_STAGE=stage0
+	debug "discover_upgrade start"
 	log_json stage0 running "discovering available updates"
-	if pkg-static upgrade -nq | grep -q '^Installed packages to be UPGRADED:'; then
+	_discovery_output=$(pkg-static upgrade -nq 2>&1 || true)
+	debug "stage0 raw output begin"
+	printf '%s\n' "${_discovery_output}" | sed 's/^/[DEBUG][stage0] /' >> "${DEBUG_LOG_FILE}"
+	debug "stage0 raw output end"
+	if printf '%s\n' "${_discovery_output}" | grep -q '^Installed packages to be UPGRADED:'; then
+		_new_version=$(printf '%s\n' "${_discovery_output}" | awk '/^\s+[[:alnum:]][^ ]* [^ ]+ -> / {print $3; exit}')
+		[ -n "${_new_version}" ] && printf '%s\n' "${_new_version}"
 		log_json stage0 ok "upgrade available"
+		debug_kv "stage0.upgrade_available" "yes"
 		return 2
 	fi
 	log_json stage0 ok "already up to date"
+	debug_kv "stage0.upgrade_available" "no"
 	return 0
 }
 
@@ -183,12 +233,13 @@ run_stage1() {
 		state_set cross_major no
 	fi
 
-	pkg-static upgrade -Fqy || return 1
-	pkg-static fetch -yU pkg || return 1
+	run_cmd pkg-static upgrade -Fqy || return 1
+	run_cmd pkg-static fetch -yU pkg || return 1
 
-	pkg query '%n %v %R %sh' > "${MANIFEST_FILE}.installed" || true
-	pkg rquery -a '%n %v %R %sh' > "${MANIFEST_FILE}.remote" || true
+	run_cmd pkg query '%n %v %R %sh' > "${MANIFEST_FILE}.installed" || true
+	run_cmd pkg rquery -a '%n %v %R %sh' > "${MANIFEST_FILE}.remote" || true
 	cat "${MANIFEST_FILE}.installed" "${MANIFEST_FILE}.remote" > "${MANIFEST_FILE}" 2>/dev/null || true
+	debug "stage1 manifest generated: ${MANIFEST_FILE}"
 
 	state_set stage stage2
 	state_set state_checksum "$(state_checksum)"
@@ -205,11 +256,11 @@ run_stage2() {
 	cross_major=$(state_get cross_major 2>/dev/null || echo no)
 	if [ "${cross_major}" = "yes" ]; then
 		export IGNORE_OSVERSION=yes
-		pkg-static install -fy pkg || return 1
+		run_cmd pkg-static install -fy pkg || return 1
 	fi
 
-	pkg-static upgrade -fy || return 1
-	pkg check -Bdsya || return 1
+	run_cmd pkg-static upgrade -fy || return 1
+	run_cmd pkg check -Bdsya || return 1
 
 	state_set stage stage3
 	state_set state_checksum "$(state_checksum)"
@@ -223,9 +274,9 @@ run_stage3() {
 	journal "begin"
 	log_json stage3 running "post-validation"
 
-	pkg check -Bdsya || return 1
-	service sshd onestatus >/dev/null 2>&1 || true
-	service filterlog onestatus >/dev/null 2>&1 || true
+	run_cmd pkg check -Bdsya || return 1
+	run_cmd service sshd onestatus >/dev/null 2>&1 || true
+	run_cmd service filterlog onestatus >/dev/null 2>&1 || true
 
 	state_set stage stage4
 	log_json stage3 ok "validation complete"
@@ -238,8 +289,8 @@ run_stage4() {
 	journal "begin"
 	log_json stage4 running "cleanup/finalize"
 
-	pkg-static autoremove -y || true
-	pkg-static clean -ay || true
+	run_cmd pkg-static autoremove -y || true
+	run_cmd pkg-static clean -ay || true
 	cp -f "${LOG_FILE}" /cf/conf/upgrade_log.latest.txt 2>/dev/null || true
 
 	state_set stage done
@@ -250,6 +301,7 @@ run_stage4() {
 
 rollback_stage() {
 	stage=${1}
+	debug "rollback_stage start for ${stage}"
 	log "ERROR: failure at ${stage}, starting rollback guardrails"
 	log_json "${stage}" error "rollback guardrails invoked"
 	journal "rollback begin"
@@ -262,6 +314,7 @@ rollback_stage() {
 
 run_stage() {
 	stage=$1
+	debug "run_stage selected=${stage}"
 	case "${stage}" in
 		stage0) discover_upgrade ;;
 		stage1) run_stage1 ;;
@@ -274,6 +327,7 @@ run_stage() {
 
 run_pending_stage() {
 	pending=$(state_get stage 2>/dev/null || echo stage1)
+	debug "run_pending_stage pending=${pending}"
 	case "${pending}" in
 		stage1|stage2|stage3|stage4) run_stage "${pending}" ;;
 		done) log "No pending stage" ;;
@@ -285,14 +339,16 @@ run_install() {
 	[ -n "${PKG_NAME}" ] || { log "ERROR: -i requires package name"; return 64; }
 	flags="-y"
 	[ "${FORCE_OPS}" -eq 1 ] && flags="${flags}f"
-	pkg-static install ${flags} "${PKG_NAME}"
+	debug "run_install pkg=${PKG_NAME} flags=${flags}"
+	run_cmd pkg-static install ${flags} "${PKG_NAME}"
 }
 
 run_remove() {
 	[ -n "${PKG_NAME}" ] || { log "ERROR: -r requires package name"; return 64; }
 	flags="-y"
 	[ "${FORCE_OPS}" -eq 1 ] && flags="${flags}f"
-	pkg-static delete ${flags} "${PKG_NAME}"
+	debug "run_remove pkg=${PKG_NAME} flags=${flags}"
+	run_cmd pkg-static delete ${flags} "${PKG_NAME}"
 }
 
 DRYRUN=0
@@ -328,6 +384,16 @@ while getopts "46bcdfhi:l:np:r:Rs:uUy" opt; do
 		*) usage; exit 64 ;;
 	esac
 done
+
+debug "parsed options mode=${MODE} boot_mode=${BOOT_MODE} boot_stage=${BOOT_STAGE:-none} explicit_stage=${EXPLICIT_STAGE:-none} dryrun=${DRYRUN} skip_repo_update=${SKIP_REPO_UPDATE} force_ops=${FORCE_OPS} progress_socket=${PROGRESS_SOCKET:-none}"
+debug_kv "default_product" "${default_product}"
+debug_kv "product_name" "${PRODUCT_NAME}"
+debug_kv "state_dir" "${STATE_DIR}"
+debug_kv "cache_root" "${CACHE_ROOT}"
+debug_kv "log_file" "${LOG_FILE}"
+debug_kv "json_progress" "${JSON_PROGRESS}"
+debug_kv "debug_log_file" "${DEBUG_LOG_FILE}"
+
 if [ "${BOOT_MODE}" -eq 1 ]; then
 	MODE=boot
 	eval "next_arg=\${$OPTIND:-}"
@@ -340,20 +406,24 @@ fi
 
 if [ -n "${PROGRESS_SOCKET}" ]; then
 	log "Progress socket provided via -p (${PROGRESS_SOCKET})"
+	debug "progress socket compatibility parameter received"
 fi
 
 if [ "${MODE}" != "boot" ]; then
 	if [ "${KONTROL_UPGRADE_LOCKED:-0}" != "1" ]; then
 		export KONTROL_UPGRADE_LOCKED=1
+		debug "acquiring lock via lockf file=${LOCK_FILE}"
 		exec lockf -k -t 0 "${LOCK_FILE}" "$0" "$@"
 	fi
 fi
 
 if [ "${DRYRUN}" -eq 1 ]; then
 	log "Dry-run enabled; no mutating operations will run"
+	debug "dry-run exit"
 	exit 0
 fi
 
+debug "starting mode handler: ${MODE}"
 case "${MODE}" in
 	check)
 		discover_upgrade
@@ -363,6 +433,7 @@ case "${MODE}" in
 		validate_repo_trust
 		refresh_repo
 		log "Repository metadata updated"
+		debug "mode update completed"
 		;;
 	install)
 		[ "${SKIP_REPO_UPDATE}" -eq 1 ] || refresh_repo
@@ -384,7 +455,9 @@ case "${MODE}" in
 	run)
 		run_stage stage1 || { rollback_stage stage1; exit 1; }
 		log "Stage1 complete; reboot required to continue with stage2"
+		debug "mode run completed stage1"
 		;;
 esac
 
+debug "script completed successfully"
 exit 0

--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade.wrapper
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade.wrapper
@@ -21,6 +21,16 @@
 pfsense_upgrade=$(realpath -q $(dirname $0)/../libexec/$(basename $0))
 lockfile="/tmp/$(basename $0).lock"
 
+DEBUG_LOG_FILE=${DEBUG_LOG_FILE:-/cf/conf/upgrade_log.debug.log}
+DEBUG_ENABLED=${DEBUG_ENABLED:-1}
+
+wrapper_debug() {
+	[ "${DEBUG_ENABLED}" = "1" ] || return 0
+	mkdir -p "$(dirname "${DEBUG_LOG_FILE}")"
+	printf '%s [DEBUG][wrapper] pid=%s %s\n' "$(date -u +%FT%TZ)" "$$" "$*" >> "${DEBUG_LOG_FILE}"
+}
+
+wrapper_debug "resolved pfsense_upgrade=${pfsense_upgrade} lockfile=${lockfile}"
 if [ ! -f ${pfsense_upgrade} ]; then
 	echo "ERROR: Unable to find ${pfsense_upgrade}"
 	exit 1
@@ -45,8 +55,10 @@ EX_UPGRADE=99
 
 while true; do
 	unset run_again
+	wrapper_debug "invoking lockf target=${pfsense_upgrade} args=$*"
 	/usr/bin/lockf -s -t 5 ${lockfile} ${pfsense_upgrade} "$@"
 	rc=$?
+	wrapper_debug "lockf return code=${rc}"
 
 	unset error
 	case "$rc" in
@@ -73,6 +85,7 @@ while true; do
 
 	[ -f "${lockfile}" ] \
 		&& rm -f ${lockfile}
+	wrapper_debug "lockfile cleanup done"
 
 	[ -n "${error}" ] \
 		&& exit $error
@@ -80,5 +93,6 @@ while true; do
 	[ -n "${run_again}" ] \
 		&& continue
 
+	wrapper_debug "wrapper exiting rc=${rc}"
 	exit $rc
 done

--- a/sysutils/pfSense-upgrade/files/kontrol-upgrade-stage.rc
+++ b/sysutils/pfSense-upgrade/files/kontrol-upgrade-stage.rc
@@ -12,22 +12,39 @@ pidfile=/var/run/Kontrol-upgrade-stage.pid
 
 : ${kontrol_upgrade_stage_enable:=YES}
 : ${kontrol_upgrade_stage_timeout:=7200}
+: ${kontrol_upgrade_stage_debug_log:=/cf/conf/upgrade_log.debug.log}
 
 start_cmd="${name}_start"
+
+kontrol_upgrade_stage_debug()
+{
+	[ "${DEBUG_ENABLED:-1}" = "1" ] || return 0
+	mkdir -p "$(dirname "${kontrol_upgrade_stage_debug_log}")"
+	printf '%s [DEBUG][rc.kontrol_upgrade_stage] pid=%s %s\n' "$(date -u +%FT%TZ)" "$$" "$*" >> "${kontrol_upgrade_stage_debug_log}"
+}
 
 kontrol_upgrade_stage_start()
 {
 	state_file="/var/db/Kontrol/upgrade/state"
-	[ -f "${state_file}" ] || return 0
+	kontrol_upgrade_stage_debug "start called state_file=${state_file}"
+	[ -f "${state_file}" ] || {
+		kontrol_upgrade_stage_debug "state file not found; nothing to do"
+		return 0
+	}
 
 	pending_stage=$(awk -F= '$1=="stage" {print $2}' "${state_file}" | tail -n1)
+	kontrol_upgrade_stage_debug "pending_stage=${pending_stage:-none}"
 	case "${pending_stage}" in
 		stage2|stage3|stage4)
 			echo "Running pending Kontrol upgrade stage: ${pending_stage}"
+			kontrol_upgrade_stage_debug "executing timeout=${kontrol_upgrade_stage_timeout} command=${command} -b ${pending_stage}"
 			/usr/bin/timeout "${kontrol_upgrade_stage_timeout}" \
 				"${command}" -b "${pending_stage}"
+			rc=$?
+			kontrol_upgrade_stage_debug "stage execution rc=${rc}"
 			;;
 		*)
+			kontrol_upgrade_stage_debug "no eligible pending stage; skipping"
 			return 0
 			;;
 	esac

--- a/sysutils/pfSense-upgrade/files/kontrol_upgrade_status.inc
+++ b/sysutils/pfSense-upgrade/files/kontrol_upgrade_status.inc
@@ -3,6 +3,25 @@
  * Minimal GUI helper library for staged Kontrol-upgrade status.
  */
 
+function kontrol_upgrade_debug_file() {
+    return '/cf/conf/upgrade_log.debug.log';
+}
+
+function kontrol_upgrade_debug($message) {
+    if (getenv('DEBUG_ENABLED') === '0') {
+        return;
+    }
+
+    $line = sprintf(
+        "%s [DEBUG][php.kontrol_upgrade_status] pid=%d %s\n",
+        gmdate('c'),
+        getmypid(),
+        $message
+    );
+
+    @file_put_contents(kontrol_upgrade_debug_file(), $line, FILE_APPEND);
+}
+
 function kontrol_upgrade_state_file() {
     return '/var/db/Kontrol/upgrade/state';
 }
@@ -14,29 +33,36 @@ function kontrol_upgrade_journal_file() {
 function kontrol_upgrade_read_state() {
     $state = [];
     $file = kontrol_upgrade_state_file();
+    kontrol_upgrade_debug("read_state file={$file}");
+
     if (!file_exists($file)) {
+        kontrol_upgrade_debug('state file does not exist');
         return $state;
     }
 
     $lines = @file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
     if (!is_array($lines)) {
+        kontrol_upgrade_debug('state file read failed');
         return $state;
     }
 
+    kontrol_upgrade_debug('state lines=' . count($lines));
     foreach ($lines as $line) {
         $parts = explode('=', $line, 2);
         if (count($parts) !== 2) {
+            kontrol_upgrade_debug('ignoring malformed line: ' . $line);
             continue;
         }
         $state[trim($parts[0])] = trim($parts[1]);
     }
 
+    kontrol_upgrade_debug('state keys=' . implode(',', array_keys($state)));
     return $state;
 }
 
 function kontrol_upgrade_progress_payload() {
     $state = kontrol_upgrade_read_state();
-    return [
+    $payload = [
         'txid' => $state['txid'] ?? null,
         'stage' => $state['stage'] ?? 'idle',
         'current_abi' => $state['current_abi'] ?? null,
@@ -44,6 +70,9 @@ function kontrol_upgrade_progress_payload() {
         'cross_major' => ($state['cross_major'] ?? 'no') === 'yes',
         'finished_at' => $state['finished_at'] ?? null,
     ];
+
+    kontrol_upgrade_debug('progress payload stage=' . $payload['stage'] . ' txid=' . ($payload['txid'] ?? 'none'));
+    return $payload;
 }
 
 ?>


### PR DESCRIPTION
### Motivation
- The `Kontrol-upgrade` flow (especially the `-c` discovery path) was producing insufficient observability and could stall/loop without clear root cause information, so a comprehensive DEBUG channel was required to trace commands, state changes, lock behavior and interactions with the GUI widgets that call `-c`.
- The pfSense UI expects `-c` to exit with code `2` when an upgrade is available and to print version text; the change must preserve this contract while giving detailed logs for troubleshooting.

### Description
- Added a dedicated debug log and enable flag to the orchestrator: `DEBUG_LOG_FILE` (default `{{LOG_FILE%.*}}.debug.log`) and `DEBUG_ENABLED`, plus helper functions `debug()`, `debug_kv()` and `run_cmd()` to centralize contextual debug output and command-level tracing in `Kontrol-upgrade`.
- Instrumented all major sections of `Kontrol-upgrade` including `state_get`/`state_set`, `retry_cmd`, `ensure_tx`, repo validation/refresh, stage handlers (`stage0..stage4`), install/remove paths, rollback guardrails, lock acquisition and mode dispatch to emit structured debug lines containing `stage`, `txid`, `pid` and `mode`.
- Improved `discover_upgrade()` (`-c`) to capture raw `pkg-static upgrade -nq` output into the debug log, attempt to parse the new version for stdout, and still return `2` when upgrades are found so existing callers (widgets / `get_system_pkg_version`) keep the same contract.
- Added debug instrumentation in the wrapper (`Kontrol-upgrade.wrapper`) to log binary resolution, `lockf` invocation and return codes, in the rc script (`kontrol-upgrade-stage.rc`) to log pending-stage detection and execution results, and in the PHP helper (`kontrol_upgrade_status.inc`) to trace state file parsing and payload generation consumed by dashboard widgets.

### Testing
- Syntax check of the main script with `sh -n sysutils/pfSense-upgrade/files/Kontrol-upgrade` succeeded with no syntax errors.
- Syntax check of the wrapper and rc script with `sh -n sysutils/pfSense-upgrade/files/Kontrol-upgrade.wrapper` and `sh -n sysutils/pfSense-upgrade/files/kontrol-upgrade-stage.rc` succeeded with no syntax errors.
- PHP lint of the helper with `php -l sysutils/pfSense-upgrade/files/kontrol_upgrade_status.inc` returned no syntax errors.
- Dry-run invocation with environment overrides (`DEBUG_LOG_FILE=/tmp/kontrol-upgrade.debug.log LOG_FILE=/tmp/kontrol-upgrade.log JSON_PROGRESS=/tmp/kontrol-upgrade.json STATE_DIR=/tmp/kontrol-upgrade-state sh sysutils/pfSense-upgrade/files/Kontrol-upgrade -n`) produced DEBUG output up to lock acquisition and exited early with `rc=127` in this Linux environment because `lockf` is not available here, but the debug file shows the new debug traces were emitted successfully up to that point.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69962305e400832e94a2b2ab44ff7cfe)