### PR TITLE
sysutils/pfSense-upgrade: replace ALTABI with OSVERSION and bump PORTREVISION

### DIFF
--- a/sysutils/pfSense-upgrade/Makefile
+++ b/sysutils/pfSense-upgrade/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	Kontrol-upgrade
 PORTVERSION=	2.3.1
-PORTREVISION=	# empty
+PORTREVISION=	1
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -272,6 +272,7 @@ repo_is_plus_upgrade() {
 abi_setup() {
 	local _freebsd_version=$(uname -r)
 	local _pkg_repo_conf="/usr/local/etc/pkg/repos/${product}.conf"
+	local _cur_osversion=$(sysctl -n kern.osreldate)
 
 	CUR_ABI="FreeBSD:${_freebsd_version%%.*}:${arch}"
 	CUR_ALTABI="freebsd:${_freebsd_version%%.*}"
@@ -300,15 +301,15 @@ abi_setup() {
 		ABI=${CUR_ABI}
 	fi
 
-	if [ -f ${_repo_abi_file%%.conf}.altabi ]; then
-		ALTABI=$(cat ${_repo_abi_file%%.conf}.altabi)
+	if [ -f ${_repo_abi_file%%.conf}.osversion ]; then
+		OSVERSION=$(cat ${_repo_abi_file%%.conf}.osversion)
 	else
-		ALTABI=${CUR_ALTABI}
+		OSVERSION=${_cur_osversion}
 	fi
 
 	# Make sure pkg.conf is set properly so GUI can work
 	echo "ABI=${ABI}" > /usr/local/etc/pkg.conf
-	echo "ALTABI=${ALTABI}" >> /usr/local/etc/pkg.conf
+	echo "OSVERSION=${OSVERSION}" >> /usr/local/etc/pkg.conf
 
 	AUTH_CA="/etc/ssl/netgate-ca.pem"
 	AUTH_CERT="/etc/ssl/pfSense-repo-custom.cert"
@@ -341,14 +342,14 @@ EOF
 		reinstall_pkg=1
 	fi
 
-	if [ "${CUR_ABI}" = "${ABI}" -o "${CUR_ABI}" = "${ALTABI}" ] ; then
+	if [ "${CUR_ABI}" = "${ABI}" -o "${_cur_osversion}" = "${OSVERSION}" ] ; then
 		NEW_MAJOR=""
 	else
 		NEW_MAJOR=1
 		export IGNORE_OSVERSION=yes
 	fi
 
-	export CUR_ABI CUR_ALTABI ABI ALTABI NEW_MAJOR
+	export CUR_ABI CUR_ALTABI ABI OSVERSION NEW_MAJOR
 }
 
 get_pkg_repo_url() {


### PR DESCRIPTION
### Motivation
- Newer `pkg` no longer accepts `ALTABI`, so the port must provide `OSVERSION` (an integer, unquoted, without a trailing semicolon) in `pkg.conf` instead. 
- The upgrade decision must compare the current kernel osreldate against the configured `OSVERSION` to detect major upgrades correctly. 
- The port revision is bumped so the updated package can be built and distributed.

### Description
- Added `_cur_osversion=$(sysctl -n kern.osreldate)` inside `abi_setup()` in `files/Kontrol-upgrade` to obtain the current integer osreldate. 
- If `${repo}.osversion` exists the script reads it; otherwise it falls back to the current osreldate and sets `OSVERSION` accordingly. 
- Replaced writing `ALTABI` to `/usr/local/etc/pkg.conf` with writing `OSVERSION=${OSVERSION}` so the file contains an unquoted integer assignment with no semicolon. 
- Updated the major-upgrade detection to compare the current osreldate with the configured `OSVERSION` and exported `OSVERSION` instead of `ALTABI`. 
- Incremented `PORTREVISION` to `1` in the `Makefile` to reflect the packaging change.

### Testing
- Ran `sh -n sysutils/pfSense-upgrade/files/Kontrol-upgrade` for syntax validation and it succeeded. 
- Verified with `rg` that `OSVERSION` is written and `ALTABI` is no longer emitted from the modified script. 
- Attempted `make -C sysutils/pfSense-upgrade -V PORTVERSION -V PORTREVISION` for local make variable inspection but it could not be executed in this Linux container because the environment uses GNU `make` which lacks the FreeBSD `make` options used for that check.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998b1d5d6a0832eb9db9ecb7a097c14)