### PR TITLE
sysutils/pfSense-upgrade: make ${PRODUCT}-repoc-static refresh optional and add NO_REPOC env

### DIFF
--- a/sysutils/pfSense-upgrade/files/Kontrol-repo-setup
+++ b/sysutils/pfSense-upgrade/files/Kontrol-repo-setup
@@ -186,11 +186,17 @@ pfSense_repo_setup() {
 	cp "${PFSENSE_REPO_CONF}" "/tmp/${PRODUCT}.conf.copy"
 
 	if [ -z "${NOUPDATE}" ]; then
-		# Fetch the repository settings.
-		if ! /usr/local/sbin/${PRODUCT}-repoc-static; then
-			echo "failed to update the repository settings!!!"
-			rm -f "/tmp/${PRODUCT}.conf.copy"
-			exit 1
+		# Fetch the repository settings when available.
+		if [ "${NO_REPOC}" = "1" ]; then
+			echo "NO_REPOC=1 set, skipping repository metadata refresh"
+		elif [ -x "/usr/local/sbin/${PRODUCT}-repoc-static" ]; then
+			if ! /usr/local/sbin/${PRODUCT}-repoc-static; then
+				echo "failed to update the repository settings!!!"
+				rm -f "/tmp/${PRODUCT}.conf.copy"
+				exit 1
+			fi
+		else
+			echo "warning: /usr/local/sbin/${PRODUCT}-repoc-static not found; skipping repository metadata refresh"
 		fi
 	fi
 


### PR DESCRIPTION
### Motivation

- The legacy `repo-setup` workflow required `${PRODUCT}-repoc-static` which does not exist in Kontrol, causing failures during repo setup.
- Make remote metadata refresh optional while preserving the local configuration steps `validate_repo_conf` and `abi_setup` which are essential for correct local operation.
- Provide an explicit environment flag to force skipping remote refresh (`NO_REPOC=1`) for predictable behavior in constrained installs.

### Description

- Modified `sysutils/pfSense-upgrade/files/Kontrol-repo-setup` to check `NO_REPOC=1` and to only call `/usr/local/sbin/${PRODUCT}-repoc-static` if it exists and is executable, otherwise log a warning and continue the local flow. 
- Preserved existing behavior for `-U` (sets `NOUPDATE`) so `-U` still prevents updates as before. 
- Kept `validate_repo_conf` and `abi_setup` mandatory and maintained the original exit-code semantics (0,1,11,12,13,14), ensuring absence of `repoc-static` does not cause exit `1` by itself. 
- Confirmed there are no other `repoc` references in the port `Makefile` that require changes.

### Testing

- Ran `PRODUCT=Kontrol sh -x sysutils/pfSense-upgrade/files/Kontrol-repo-setup` with `repoc-static` absent and observed successful completion (`exit 0`) with a warning and execution of `validate_repo_conf` and `abi_setup` (passed).
- Ran `PRODUCT=Kontrol sh -x sysutils/pfSense-upgrade/files/Kontrol-repo-setup -U` and observed successful completion (`exit 0`) with no attempt to refresh remote metadata (passed).
- Created a stub `/usr/local/sbin/Kontrol-repoc-static` and ran `NO_REPOC=1 PRODUCT=Kontrol sh -x sysutils/pfSense-upgrade/files/Kontrol-repo-setup`; observed successful completion (`exit 0`) and that the helper was not invoked (passed).
- Attempted `pkg -vv` and `pkg update -f` but the test environment lacks `pkg` (commands returned 127), so those checks are documented as warnings due to environment limitations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69992681a054832e91e9a858b1192cc3)