### PR TITLE
sysutils/pfSense-upgrade: refresh repo metadata before stage 3 package upgrade

### DIFF
--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -1011,6 +1011,12 @@ pkg_upgrade() {
 	fi
 
 	if [ "${next_stage}" = "3" ]; then
+		# Stage 2 keeps additional packages locked while base system and
+		# core packages are upgraded. Refresh metadata before the final
+		# pass so package upgrades pending only for add-on packages are
+		# not skipped when this stage is executed with -U during boot.
+		pkg_update force mute
+
 		if upgrade_available; then
 			delete_annotation=1
 			_exec "pkg-static upgrade${dont_update}" \


### PR DESCRIPTION
### Motivation
- During the upgrade flow stage 3 can run with repository updates disabled (`-U`), so repository metadata may be stale and newly published add-on package builds are not seen by the final `pkg-static upgrade` pass, leaving installed add-ons (e.g. `Kontrol-pkg-cron`) on older versions after reboot.

### Description
- Add an explicit metadata refresh by calling `pkg_update force mute` at the start of the `next_stage=3` block in `sysutils/pfSense-upgrade/files/Kontrol-upgrade` so the final upgrade pass can see recently published add-on package versions.
- The change is limited to the stage-3 path and does not alter the rest of the upgrade sequencing or behavior other than ensuring fresh repo metadata before the final package upgrade.

### Testing
- Performed a shell syntax check with `sh -n sysutils/pfSense-upgrade/files/Kontrol-upgrade` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a5c9a4548832e8a15e1ca2b908780)