### PR TITLE
www/Kontrol-pkg-E2guardian54: guard dnshaper queue source

### DIFF
--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.xml
@@ -149,7 +149,7 @@
 					Do not forget to apply a mask on limiter if you want to define a per user/ip limit. and check Allow Users on Interface option above.<br>
 					<b>NOTE: </b> To match transparent clients too, apply limiters under <b>firewall -> rules</b> that allows access to this firewall(127.0.0.1) under Listen port(s).]]></description>
 			<type>select_source</type>
-			<source><![CDATA[$config['dnshaper']['queue']]]></source>
+			<source><![CDATA[(is_array($config['dnshaper'] ?? null) && is_array($config['dnshaper']['queue'] ?? null) ? $config['dnshaper']['queue'] : [])]]></source>
 			<source_name>name</source_name>
 			<source_value>number</source_value>
 			<show_disable_value>none</show_disable_value>
@@ -160,7 +160,7 @@
 			<description><![CDATA[Choose the Out queue/Virtual interface only if In is also selected.<br>
 				The Out selection is applied to traffic leaving the interface where the rule is created, the In selection is applied to traffic coming into the chosen interface.]]></description>
 			<type>select_source</type>
-			<source><![CDATA[$config['dnshaper']['queue']]]></source>
+			<source><![CDATA[(is_array($config['dnshaper'] ?? null) && is_array($config['dnshaper']['queue'] ?? null) ? $config['dnshaper']['queue'] : [])]]></source>
 			<source_name>name</source_name>
 			<source_value>number</source_value>
 			<show_disable_value>none</show_disable_value>


### PR DESCRIPTION
### Motivation
- Prevent PHP 8 runtime notices `Cannot access offset of type string on string` when the `dnshaper` config is missing or not an array, which caused log errors when opening/closing the package config page.

### Description
- Updated `www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.xml` to replace direct uses of `$config['dnshaper']['queue']` in the `inpipe` and `outpipe` `<source>` nodes with a guarded expression: `(is_array($config['dnshaper'] ?? null) && is_array($config['dnshaper']['queue'] ?? null) ? $config['dnshaper']['queue'] : [])`.

### Testing
- Ran the automated replacement script which reported `updated 2`, executed `rg` to locate occurrences, inspected the `git diff` to confirm only the two `<source>` nodes changed, and committed the change; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3e0f4a694832e8e1e42fee3c59aad)