### PR TITLE
sysutils: ajustar geração de /usr/local/etc/pkg.conf para upgrades entre FreeBSD 14 e 15

### DIFF
--- a/sysutils/pfSense-repo/files/pkg-install.in
+++ b/sysutils/pfSense-repo/files/pkg-install.in
@@ -61,10 +61,41 @@ PKG_CONF="/usr/local/etc/pkg.conf"
 REAL_CONF=$(readlink ${REPO_CONF})
 
 ABI_FILE="${REAL_CONF%%.conf}.abi"
-OSVERSION=$(/sbin/sysctl -n kern.osreldate)
+ALTABI_FILE="${REAL_CONF%%.conf}.altabi"
+OSVERSION_FILE="${REAL_CONF%%.conf}.osversion"
+TARGET_OSMAJOR=""
 
-echo "ABI_FILE=${ABI_FILE}" > ${PKG_CONF}
-echo "OSVERSION=${OSVERSION}" >> ${PKG_CONF}
+if [ -f "${ABI_FILE}" ]; then
+	ABI=$(/bin/cat "${ABI_FILE}")
+else
+	ABI="FreeBSD:$(/usr/bin/uname -r | /usr/bin/cut -d. -f1):$(/usr/bin/uname -p)"
+fi
+
+TARGET_OSMAJOR=$(/bin/echo "${ABI}" | /usr/bin/awk -F: 'tolower($1)=="freebsd" { print $2 }')
+
+if [ -f "${OSVERSION_FILE}" ]; then
+	OSVERSION=$(/bin/cat "${OSVERSION_FILE}")
+elif [ -n "${TARGET_OSMAJOR}" ]; then
+	OSVERSION="${TARGET_OSMAJOR}00000"
+else
+	OSVERSION=$(/sbin/sysctl -n kern.osreldate)
+fi
+
+if [ -f "${ALTABI_FILE}" ]; then
+	ALTABI=$(/bin/cat "${ALTABI_FILE}")
+else
+	ALTABI=""
+fi
+
+if [ "${TARGET_OSMAJOR}" -ge 15 ] 2>/dev/null; then
+	echo "ABI=${ABI}" > ${PKG_CONF}
+	echo "OSVERSION=${OSVERSION}" >> ${PKG_CONF}
+else
+	echo "ABI=${ABI}" > ${PKG_CONF}
+	if [ -n "${ALTABI}" ]; then
+		echo "ALTABI=${ALTABI}" >> ${PKG_CONF}
+	fi
+fi
 
 # Help users to fix fstab before risk moving to FreeBSD 11
 if /usr/bin/grep -q -E '/dev/ad[[:digit:]]' /etc/fstab; then

--- a/sysutils/pfSense-upgrade/files/Kontrol-repo-setup
+++ b/sysutils/pfSense-upgrade/files/Kontrol-repo-setup
@@ -128,11 +128,28 @@ abi_setup() {
 		ALTABI=${CUR_ALTABI}
 	fi
 
+	_target_osmajor=$(echo "${ABI}" | /usr/bin/awk -F: 'tolower($1)=="freebsd" { print $2 }')
+	if [ -f ${_repo_conf_file%%.conf}.osversion ]; then
+		OSVERSION=$(cat ${_repo_conf_file%%.conf}.osversion)
+	elif [ -n "${_target_osmajor}" ]; then
+		# FreeBSD kern.osreldate format for major fallback (e.g. 15 -> 1500000)
+		OSVERSION="${_target_osmajor}00000"
+	else
+		OSVERSION=$(sysctl -n kern.osreldate)
+	fi
+
 	# Make sure pkg.conf is set properly so GUI can work
-	cat << EOF > "${PKG_CONF}"
+	if [ "${_target_osmajor}" -ge 15 ] 2>/dev/null; then
+		cat << EOF > "${PKG_CONF}"
+ABI=${ABI}
+OSVERSION=${OSVERSION}
+EOF
+	else
+		cat << EOF > "${PKG_CONF}"
 ABI=${ABI}
 ALTABI=${ALTABI}
 EOF
+	fi
 	if [ -n "${dbdir}" ] && [ -n "${reposdir}" ]; then
 			cat << EOF >> ${PKG_CONF}""
 PKG_DBDIR=${dbdir}
@@ -168,7 +185,16 @@ EOF
 		err=11
 	fi
 
-	if [ "${CUR_ABI}" != "${ABI}" ] && [ "${CUR_ABI}" != "${ALTABI}" ]; then
+	if [ "${_target_osmajor}" -ge 15 ] 2>/dev/null; then
+		if [ "${CUR_ABI}" != "${ABI}" ]; then
+			# Set NEW_MAJOR
+			if [ "${err}" -eq 11 ]; then
+				err=13
+			else
+				err=12
+			fi
+		fi
+	elif [ "${CUR_ABI}" != "${ABI}" ] && [ "${CUR_ABI}" != "${ALTABI}" ]; then
 		# Set NEW_MAJOR
 		if [ "${err}" -eq 11 ]; then
 			err=13

--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -314,8 +314,13 @@ abi_setup() {
 	fi
 
 	# Make sure pkg.conf is set properly so GUI can work
-	echo "ABI=${ABI}" > /usr/local/etc/pkg.conf
-	echo "OSVERSION=${OSVERSION}" >> /usr/local/etc/pkg.conf
+	if [ "${_target_osmajor}" -ge 15 ] 2>/dev/null; then
+		echo "ABI=${ABI}" > /usr/local/etc/pkg.conf
+		echo "OSVERSION=${OSVERSION}" >> /usr/local/etc/pkg.conf
+	else
+		echo "ABI=${ABI}" > /usr/local/etc/pkg.conf
+		echo "ALTABI=${CUR_ALTABI}" >> /usr/local/etc/pkg.conf
+	fi
 
 	AUTH_CA="/etc/ssl/netgate-ca.pem"
 	AUTH_CERT="/etc/ssl/pfSense-repo-custom.cert"


### PR DESCRIPTION
### Motivation
- Corrigir comportamento durante upgrades onde a versão destino roda em FreeBSD 15+ e o `pkg` requisito passa a precisar de `OSVERSION` em vez de `ALTABI`, garantindo compatibilidade entre pfSense 2.7.x (FreeBSD 14) e 2.8.x (FreeBSD 15).

### Description
- `sysutils/pfSense-upgrade/files/Kontrol-repo-setup` agora extrai o major alvo a partir do `ABI` e escreve `pkg.conf` com `ABI`+`OSVERSION` para alvos FreeBSD 15+, ou `ABI`+`ALTABI` para alvos 14 e anteriores, e ajusta a lógica que determina mudança de major (`NEW_MAJOR`).
- `sysutils/pfSense-upgrade/files/Kontrol-upgrade` foi alinhado para o mesmo comportamento condicional ao gerar `/usr/local/etc/pkg.conf` (15+ -> `OSVERSION`, legado -> `ALTABI`).
- `sysutils/pfSense-repo/files/pkg-install.in` foi atualizado para ler o conteúdo real de `.abi`, `.altabi` e `.osversion`, inferir `OSVERSION` a partir do major do `ABI` quando aplicável, e gerar `pkg.conf` condicionalmente (15+ com `OSVERSION`, <=14 preservando `ALTABI`).
- Arquivos alterados: `sysutils/pfSense-upgrade/files/Kontrol-repo-setup`, `sysutils/pfSense-upgrade/files/Kontrol-upgrade`, `sysutils/pfSense-repo/files/pkg-install.in`.

### Testing
- `sh -n sysutils/pfSense-upgrade/files/Kontrol-repo-setup` — sucesso.
- `sh -n sysutils/pfSense-upgrade/files/Kontrol-upgrade` — sucesso.
- `sh -n sysutils/pfSense-repo/files/pkg-install.in` — sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2ed7b1114832e940216200ba26b3c)