### PR TITLE
Silence some e2guardian log messages and guard dnshaper queue access in XML

### DIFF
--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc
@@ -2254,11 +2254,9 @@ EOF;
 
 
 	//log rotation script
-    	log_error("Checking log rotation");
 	$lrt_file = E2GUARDIAN_WWWDIR . "/e2guardian_logrotate.php";
 	$cron_cmd = E2GUARDIAN_BINDIR . "/php -q {$lrt_file}";
 	if ($logrotate == "on") {
-        log_error("Log rotate on");
 		e2g_check_cron($cron_cmd, "create", $cronminute, $cronhour);
 	} else {
 		file_put_contents($lrt_file, "", LOCK_EX);
@@ -2508,23 +2506,20 @@ function e2guardian_start($via_rpc = "no", $install_process = false, $force_star
                 copy(E2GUARDIAN_PKGDIR . '/e2guardian_rc.template', $script);
 		chmod ($script, 0755);
 		$max_threads = "sysctl kern.threads.max_threads_per_proc=20480";
-		if (is_process_running('e2guardian')) {
-			switch ($e2g_cfg['applyaction']){
-				case "rc.d":
-					log_error("Restarting e2g with rc.d script");
-					mwexec("$script stop");
-					sleep(2);
-                     			mwexec_bg("$script start");
-					break;
-				case "-r":
-					log_error("Sending USR1 to e2g processes");
-                                        mwexec_bg("$max_threads;" . E2GUARDIAN_SBINDIR . "/e2guardian -g");
-					break;
-				default:
-					log_error("Restarting e2g by sending -Q action to e2g binaries");
-                                        mwexec_bg("$max_threads;" . E2GUARDIAN_SBINDIR . "/e2guardian -Q");
-					break;
-			}
+			if (is_process_running('e2guardian')) {
+				switch ($e2g_cfg['applyaction']){
+					case "rc.d":
+						mwexec("$script stop");
+						sleep(2);
+	                     			mwexec_bg("$script start");
+						break;
+					case "-r":
+	                                        mwexec_bg("$max_threads;" . E2GUARDIAN_SBINDIR . "/e2guardian -g");
+						break;
+					default:
+	                                        mwexec_bg("$max_threads;" . E2GUARDIAN_SBINDIR . "/e2guardian -Q");
+						break;
+				}
 		} else {
 			//log_error('Starting E2guardian');
 			//mwexec("$script start");

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.xml
@@ -149,7 +149,7 @@
 					Do not forget to apply a mask on limiter if you want to define a per user/ip limit. and check Allow Users on Interface option above.<br>
 					<b>NOTE: </b> To match transparent clients too, apply limiters under <b>firewall -> rules</b> that allows access to this firewall(127.0.0.1) under Listen port(s).]]></description>
 			<type>select_source</type>
-			<source><![CDATA[$config['dnshaper']['queue']]]></source>
+			<source><![CDATA[(is_array($config['dnshaper'] ?? null) && is_array($config['dnshaper']['queue'] ?? null) ? $config['dnshaper']['queue'] : [])]]></source>
 			<source_name>name</source_name>
 			<source_value>number</source_value>
 			<show_disable_value>none</show_disable_value>
@@ -160,7 +160,7 @@
 			<description><![CDATA[Choose the Out queue/Virtual interface only if In is also selected.<br>
 				The Out selection is applied to traffic leaving the interface where the rule is created, the In selection is applied to traffic coming into the chosen interface.]]></description>
 			<type>select_source</type>
-			<source><![CDATA[$config['dnshaper']['queue']]]></source>
+			<source><![CDATA[(is_array($config['dnshaper'] ?? null) && is_array($config['dnshaper']['queue'] ?? null) ? $config['dnshaper']['queue'] : [])]]></source>
 			<source_name>name</source_name>
 			<source_value>number</source_value>
 			<show_disable_value>none</show_disable_value>


### PR DESCRIPTION
### Motivation

- Reduce noisy/unnecessary `log_error` output during log rotation and daemon restart/reload paths to avoid cluttering system logs.
- Prevent PHP warnings/notices when the `dnshaper` configuration or its `queue` key is missing by making `select_source` usage defensive. 

### Description

- Removed several `log_error` calls in `e2guardian.inc` around the log rotation and e2guardian restart/apply action code paths. 
- Kept the existing restart behavior but eliminated the informational logging inside the `applyaction` switch branch and log-rotation branch. 
- Updated the `inpipe` and `outpipe` `<source>` expressions in `e2guardian.xml` to use a defensive ternary that returns an empty array when `$config['dnshaper']` or its `queue` element is not an array: `(is_array($config['dnshaper'] ?? null) && is_array($config['dnshaper']['queue'] ?? null) ? $config['dnshaper']['queue'] : [])`.
- Minor whitespace/indentation cleanup in the modified sections. 

### Testing

- Ran PHP syntax check with `php -l` on the modified `e2guardian.inc` file and it returned no syntax errors. 
- Validated the modified XML with `xmllint --noout` on `e2guardian.xml` and it passed validation. 
- No unit tests exist for these files, and no automated integration tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3e0f4a694832e8e1e42fee3c59aad)