### PR TITLE
www/Kontrol-pkg-KontrolSquid-Legacy: PHP8-safe config iteration and bump PORTREVISION

### DIFF
--- a/www/Kontrol-pkg-KontrolSquid-Legacy/Makefile
+++ b/www/Kontrol-pkg-KontrolSquid-Legacy/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	Kontrol-pkg-KontrolSquid-Legacy
 PORTVERSION=	1.1.10
+PORTREVISION=	1
 CATEGORIES=	www
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/www/Kontrol-pkg-KontrolSquid-Legacy/files/usr/local/pkg/squid.inc
+++ b/www/Kontrol-pkg-KontrolSquid-Legacy/files/usr/local/pkg/squid.inc
@@ -1625,7 +1625,7 @@ EOD;
 /* Proxy Server: Remote Proxy Settings configuration handler */
 function squid_resync_upstream() {
 	$conf = "\n#Remote proxies\n";
-	foreach (config_get_path('installedpackages/squidremote/config') as $settings) {
+	foreach (config_get_path('installedpackages/squidremote/config', []) as $settings) {
 		if ($settings['enable'] == 'on') {
 			$conf .= "cache_peer {$settings['proxyaddr']} {$settings['hierarchy']} {$settings['proxyport']} ";
 			if ($settings['icpport'] == '7') {


### PR DESCRIPTION
### Motivation
- Evitar avisos/erros em tempo de execução com PHP 8 quando iterar sobre chaves de configuração que podem ser nulas ou ausentes. 
- Garantir que a correção seja empacotada incrementando a revisão do port.

### Description
- Adiciona `PORTREVISION=1` no `www/Kontrol-pkg-KontrolSquid-Legacy/Makefile` para publicar uma nova revisão do pacote. 
- Torna a iteração em `squid_resync_upstream()` robusta ao usar `config_get_path('installedpackages/squidremote/config', [])` em `files/usr/local/pkg/squid.inc`, fornecendo um array vazio como fallback para evitar iteração sobre `null`.

### Testing
- Executado `php -l www/Kontrol-pkg-KontrolSquid-Legacy/files/usr/local/pkg/squid.inc` que retornou `No syntax errors detected` (sucesso). 
- Tentativa de verificar variáveis do port via `make -C www/Kontrol-pkg-KontrolSquid-Legacy -V PORTNAME -V PORTVERSION -V PORTREVISION` falhou no ambiente devido ao `make` disponível ser GNU `make` (o teste requer `bmake` do FreeBSD), portanto esse passo não foi concluído aqui.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c432cfef74832e9aeb64498d1e3c9d)