### PR TITLE
www/squid415: stop inheriting std::binary_function to fix libc++ C++17 build

### DIFF
--- a/www/squid415/files/patch-src_HttpHeaderTools.h
+++ b/www/squid415/files/patch-src_HttpHeaderTools.h
@@ -1,0 +1,11 @@
+--- src/HttpHeaderTools.h.orig	2021-08-23 03:27:17 UTC
++++ src/HttpHeaderTools.h
+@@ -67,7 +67,7 @@
+ class HttpHeaderFieldAttrs;
+ 
+ class HttpHeaderFieldStat {
+-    class NoCaseLessThan: public std::binary_function<std::string, std::string, bool>
++    class NoCaseLessThan
+     {
+     public:
+         bool operator() (const std::string &lhs, const std::string &rhs) const

--- a/www/squid415/files/patch-src_base_LookupTable.h
+++ b/www/squid415/files/patch-src_base_LookupTable.h
@@ -1,0 +1,11 @@
+--- src/base/LookupTable.h.orig	2021-08-23 03:27:17 UTC
++++ src/base/LookupTable.h
+@@ -47,7 +47,7 @@
+ /// Implement algorithm expected by Splay
+ /// using char* compare, to preserve historical behavior
+ /// and minimize refactoring.
+-class SBufCaseInsensitiveLess : public std::binary_function<SBuf, SBuf, bool> {
++class SBufCaseInsensitiveLess {
+ public:
+     bool operator() (const SBuf &, const SBuf &) const;
+ };


### PR DESCRIPTION
### Motivation
- The Squid 4.15 build fails on modern libc++/C++17 because `std::binary_function` is removed, producing hard errors in `src/base/LookupTable.h` and `src/HttpHeaderTools.h`. 
- The change aims to make the port compile with current C++ standard libraries by removing the obsolete inheritance while preserving behavior.

### Description
- Add `www/squid415/files/patch-src_base_LookupTable.h` to remove `: public std::binary_function<SBuf, SBuf, bool>` from `SBufCaseInsensitiveLess` and keep its `operator()` intact. 
- Add `www/squid415/files/patch-src_HttpHeaderTools.h` to remove `: public std::binary_function<std::string, std::string, bool>` from `NoCaseLessThan` and keep its `operator()` intact. 
- Both patches preserve existing comparator semantics and avoid further refactoring by dropping the unnecessary base class.

### Testing
- `git status --short` was run and showed the two new patch files staged for commit (succeeded). 
- Committed the changes to the local tree with `git commit` (succeeded). 
- Attempted the ports make-variable check with `make -C www/squid415 -V ...` but it failed because this environment uses GNU `make` and not FreeBSD `bmake`, so a full ports-framework or build validation could not be executed here (failed due to environment limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4438ded6c832ebdc4a1e3b955bc31)