### PR TITLE
Remove deprecated std::binary_function usage and update mem_fun to mem_fn; add <functional> include

### DIFF
--- a/www/squid415/files/patch-src_HttpHeaderTools.h
+++ b/www/squid415/files/patch-src_HttpHeaderTools.h
@@ -1,0 +1,11 @@
+--- src/HttpHeaderTools.h.orig	2021-08-23 03:27:17 UTC
++++ src/HttpHeaderTools.h
+@@ -67,7 +67,7 @@
+ private:
+     /// Case-insensitive std::string "less than" comparison functor.
+     /// Fast version recommended by Meyers' "Effective STL" for ASCII c-strings.
+-    class NoCaseLessThan: public std::binary_function<std::string, std::string, bool>
++    class NoCaseLessThan
+     {
+     public:
+         bool operator()(const std::string &lhs, const std::string &rhs) const {

--- a/www/squid415/files/patch-src_acl_InnerNode.cc
+++ b/www/squid415/files/patch-src_acl_InnerNode.cc
@@ -1,0 +1,17 @@
+--- src/acl/InnerNode.cc.orig	2021-08-23 03:27:17 UTC
++++ src/acl/InnerNode.cc
+@@ -16,12 +16,13 @@
+ #include "Debug.h"
+ #include "globals.h"
+ #include <algorithm>
++#include <functional>
+ 
+ void
+ Acl::InnerNode::prepareForUse()
+ {
+-    std::for_each(nodes.begin(), nodes.end(), std::mem_fun(&ACL::prepareForUse));
++    std::for_each(nodes.begin(), nodes.end(), std::mem_fn(&ACL::prepareForUse));
+ }
+ 
+ bool
+ Acl::InnerNode::empty() const

--- a/www/squid415/files/patch-src_base_LookupTable.h
+++ b/www/squid415/files/patch-src_base_LookupTable.h
@@ -1,0 +1,11 @@
+--- src/base/LookupTable.h.orig	2021-08-23 03:27:17 UTC
++++ src/base/LookupTable.h
+@@ -47,7 +47,7 @@
+  *
+  */
+ 
+-class SBufCaseInsensitiveLess : public std::binary_function<SBuf, SBuf, bool> {
++class SBufCaseInsensitiveLess {
+ public:
+     bool operator() (const SBuf &x, const SBuf &y) const {
+         return x.caseCmp(y) < 0;


### PR DESCRIPTION
### Motivation
- Remove deprecated uses of `std::binary_function` and update legacy function adapters to compile cleanly with modern C++ toolchains.
- Replace `std::mem_fun` with `std::mem_fn` to avoid deprecation and ensure correct behavior with member function pointers.

### Description
- In `src/HttpHeaderTools.h` removed inheritance from `std::binary_function` for `NoCaseLessThan` and left a plain functor class with `operator()`.
- In `src/base/LookupTable.h` removed `std::binary_function` inheritance from `SBufCaseInsensitiveLess` and kept the functor implementation.
- In `src/acl/InnerNode.cc` added `#include <functional>` and replaced `std::mem_fun(&ACL::prepareForUse)` with `std::mem_fn(&ACL::prepareForUse)`.

### Testing
- Performed a project build (`make`) after the changes and the compilation completed successfully with the updated code.
- No automated unit tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4438ded6c832ebdc4a1e3b955bc31)