### PR TITLE
Modernize C++ usage: remove deprecated adapters and fix redundant cast

### DIFF
--- a/www/squid415/files/patch-src_CpuAffinitySet.cc
+++ b/www/squid415/files/patch-src_CpuAffinitySet.cc
@@ -1,0 +1,11 @@
+--- src/CpuAffinitySet.cc.orig	2021-08-23 03:27:17 UTC
++++ src/CpuAffinitySet.cc
+@@ -38,7 +38,7 @@
+     } else {
+         cpu_set_t cpuSet;
+         memcpy(&cpuSet, &theCpuSet, sizeof(cpuSet));
+-        (void) CPU_AND(&cpuSet, &cpuSet, &theOrigCpuSet);
++        CPU_AND(&cpuSet, &cpuSet, &theOrigCpuSet);
+         if (CPU_COUNT(&cpuSet) <= 0) {
+             debugs(54, DBG_IMPORTANT, "ERROR: invalid CPU affinity for process "
+                    "PID " << getpid() << ", may be caused by an invalid core in "

--- a/www/squid415/files/patch-src_HttpHeaderTools.h
+++ b/www/squid415/files/patch-src_HttpHeaderTools.h
@@ -1,0 +1,11 @@
+--- src/HttpHeaderTools.h.orig	2021-08-23 03:27:17 UTC
++++ src/HttpHeaderTools.h
+@@ -67,7 +67,7 @@
+ private:
+     /// Case-insensitive std::string "less than" comparison functor.
+     /// Fast version recommended by Meyers' "Effective STL" for ASCII c-strings.
+-    class NoCaseLessThan: public std::binary_function<std::string, std::string, bool>
++    class NoCaseLessThan
+     {
+     public:
+         bool operator()(const std::string &lhs, const std::string &rhs) const {

--- a/www/squid415/files/patch-src_acl_InnerNode.cc
+++ b/www/squid415/files/patch-src_acl_InnerNode.cc
@@ -1,0 +1,17 @@
+--- src/acl/InnerNode.cc.orig	2021-08-23 03:27:17 UTC
++++ src/acl/InnerNode.cc
+@@ -16,12 +16,13 @@
+ #include "Debug.h"
+ #include "globals.h"
+ #include <algorithm>
++#include <functional>
+ 
+ void
+ Acl::InnerNode::prepareForUse()
+ {
+-    std::for_each(nodes.begin(), nodes.end(), std::mem_fun(&ACL::prepareForUse));
++    std::for_each(nodes.begin(), nodes.end(), std::mem_fn(&ACL::prepareForUse));
+ }
+ 
+ bool
+ Acl::InnerNode::empty() const

--- a/www/squid415/files/patch-src_base_LookupTable.h
+++ b/www/squid415/files/patch-src_base_LookupTable.h
@@ -1,0 +1,11 @@
+--- src/base/LookupTable.h.orig	2021-08-23 03:27:17 UTC
++++ src/base/LookupTable.h
+@@ -47,7 +47,7 @@
+  *
+  */
+ 
+-class SBufCaseInsensitiveLess : public std::binary_function<SBuf, SBuf, bool> {
++class SBufCaseInsensitiveLess {
+ public:
+     bool operator() (const SBuf &x, const SBuf &y) const {
+         return x.caseCmp(y) < 0;


### PR DESCRIPTION
### Motivation

- Remove use of deprecated C++98 adapters and adapters removed in modern standards and fix a redundant cast to silence warnings and ensure compatibility with C++17+ toolchains. 

### Description

- Remove inheritance from `std::binary_function` in `NoCaseLessThan` (in `src/HttpHeaderTools.h`) and `SBufCaseInsensitiveLess` (in `src/base/LookupTable.h`).
- Replace `std::mem_fun` with `std::mem_fn` and add `#include <functional>` in `src/acl/InnerNode.cc`.
- Remove an unnecessary cast-to-`void` on the `CPU_AND` call in `src/CpuAffinitySet.cc`.

### Testing

- Built the project with a C++17-capable toolchain using `./configure && make`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4438ded6c832ebdc4a1e3b955bc31)