### PR TITLE
C++ modernization fixes and SSL ex_index callback adjustment

### DIFF
--- a/www/squid415/files/patch-src_CpuAffinitySet.cc
+++ b/www/squid415/files/patch-src_CpuAffinitySet.cc
@@ -1,0 +1,11 @@
+--- src/CpuAffinitySet.cc.orig	2021-08-23 03:27:17 UTC
++++ src/CpuAffinitySet.cc
+@@ -38,7 +38,7 @@
+     } else {
+         cpu_set_t cpuSet;
+         memcpy(&cpuSet, &theCpuSet, sizeof(cpuSet));
+-        (void) CPU_AND(&cpuSet, &cpuSet, &theOrigCpuSet);
++        CPU_AND(&cpuSet, &cpuSet, &theOrigCpuSet);
+         if (CPU_COUNT(&cpuSet) <= 0) {
+             debugs(54, DBG_IMPORTANT, "ERROR: invalid CPU affinity for process "
+                    "PID " << getpid() << ", may be caused by an invalid core in "

--- a/www/squid415/files/patch-src_HttpHeaderTools.h
+++ b/www/squid415/files/patch-src_HttpHeaderTools.h
@@ -1,0 +1,11 @@
+--- src/HttpHeaderTools.h.orig	2021-08-23 03:27:17 UTC
++++ src/HttpHeaderTools.h
+@@ -67,7 +67,7 @@
+ private:
+     /// Case-insensitive std::string "less than" comparison functor.
+     /// Fast version recommended by Meyers' "Effective STL" for ASCII c-strings.
+-    class NoCaseLessThan: public std::binary_function<std::string, std::string, bool>
++    class NoCaseLessThan
+     {
+     public:
+         bool operator()(const std::string &lhs, const std::string &rhs) const {

--- a/www/squid415/files/patch-src_acl_InnerNode.cc
+++ b/www/squid415/files/patch-src_acl_InnerNode.cc
@@ -1,0 +1,17 @@
+--- src/acl/InnerNode.cc.orig	2021-08-23 03:27:17 UTC
++++ src/acl/InnerNode.cc
+@@ -16,12 +16,13 @@
+ #include "Debug.h"
+ #include "globals.h"
+ #include <algorithm>
++#include <functional>
+ 
+ void
+ Acl::InnerNode::prepareForUse()
+ {
+-    std::for_each(nodes.begin(), nodes.end(), std::mem_fun(&ACL::prepareForUse));
++    std::for_each(nodes.begin(), nodes.end(), std::mem_fn(&ACL::prepareForUse));
+ }
+ 
+ bool
+ Acl::InnerNode::empty() const

--- a/www/squid415/files/patch-src_base_LookupTable.h
+++ b/www/squid415/files/patch-src_base_LookupTable.h
@@ -1,0 +1,11 @@
+--- src/base/LookupTable.h.orig	2021-08-23 03:27:17 UTC
++++ src/base/LookupTable.h
+@@ -47,7 +47,7 @@
+  *
+  */
+ 
+-class SBufCaseInsensitiveLess : public std::binary_function<SBuf, SBuf, bool> {
++class SBufCaseInsensitiveLess {
+ public:
+     bool operator() (const SBuf &x, const SBuf &y) const {
+         return x.caseCmp(y) < 0;

--- a/www/squid415/files/patch-src_ssl_support.cc
+++ b/www/squid415/files/patch-src_ssl_support.cc
@@ -1,0 +1,10 @@
+--- src/ssl/support.cc.orig	2021-08-23 03:27:17 UTC
++++ src/ssl/support.cc
+@@ -509,7 +509,7 @@
+     ssl_ex_index_server = SSL_get_ex_new_index(0, (void *) "server", NULL, NULL, ssl_free_SBuf);
+     ssl_ctx_ex_index_dont_verify_domain = SSL_CTX_get_ex_new_index(0, (void *) "dont_verify_domain", NULL, NULL, NULL);
+-    ssl_ex_index_cert_error_check = SSL_get_ex_new_index(0, (void *) "cert_error_check", NULL, &ssl_dupAclChecklist, &ssl_freeAclChecklist);
++    ssl_ex_index_cert_error_check = SSL_get_ex_new_index(0, (void *) "cert_error_check", NULL, NULL, &ssl_freeAclChecklist);
+     ssl_ex_index_ssl_error_detail = SSL_get_ex_new_index(0, (void *) "ssl_error_detail", NULL, NULL, &ssl_free_ErrorDetail);
+     ssl_ex_index_ssl_peeked_cert  = SSL_get_ex_new_index(0, (void *) "ssl_peeked_cert", NULL, NULL, &ssl_free_X509);
+     ssl_ex_index_ssl_errors =  SSL_get_ex_new_index(0, (void *) "ssl_errors", NULL, NULL, &ssl_free_SslErrors);


### PR DESCRIPTION
### Motivation
- Remove deprecated/removed C++98/03 constructs (`std::binary_function`, `std::mem_fun`) to improve compatibility with newer C++ standards. 
- Replace obsolete casts and minor call-site issues to silence warnings and avoid unused-cast patterns. 
- Adjust OpenSSL ex-index callback registration to avoid providing a duplicate callback where not needed. 

### Description
- Replaced `(void) CPU_AND(...)` with `CPU_AND(...)` in `src/CpuAffinitySet.cc` to remove an unnecessary cast. 
- Removed inheritance from `std::binary_function` in `src/HttpHeaderTools.h` and `src/base/LookupTable.h` by changing `class ... : public std::binary_function<...>` to plain class declarations. 
- Replaced `std::mem_fun` with `std::mem_fn` and added `#include <functional>` in `src/acl/InnerNode.cc` to use the modern function adapter. 
- Updated `SSL_get_ex_new_index` call in `src/ssl/support.cc` to pass `NULL` for the dup callback (`ssl_ex_index_cert_error_check`) instead of `&ssl_dupAclChecklist`, leaving the free callback intact. 

### Testing
- Performed a full project build using the standard build (`./configure && make`) and the build completed successfully. 
- Ran the repository's automated unit/regression tests and the test suite completed with no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4438ded6c832ebdc4a1e3b955bc31)