### PR TITLE
squid415: compatibility fixes for modern toolchains and require OpenSSL 1.1; update Kontrol package deps

### DIFF
--- a/www/Kontrol-pkg-KontrolSquid-Legacy/Makefile
+++ b/www/Kontrol-pkg-KontrolSquid-Legacy/Makefile
@@ -13,15 +13,15 @@ COMMENT=	Kontrol Custom Squid Package
 
 LICENSE=	APACHE20
 
-BUILD_DEPENDS=	squid415-4.15*:www/squid415
-RUN_DEPENDS=	squid415-4.15*:www/squid415 \
+BUILD_DEPENDS=	squid415>=4.15:www/squid415
+RUN_DEPENDS=	squid415>=4.15:www/squid415 \
 		squid_radius_auth>=0:www/squid_radius_auth \
 		c-icap-modules>=0:www/c-icap-modules \
 		squidclamav>=0:www/squidclamav \
 		samba416>=0:net/samba416 \
 		base64>=0:converters/base64
 
-CONFLITS_WITH=	Kontrol-pkg-squid
+CONFLICTS_WITH=	Kontrol-pkg-squid
 
 NO_BUILD=	yes
 NO_MTREE=	yes

--- a/www/squid415/Makefile
+++ b/www/squid415/Makefile
@@ -15,6 +15,11 @@ LICENSE_FILE=	${WRKSRC}/COPYING
 
 USES=		compiler:c++11-lib cpe gmake localbase:ldflags perl5 \
 		shebangfix tar:xz
+# Force OpenSSL 1.1 for this legacy branch to avoid OpenSSL 3 API breakage
+DEFAULT_VERSIONS+=	ssl=openssl111
+# Squid 4.15 uses OpenSSL APIs deprecated in OpenSSL 3.0+;
+# keep deprecation diagnostics non-fatal in strict builder environments.
+CXXFLAGS+=	-Wno-error=deprecated-declarations
 CPE_VENDOR=	squid-cache
 USE_RC_SUBR=	squid
 
@@ -64,8 +69,10 @@ OPTIONS_DEFINE=		ARP_ACL CACHE_DIGESTS DEBUG DELAY_POOLS DOCS ECAP ESI \
 			SSL SSL_CRTD STACKTRACES TDB VIA_DB WCCP WCCPV2
 # Squid 4.15 legacy: keep NIS optional (not default) to avoid
 # configure failure in environments where NIS helper cannot be built.
+# OpenSSL from ports is incompatible with GSSAPI_BASE in this port;
+# prefer GSSAPI_MIT by default to avoid IGNORE conflicts.
 OPTIONS_DEFAULT=	ARP_ACL CACHE_DIGESTS DELAY_POOLS FOLLOW_XFF \
-			FS_AUFS FS_DISKD FS_ROCK GSSAPI_BASE HTCP ICAP ICMP \
+			FS_AUFS FS_DISKD FS_ROCK GSSAPI_MIT HTCP ICAP ICMP \
 			IDENT KQUEUE LARGEFILE LAX_HTTP SNMP SSL SSL_CRTD \
 			TP_IPFW VIA_DB WCCP WCCPV2
 OPTIONS_GROUP=		AUTH

--- a/www/squid415/files/patch-src_CpuAffinitySet.cc
+++ b/www/squid415/files/patch-src_CpuAffinitySet.cc
@@ -1,0 +1,11 @@
+--- src/CpuAffinitySet.cc.orig	2021-08-23 03:27:17 UTC
++++ src/CpuAffinitySet.cc
+@@ -38,7 +38,7 @@
+     } else {
+         cpu_set_t cpuSet;
+         memcpy(&cpuSet, &theCpuSet, sizeof(cpuSet));
+-        (void) CPU_AND(&cpuSet, &cpuSet, &theOrigCpuSet);
++        CPU_AND(&cpuSet, &cpuSet, &theOrigCpuSet);
+         if (CPU_COUNT(&cpuSet) <= 0) {
+             debugs(54, DBG_IMPORTANT, "ERROR: invalid CPU affinity for process "
+                    "PID " << getpid() << ", may be caused by an invalid core in "

--- a/www/squid415/files/patch-src_HttpHeaderTools.h
+++ b/www/squid415/files/patch-src_HttpHeaderTools.h
@@ -1,0 +1,11 @@
+--- src/HttpHeaderTools.h.orig	2021-08-23 03:27:17 UTC
++++ src/HttpHeaderTools.h
+@@ -67,7 +67,7 @@
+ private:
+     /// Case-insensitive std::string "less than" comparison functor.
+     /// Fast version recommended by Meyers' "Effective STL" for ASCII c-strings.
+-    class NoCaseLessThan: public std::binary_function<std::string, std::string, bool>
++    class NoCaseLessThan
+     {
+     public:
+         bool operator()(const std::string &lhs, const std::string &rhs) const {

--- a/www/squid415/files/patch-src_acl_InnerNode.cc
+++ b/www/squid415/files/patch-src_acl_InnerNode.cc
@@ -1,0 +1,17 @@
+--- src/acl/InnerNode.cc.orig	2021-08-23 03:27:17 UTC
++++ src/acl/InnerNode.cc
+@@ -16,12 +16,13 @@
+ #include "Debug.h"
+ #include "globals.h"
+ #include <algorithm>
++#include <functional>
+ 
+ void
+ Acl::InnerNode::prepareForUse()
+ {
+-    std::for_each(nodes.begin(), nodes.end(), std::mem_fun(&ACL::prepareForUse));
++    std::for_each(nodes.begin(), nodes.end(), std::mem_fn(&ACL::prepareForUse));
+ }
+ 
+ bool
+ Acl::InnerNode::empty() const

--- a/www/squid415/files/patch-src_base_LookupTable.h
+++ b/www/squid415/files/patch-src_base_LookupTable.h
@@ -1,0 +1,11 @@
+--- src/base/LookupTable.h.orig	2021-08-23 03:27:17 UTC
++++ src/base/LookupTable.h
+@@ -47,7 +47,7 @@
+  *
+  */
+ 
+-class SBufCaseInsensitiveLess : public std::binary_function<SBuf, SBuf, bool> {
++class SBufCaseInsensitiveLess {
+ public:
+     bool operator() (const SBuf &x, const SBuf &y) const {
+         return x.caseCmp(y) < 0;

--- a/www/squid415/files/patch-src_ssl_support.cc
+++ b/www/squid415/files/patch-src_ssl_support.cc
@@ -1,0 +1,10 @@
+--- src/ssl/support.cc.orig	2021-08-23 03:27:17 UTC
++++ src/ssl/support.cc
+@@ -509,7 +509,7 @@
+     ssl_ex_index_server = SSL_get_ex_new_index(0, (void *) "server", NULL, NULL, ssl_free_SBuf);
+     ssl_ctx_ex_index_dont_verify_domain = SSL_CTX_get_ex_new_index(0, (void *) "dont_verify_domain", NULL, NULL, NULL);
+-    ssl_ex_index_cert_error_check = SSL_get_ex_new_index(0, (void *) "cert_error_check", NULL, &ssl_dupAclChecklist, &ssl_freeAclChecklist);
++    ssl_ex_index_cert_error_check = SSL_get_ex_new_index(0, (void *) "cert_error_check", NULL, NULL, &ssl_freeAclChecklist);
+     ssl_ex_index_ssl_error_detail = SSL_get_ex_new_index(0, (void *) "ssl_error_detail", NULL, NULL, &ssl_free_ErrorDetail);
+     ssl_ex_index_ssl_peeked_cert  = SSL_get_ex_new_index(0, (void *) "ssl_peeked_cert", NULL, NULL, &ssl_free_X509);
+     ssl_ex_index_ssl_errors =  SSL_get_ex_new_index(0, (void *) "ssl_errors", NULL, NULL, &ssl_free_SslErrors);


### PR DESCRIPTION
### Motivation
- Keep Squid 4.15 buildable on modern toolchains and avoid OpenSSL 3 API breakage while preserving compatibility for the legacy branch. 
- Address C++ API removals and deprecated/removed helper functions to fix compile errors with newer compilers and libraries. 
- Ensure the Kontrol custom package depends on a suitable `squid415` version range. 

### Description
- Force OpenSSL 1.1 for this legacy Squid 4.15 branch by adding `DEFAULT_VERSIONS+= ssl=openssl111` and suppress deprecation-as-error by adding `CXXFLAGS+= -Wno-error=deprecated-declarations` in `www/squid415/Makefile`. 
- Prefer `GSSAPI_MIT` in `OPTIONS_DEFAULT` and add a comment about OpenSSL/GSSAPI interaction to avoid conflicts. 
- Update `www/Kontrol-pkg-KontrolSquid-Legacy/Makefile` to use `BUILD_DEPENDS`/`RUN_DEPENDS` with `squid415>=4.15:www/squid415` dependency syntax. 
- Add a set of source patches under `www/squid415/files/` to modernize the code: remove uses of deprecated `std::binary_function`, replace `std::mem_fun` with `std::mem_fn`, remove unnecessary cast on `CPU_AND`, and adjust `SSL_get_ex_new_index` usage to match expected callbacks and avoid double-free/dup issues. 

### Testing
- Built the `www/squid415` port in the ports tree with `make` and the port compiled and staged successfully. 
- Verified the `Kontrol-pkg-KontrolSquid-Legacy` Makefile dependency changes by staging the package build, which completed without dependency resolution errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4438ded6c832ebdc4a1e3b955bc31)