### PR TITLE
sarg: adicionar botão de exclusão de relatórios e índice dinâmico resiliente

### DIFF
--- a/www/Kontrol-pkg-sarg/files/usr/local/www/sarg_frame.php
+++ b/www/Kontrol-pkg-sarg/files/usr/local/www/sarg_frame.php
@@ -35,6 +35,48 @@ session_start();
 //Starting Cache Session - export to PDF process
 ob_start();
 
+function sarg_build_runtime_index($dir, $dsuffix = "") {
+	$items = array();
+	if (is_dir($dir)) {
+		foreach (glob($dir . "/*", GLOB_ONLYDIR) as $path) {
+			$name = basename($path);
+			if ($name == "images") {
+				continue;
+			}
+			if (file_exists($path . "/index.html") || file_exists($path . "/index.html.gz")) {
+				$items[] = array(
+					'name' => $name,
+					'mtime' => filemtime($path)
+				);
+			}
+		}
+	}
+	usort($items, function($a, $b) {
+		return $b['mtime'] <=> $a['mtime'];
+	});
+
+	$html = '<!DOCTYPE html><html><head><meta charset="UTF-8">';
+	$html .= '<title>Sarg Reports</title>';
+	$html .= '<style>body{font-family:Segoe UI,Arial,sans-serif;padding:12px;}';
+	$html .= 'table{border-collapse:collapse;width:100%;}';
+	$html .= 'th,td{padding:8px;border-bottom:1px solid #ddd;text-align:left;}';
+	$html .= 'h2{margin-top:0;}</style></head><body>';
+	$html .= '<h2>Sarg Reports</h2>';
+	$html .= '<table><thead><tr><th>Directory</th><th>Last update</th></tr></thead><tbody>';
+
+	if (empty($items)) {
+		$html .= '<tr><td colspan="2">No reports found.</td></tr>';
+	} else {
+		foreach ($items as $item) {
+			$link = '/sarg_frame.php?dir=' . urlencode($dsuffix) . '&file=' . rawurlencode($item['name']) . '/index.html';
+			$html .= '<tr><td><a href="' . htmlspecialchars($link) . '">' . htmlspecialchars($item['name']) . '</a></td>';
+			$html .= '<td>' . date("Y-m-d H:i:s", $item['mtime']) . '</td></tr>';
+		}
+	}
+	$html .= '</tbody></table></body></html>';
+	return $html;
+}
+
 
 $uname = posix_uname();
 if ($uname['machine'] == 'amd64') {
@@ -74,6 +116,8 @@ if (file_exists("{$dir}/{$url}")) {
 	$data = gzfile("{$dir}/{$url}.gz");
 	$report = implode($data);
 	unset ($data);
+} elseif ($url == "index.html" && $prefix == "") {
+	$report = sarg_build_runtime_index($dir, $dsuffix);
 }
 if ($report != "" ) {
 	$pattern[0] = "/href=\W(\S+html)\W/";

--- a/www/Kontrol-pkg-sarg/files/usr/local/www/sarg_reports.php
+++ b/www/Kontrol-pkg-sarg/files/usr/local/www/sarg_reports.php
@@ -29,14 +29,67 @@
 */
 require("guiconfig.inc");
 
-if ($savemsg) {
-    print_info_box($savemsg);
-}
-
 if ($uname['machine'] == 'amd64') {
         ini_set('memory_limit', '512M');
 }
 
+function sarg_reports_base_dir($suffix = "") {
+	$dir = "/usr/local/sarg-reports";
+	if ($suffix != "") {
+		$dir .= "/" . preg_replace("/\W/", "", $suffix);
+	}
+	return $dir;
+}
+
+function sarg_list_report_directories($dir) {
+	$reports = array();
+	if (!is_dir($dir)) {
+		return $reports;
+	}
+	foreach (glob($dir . "/*", GLOB_ONLYDIR) as $path) {
+		$name = basename($path);
+		if ($name == "images") {
+			continue;
+		}
+		if (file_exists($path . "/index.html") || file_exists($path . "/index.html.gz")) {
+			$reports[$name] = array(
+				'name' => $name,
+				'path' => $path,
+				'mtime' => filemtime($path)
+			);
+		}
+	}
+	uasort($reports, function($a, $b) {
+		return $b['mtime'] <=> $a['mtime'];
+	});
+	return $reports;
+}
+
+$input_errors = array();
+$savemsg = "";
+$dir_suffix = preg_replace("/\W/", "", $_REQUEST['dir']);
+$report_base_dir = sarg_reports_base_dir($dir_suffix);
+
+if ($_POST['delete_report'] == "yes") {
+	$report_name = preg_replace("/[^a-zA-Z0-9._-]/", "", $_POST['report_name']);
+	if ($report_name == "") {
+		$input_errors[] = gettext("Report name is invalid.");
+	} elseif ($report_name == "images") {
+		$input_errors[] = gettext("The shared images directory cannot be deleted.");
+	} else {
+		$full_path = "{$report_base_dir}/{$report_name}";
+		if (!is_dir($full_path)) {
+			$input_errors[] = sprintf(gettext("Report '%s' not found."), htmlspecialchars($report_name));
+		} elseif (strpos(realpath($full_path), realpath($report_base_dir)) !== 0) {
+			$input_errors[] = gettext("Invalid report path.");
+		} else {
+			conf_mount_rw();
+			rmdir_recursive($full_path);
+			conf_mount_ro();
+			$savemsg = sprintf(gettext("Report '%s' deleted successfully."), htmlspecialchars($report_name));
+		}
+	}
+}
 
 $pgtitle = array(gettext("Package"), gettext("Sarg"), gettext("Reports"));
 $shortcut_section = "sarg";
@@ -60,10 +113,18 @@ if ($_REQUEST['dir'] != "") {
     
 ?>
 <body link="#0000CC" vlink="#0000CC" alink="#0000CC">
-<form>
+<form method="post">
 <div id="mainlevel">
 <table width="100%" border="0" cellpadding="0" cellspacing="0">
 	<tr><td>
+		<?php
+		if (!empty($input_errors)) {
+			print_input_errors($input_errors);
+		}
+		if (!empty($savemsg)) {
+			print_info_box($savemsg);
+		}
+		?>
 		<?php
 		$tab_array = array();
 		$tab_array[] = array(gettext("General"), false, "/pkg_edit.php?xml=sarg.xml&id=0");
@@ -104,6 +165,41 @@ if ($_REQUEST['dir'] != "") {
 		<div id="mainarea">
 		</div>
 		<br />
+		<?php $reports = sarg_list_report_directories($report_base_dir); ?>
+		<div class="panel panel-default">
+			<div class="panel-heading"><h2 class="panel-title"><?=gettext("Manage stored reports")?></h2></div>
+			<div class="panel-body">
+				<?php if (empty($reports)): ?>
+					<?=gettext("No generated report directories were found for this view.")?>
+				<?php else: ?>
+					<table class="table table-striped table-condensed">
+						<thead>
+							<tr>
+								<th><?=gettext("Report directory")?></th>
+								<th><?=gettext("Last update")?></th>
+								<th><?=gettext("Actions")?></th>
+							</tr>
+						</thead>
+						<tbody>
+							<?php foreach ($reports as $report): ?>
+							<tr>
+								<td><?=htmlspecialchars($report['name'])?></td>
+								<td><?=date("Y-m-d H:i:s", $report['mtime'])?></td>
+								<td>
+									<button type="submit" class="btn btn-danger btn-xs"
+									        name="report_name" value="<?=htmlspecialchars($report['name'])?>"
+									        onclick="return confirm('<?=gettext("Delete this report directory? This action cannot be undone.")?>');">
+										<?=gettext("Delete")?>
+									</button>
+								</td>
+							</tr>
+							<?php endforeach; ?>
+						</tbody>
+					</table>
+				<?php endif; ?>
+				<input type="hidden" name="delete_report" value="yes" />
+			</div>
+		</div>
 		<script type="text/javascript">
 		//<![CDATA[
 		var axel = Math.random() + "";


### PR DESCRIPTION
### Motivation
- Permitir que o administrador apague diretórios de relatórios gerados pelo Sarg diretamente pela interface do pacote para limpar relatórios antigos.
- Evitar que a remoção de relatórios quebre a navegação HTML quando o índice estático (`index.html`) estiver ausente ou desatualizado.
- Verificar viabilidade de leitura de logs nativos do E2Guardian e documentar o estado atual de compatibilidade.

### Description
- Adiciona funções de gerenciamento e listagem em `sarg_reports.php`: `sarg_reports_base_dir()` e `sarg_list_report_directories()` para descobrir diretórios de relatório e ordenar por modificação; adiciona UI com tabela e botão `Delete` por diretório e validações de entrada para impedir nomes inválidos, exclusão do diretório `images` e path traversal; usa `conf_mount_rw()`/`rmdir_recursive()` para remoção segura.
- Implementa fallback em `sarg_frame.php` com `sarg_build_runtime_index()` que gera dinamicamente uma página índice listando apenas diretórios de relatório existentes quando `index.html` raiz não é encontrado, desacoplando a navegação da existência de um índice estático.
- Ajustes menores: formulário em `sarg_reports.php` agora usa `method="post"` e pequenos hardening/normalização de parâmetros (`preg_replace`/`preg_replace` sanitizadores); remoção de tentativa anterior de print direto de `$savemsg` foi reorganizada para exibir mensagens via `print_input_errors()`/`print_info_box()`.
- Arquivos modificados: `www/Kontrol-pkg-sarg/files/usr/local/www/sarg_reports.php` e `www/Kontrol-pkg-sarg/files/usr/local/www/sarg_frame.php`.
- Observação sobre E2Guardian: o código atual valida que o formato de log do E2Guardian esteja em modo "squid" (o pacote exige `logfileformat == 3`), portanto a leitura direta do formato nativo do E2Guardian não é suportada apenas por configuração; é factível converter os logs nativos para o formato aceito pelo Sarg via um conversor intermediário, mas isso exige alteração/adição fora do escopo deste PR (parser ou pré-processamento dos logs).

### Testing
- Verificações de sintaxe PHP com `php -l` foram executadas em `sarg_reports.php` e `sarg_frame.php` e retornaram sem erros.
- Testes funcionais manuais não foram executados neste ambiente (sem browser GUI), mas a listagem, validação e geração dinâmica de índice foram cobertas por inspeção de código e verificação de chamadas I/O (uso de `glob`, `file_exists`, `filemtime`).
- Nenhum teste automatizado adicional foi incluído; mudanças focadas em UI backend e fallback de índice demonstraram compatibilidade estática pelo linter PHP.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbd83ff074832e99819d1349df96a4)