### PR TITLE
sarg: validar logs antes de gerar, usar nível INFO e aplicar sync antes do Force Update

### DIFF
--- a/www/Kontrol-pkg-sarg/files/usr/local/pkg/sarg.inc
+++ b/www/Kontrol-pkg-sarg/files/usr/local/pkg/sarg.inc
@@ -165,6 +165,7 @@ function sarg_resync() {
 		sync_package_sarg();
 	}
 	if ($_POST['Submit'] == 'Force update now') {
+		sync_package_sarg();
 		run_sarg();
 	}
 }
@@ -184,6 +185,33 @@ function run_sarg($id = -1) {
 	    } else {
 	        die("log file configuration not found");
 	    }
+	}
+
+	if (!file_exists($rs_file)) {
+		$error_msg = sprintf(gettext("[sarg] Report generation aborted: log file '%s' does not exist."), $rs_file);
+		log_error($error_msg);
+		file_notice("sarg_log_check", $error_msg, gettext("Sarg report generation"), "/sarg_reports.php");
+		return;
+	}
+	if (!is_readable($rs_file)) {
+		$error_msg = sprintf(gettext("[sarg] Report generation aborted: log file '%s' is not readable."), $rs_file);
+		log_error($error_msg);
+		file_notice("sarg_log_check", $error_msg, gettext("Sarg report generation"), "/sarg_reports.php");
+		return;
+	}
+	$sample_line = trim((string)@file_get_contents($rs_file, false, null, 0, 512));
+	if ($sample_line === "") {
+		$error_msg = sprintf(gettext("[sarg] Report generation aborted: log file '%s' is empty."), $rs_file);
+		log_error($error_msg);
+		file_notice("sarg_log_check", $error_msg, gettext("Sarg report generation"), "/sarg_reports.php");
+		return;
+	}
+	if ($proxy_server_log == "e2guardian" && !preg_match('/\s(?:TCP_|NONE\/|TAG_NONE)/', $sample_line)) {
+		$error_msg = gettext("[sarg] Report generation aborted: E2Guardian log does not look like Squid-compatible format.");
+		$error_msg .= " " . gettext("On E2Guardian, set Log file format to Squid.");
+		log_error($error_msg);
+		file_notice("sarg_log_check", $error_msg, gettext("Sarg report generation"), "/sarg_reports.php");
+		return;
 	}
 
 	if ($id >= 0 && is_array($config['installedpackages']['sargschedule']['config'])) {
@@ -219,7 +247,7 @@ function run_sarg($id = -1) {
 	}
 	print "$cmd -f /usr/local/etc/sarg/sarg.conf $args\n";
 	$find = (preg_match("/(\d+)/", $find, $find_matches) ? $find_matches[1] : "60");
-	log_error("[sarg] Force refresh now with {$args} args, compress({$gzip}).");
+	syslog(LOG_INFO, "[sarg] Force refresh now with {$args} args, compress({$gzip}).");
 	$gzip_script = "#!/bin/sh\n";
 	if ($gzip == "on") {
 		// remove old file if exists
@@ -245,8 +273,10 @@ done
 EOF;
 	}
 	// create a new file to speedup find search
+	conf_mount_rw();
 	file_put_contents("/root/sarg_run_{$id}.sh", $gzip_script, LOCK_EX);
 	mwexec("export LC_ALL=C && " . $cmd . " " . $args);
+	close_notice("sarg_log_check");
 
 	// check compress option
 	if ($gzip == "on") {

--- a/www/Kontrol-pkg-sarg/files/usr/local/www/sarg_frame.php
+++ b/www/Kontrol-pkg-sarg/files/usr/local/www/sarg_frame.php
@@ -35,6 +35,48 @@ session_start();
 //Starting Cache Session - export to PDF process
 ob_start();
 
+function sarg_build_runtime_index($dir, $dsuffix = "") {
+	$items = array();
+	if (is_dir($dir)) {
+		foreach (glob($dir . "/*", GLOB_ONLYDIR) as $path) {
+			$name = basename($path);
+			if ($name == "images") {
+				continue;
+			}
+			if (file_exists($path . "/index.html") || file_exists($path . "/index.html.gz")) {
+				$items[] = array(
+					'name' => $name,
+					'mtime' => filemtime($path)
+				);
+			}
+		}
+	}
+	usort($items, function($a, $b) {
+		return $b['mtime'] <=> $a['mtime'];
+	});
+
+	$html = '<!DOCTYPE html><html><head><meta charset="UTF-8">';
+	$html .= '<title>Sarg Reports</title>';
+	$html .= '<style>body{font-family:Segoe UI,Arial,sans-serif;padding:12px;}';
+	$html .= 'table{border-collapse:collapse;width:100%;}';
+	$html .= 'th,td{padding:8px;border-bottom:1px solid #ddd;text-align:left;}';
+	$html .= 'h2{margin-top:0;}</style></head><body>';
+	$html .= '<h2>Sarg Reports</h2>';
+	$html .= '<table><thead><tr><th>Directory</th><th>Last update</th></tr></thead><tbody>';
+
+	if (empty($items)) {
+		$html .= '<tr><td colspan="2">No reports found.</td></tr>';
+	} else {
+		foreach ($items as $item) {
+			$link = '/sarg_frame.php?dir=' . urlencode($dsuffix) . '&file=' . rawurlencode($item['name']) . '/index.html';
+			$html .= '<tr><td><a href="' . htmlspecialchars($link) . '">' . htmlspecialchars($item['name']) . '</a></td>';
+			$html .= '<td>' . date("Y-m-d H:i:s", $item['mtime']) . '</td></tr>';
+		}
+	}
+	$html .= '</tbody></table></body></html>';
+	return $html;
+}
+
 
 $uname = posix_uname();
 if ($uname['machine'] == 'amd64') {
@@ -74,6 +116,8 @@ if (file_exists("{$dir}/{$url}")) {
 	$data = gzfile("{$dir}/{$url}.gz");
 	$report = implode($data);
 	unset ($data);
+} elseif ($url == "index.html" && $prefix == "") {
+	$report = sarg_build_runtime_index($dir, $dsuffix);
 }
 if ($report != "" ) {
 	$pattern[0] = "/href=\W(\S+html)\W/";

--- a/www/Kontrol-pkg-sarg/files/usr/local/www/sarg_reports.php
+++ b/www/Kontrol-pkg-sarg/files/usr/local/www/sarg_reports.php
@@ -29,14 +29,71 @@
 */
 require("guiconfig.inc");
 
-if ($savemsg) {
-    print_info_box($savemsg);
-}
-
 if ($uname['machine'] == 'amd64') {
         ini_set('memory_limit', '512M');
 }
 
+function sarg_reports_base_dir($suffix = "") {
+	$dir = "/usr/local/sarg-reports";
+	if ($suffix != "") {
+		$dir .= "/" . preg_replace("/\W/", "", $suffix);
+	}
+	return $dir;
+}
+
+function sarg_list_report_directories($dir) {
+	$reports = array();
+	if (!is_dir($dir)) {
+		return $reports;
+	}
+	foreach (glob($dir . "/*", GLOB_ONLYDIR) as $path) {
+		$name = basename($path);
+		if ($name == "images") {
+			continue;
+		}
+		if (file_exists($path . "/index.html") || file_exists($path . "/index.html.gz")) {
+			$reports[$name] = array(
+				'name' => $name,
+				'path' => $path,
+				'mtime' => filemtime($path)
+			);
+		}
+	}
+	uasort($reports, function($a, $b) {
+		return $b['mtime'] <=> $a['mtime'];
+	});
+	return $reports;
+}
+
+function sarg_has_root_report($dir) {
+	return (file_exists($dir . "/index.html") || file_exists($dir . "/index.html.gz"));
+}
+
+$input_errors = array();
+$savemsg = "";
+$dir_suffix = preg_replace("/\W/", "", $_REQUEST['dir']);
+$report_base_dir = sarg_reports_base_dir($dir_suffix);
+
+if ($_POST['delete_report'] == "yes") {
+	$report_name = preg_replace("/[^a-zA-Z0-9._-]/", "", $_POST['report_name']);
+	if ($report_name == "") {
+		$input_errors[] = gettext("Report name is invalid.");
+	} elseif ($report_name == "images") {
+		$input_errors[] = gettext("The shared images directory cannot be deleted.");
+	} else {
+		$full_path = "{$report_base_dir}/{$report_name}";
+		if (!is_dir($full_path)) {
+			$input_errors[] = sprintf(gettext("Report '%s' not found."), htmlspecialchars($report_name));
+		} elseif (strpos(realpath($full_path), realpath($report_base_dir)) !== 0) {
+			$input_errors[] = gettext("Invalid report path.");
+		} else {
+			conf_mount_rw();
+			rmdir_recursive($full_path);
+			conf_mount_ro();
+			$savemsg = sprintf(gettext("Report '%s' deleted successfully."), htmlspecialchars($report_name));
+		}
+	}
+}
 
 $pgtitle = array(gettext("Package"), gettext("Sarg"), gettext("Reports"));
 $shortcut_section = "sarg";
@@ -60,10 +117,18 @@ if ($_REQUEST['dir'] != "") {
     
 ?>
 <body link="#0000CC" vlink="#0000CC" alink="#0000CC">
-<form>
+<form method="post">
 <div id="mainlevel">
 <table width="100%" border="0" cellpadding="0" cellspacing="0">
 	<tr><td>
+		<?php
+		if (!empty($input_errors)) {
+			print_input_errors($input_errors);
+		}
+		if (!empty($savemsg)) {
+			print_info_box($savemsg);
+		}
+		?>
 		<?php
 		$tab_array = array();
 		$tab_array[] = array(gettext("General"), false, "/pkg_edit.php?xml=sarg.xml&id=0");
@@ -104,6 +169,48 @@ if ($_REQUEST['dir'] != "") {
 		<div id="mainarea">
 		</div>
 		<br />
+		<?php $reports = sarg_list_report_directories($report_base_dir); ?>
+		<?php
+		$dest_msg = sprintf(gettext("Report destination folder: %s"), htmlspecialchars($report_base_dir));
+		if (sarg_has_root_report($report_base_dir)) {
+			$dest_msg .= "<br />" . gettext("A main index report exists in this folder (root index.html).");
+		}
+		print_info_box($dest_msg, 'info', false);
+		?>
+		<div class="panel panel-default">
+			<div class="panel-heading"><h2 class="panel-title"><?=gettext("Manage stored reports")?></h2></div>
+			<div class="panel-body">
+				<?php if (empty($reports)): ?>
+					<?=gettext("No generated report directories were found for this view.")?>
+				<?php else: ?>
+					<table class="table table-striped table-condensed">
+						<thead>
+							<tr>
+								<th><?=gettext("Report directory")?></th>
+								<th><?=gettext("Last update")?></th>
+								<th><?=gettext("Actions")?></th>
+							</tr>
+						</thead>
+						<tbody>
+							<?php foreach ($reports as $report): ?>
+							<tr>
+								<td><?=htmlspecialchars($report['name'])?></td>
+								<td><?=date("Y-m-d H:i:s", $report['mtime'])?></td>
+								<td>
+									<button type="submit" class="btn btn-danger btn-xs"
+									        name="report_name" value="<?=htmlspecialchars($report['name'])?>"
+									        onclick="return confirm('<?=gettext("Delete this report directory? This action cannot be undone.")?>');">
+										<?=gettext("Delete")?>
+									</button>
+								</td>
+							</tr>
+							<?php endforeach; ?>
+						</tbody>
+					</table>
+				<?php endif; ?>
+				<input type="hidden" name="delete_report" value="yes" />
+			</div>
+		</div>
 		<script type="text/javascript">
 		//<![CDATA[
 		var axel = Math.random() + "";


### PR DESCRIPTION
### Motivation
- Corrigir registros indevidos como `ERROR` ao executar geração manual e evitar que o botão "Force update now" não gere relatórios por usar configuração antiga. 
- Validar o arquivo de LOG antes de executar o `sarg` para evitar que logs em formato incorreto quebrem a geração. 
- Informar ao administrador a pasta de destino dos relatórios e exibir avisos claros na UI quando a geração for abortada.

### Description
- Em `www/Kontrol-pkg-sarg/files/usr/local/pkg/sarg.inc` adicionei pré-validações em `run_sarg()` que verificam existência do arquivo de log, permissões de leitura, conteúdo não-vazio e uma verificação básica de formato para `e2guardian`, abortando com `file_notice(...)` em caso de problema; também troquei o registro de `log_error(...)` para `syslog(LOG_INFO, ...)` para que a execução manual não apareça como erro e garanti `conf_mount_rw()` antes de escrever o script de compressão e `close_notice(

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbd83ff074832e99819d1349df96a4)