### PR TITLE
Add Kontrol OpenVPN Schedule port with reversible OpenVPN auth enforcement

### DIFF
--- a/www/Kontrol-pkg-OpenVPN-Schedule/Makefile
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/Makefile
@@ -1,0 +1,40 @@
+# $FreeBSD$
+
+PORTNAME=	Kontrol-pkg-OpenVPN-Schedule
+PORTVERSION=	0.1.0
+CATEGORIES=	www
+MASTER_SITES=	# empty
+DISTFILES=	# empty
+EXTRACT_ONLY=	# empty
+
+MAINTAINER=	contato@kontrol.com.br
+COMMENT=	Kontrol OpenVPN login schedule enforcement package
+LICENSE=	APACHE20
+
+NO_BUILD=	yes
+NO_MTREE=	yes
+
+SUB_FILES=	pkg-install pkg-deinstall
+SUB_LIST=	PORTNAME=${PORTNAME}
+
+do-extract:
+	${MKDIR} ${WRKSRC}
+
+do-install:
+	${MKDIR} ${STAGEDIR}${PREFIX}/pkg
+	${MKDIR} ${STAGEDIR}${PREFIX}/www
+	${MKDIR} ${STAGEDIR}${PREFIX}/share/doc/${PORTNAME}
+	${INSTALL_DATA} -m 0644 ${FILESDIR}${PREFIX}/pkg/openvpn_schedule.xml \
+		${STAGEDIR}${PREFIX}/pkg
+	${INSTALL_DATA} -m 0644 ${FILESDIR}${PREFIX}/pkg/openvpn_schedule.inc \
+		${STAGEDIR}${PREFIX}/pkg
+	${INSTALL_DATA} -m 0644 ${FILESDIR}${PREFIX}/pkg/openvpn_schedule_hook.inc \
+		${STAGEDIR}${PREFIX}/pkg
+	${INSTALL_DATA} -m 0644 ${FILESDIR}${PREFIX}/www/openvpn_schedule.php \
+		${STAGEDIR}${PREFIX}/www
+	${INSTALL_DATA} -m 0644 ${FILESDIR}${PREFIX}/share/doc/${PORTNAME}/README.md \
+		${STAGEDIR}${PREFIX}/share/doc/${PORTNAME}
+	@${REINPLACE_CMD} -i '' -e "s|%%PKGVERSION%%|${PKGVERSION}|" \
+		${STAGEDIR}${PREFIX}/pkg/openvpn_schedule.xml
+
+.include <bsd.port.mk>

--- a/www/Kontrol-pkg-OpenVPN-Schedule/files/pkg-deinstall.in
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/files/pkg-deinstall.in
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+/usr/local/bin/php -f /etc/rc.packages %%PORTNAME%% "${2}"

--- a/www/Kontrol-pkg-OpenVPN-Schedule/files/pkg-install.in
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/files/pkg-install.in
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [ "${2}" != "POST-INSTALL" ] && [ "${2}" != "POST-UPGRADE" ]; then
+	exit 0
+fi
+
+/usr/local/bin/php -f /etc/rc.packages %%PORTNAME%% "${2}"

--- a/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule.inc
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule.inc
@@ -1,0 +1,176 @@
+<?php
+/*
+ * openvpn_schedule.inc
+ * Kontrol OpenVPN schedule-based login control.
+ */
+
+require_once('config.inc');
+require_once('util.inc');
+
+const OVPN_SCHEDULE_LOG_TAG = '[openvpn_schedule]';
+const OVPN_SCHEDULE_STATE_DIR = '/var/db/openvpn_schedule';
+const OVPN_SCHEDULE_MANIFEST = '/var/db/openvpn_schedule/manifest.json';
+const OVPN_SCHEDULE_TARGET = '/etc/inc/openvpn.auth-user.php';
+const OVPN_SCHEDULE_REQUIRE_MARK = "require_once('/usr/local/pkg/openvpn_schedule_hook.inc');";
+const OVPN_SCHEDULE_CALL_MARK = "openvpn_schedule_enforce_or_exit();";
+
+function openvpn_schedule_log($message) {
+	log_error(OVPN_SCHEDULE_LOG_TAG . ' ' . $message);
+}
+
+function openvpn_schedule_sync() {
+	openvpn_schedule_apply_runtime_patch();
+}
+
+function openvpn_schedule_install() {
+	openvpn_schedule_log('install start');
+	if (!openvpn_schedule_apply_runtime_patch()) {
+		openvpn_schedule_log('install failed: patch apply unsuccessful');
+		return;
+	}
+	openvpn_schedule_log('install done');
+}
+
+function openvpn_schedule_upgrade() {
+	openvpn_schedule_log('upgrade start');
+	openvpn_schedule_migrate_config();
+	if (!openvpn_schedule_apply_runtime_patch()) {
+		openvpn_schedule_log('upgrade failed: patch apply unsuccessful');
+		return;
+	}
+	openvpn_schedule_log('upgrade done');
+}
+
+function openvpn_schedule_deinstall() {
+	openvpn_schedule_log('deinstall start');
+	if (!openvpn_schedule_restore_runtime_patch()) {
+		openvpn_schedule_log('deinstall failed: could not restore original auth file. Manual recovery required from backup in ' . OVPN_SCHEDULE_STATE_DIR);
+		return;
+	}
+	config_del_path('installedpackages/openvpn_schedule');
+	write_config('Removed OpenVPN schedule package configuration');
+	@unlink(OVPN_SCHEDULE_MANIFEST);
+	@rmdir(OVPN_SCHEDULE_STATE_DIR);
+	openvpn_schedule_log('deinstall done');
+}
+
+function openvpn_schedule_migrate_config() {
+	$cfg = config_get_path('installedpackages/openvpn_schedule', []);
+	if (!is_array($cfg)) {
+		config_set_path('installedpackages/openvpn_schedule', []);
+		write_config('Migrated OpenVPN schedule package configuration');
+		return;
+	}
+	if (!isset($cfg['config'][0]['default_policy'])) {
+		$cfg['config'][0]['default_policy'] = 'allow';
+		config_set_path('installedpackages/openvpn_schedule', $cfg);
+		write_config('Migrated OpenVPN schedule default policy');
+	}
+}
+
+function openvpn_schedule_build_manifest($backup_file, $target_sha256, $backup_sha256) {
+	return [
+		'target' => OVPN_SCHEDULE_TARGET,
+		'backup' => $backup_file,
+		'target_sha256_before' => $target_sha256,
+		'backup_sha256' => $backup_sha256,
+		'patched_at' => gmdate('c')
+	];
+}
+
+function openvpn_schedule_read_manifest() {
+	if (!file_exists(OVPN_SCHEDULE_MANIFEST)) {
+		return null;
+	}
+	$data = json_decode(file_get_contents(OVPN_SCHEDULE_MANIFEST), true);
+	return is_array($data) ? $data : null;
+}
+
+function openvpn_schedule_apply_runtime_patch() {
+	safe_mkdir(OVPN_SCHEDULE_STATE_DIR);
+	if (!file_exists(OVPN_SCHEDULE_TARGET)) {
+		openvpn_schedule_log('compatibility error: target file not found ' . OVPN_SCHEDULE_TARGET);
+		return false;
+	}
+
+	$current = file_get_contents(OVPN_SCHEDULE_TARGET);
+	if (strpos($current, OVPN_SCHEDULE_REQUIRE_MARK) !== false && strpos($current, OVPN_SCHEDULE_CALL_MARK) !== false) {
+		openvpn_schedule_log('runtime patch already present, nothing to do');
+		return true;
+	}
+
+	$has_anchor_require = strpos($current, "require_once('auth.inc');") !== false;
+	$has_anchor_call = strpos($current, '$authcfg = array();') !== false;
+	if (!$has_anchor_require || !$has_anchor_call) {
+		openvpn_schedule_log('compatibility error: unsupported openvpn auth file version, refusing to patch');
+		return false;
+	}
+
+	$before_sha = hash_file('sha256', OVPN_SCHEDULE_TARGET);
+	$backup_file = OVPN_SCHEDULE_STATE_DIR . '/openvpn.auth-user.php.' . gmdate('YmdHis') . '.bak';
+	if (!@copy(OVPN_SCHEDULE_TARGET, $backup_file)) {
+		openvpn_schedule_log('failed to create backup file: ' . $backup_file);
+		return false;
+	}
+	$backup_sha = hash_file('sha256', $backup_file);
+
+	$patched = str_replace(
+		"require_once('auth.inc');",
+		"require_once('auth.inc');\n" . OVPN_SCHEDULE_REQUIRE_MARK,
+		$current
+	);
+	$patched = str_replace(
+		'$authcfg = array();',
+		OVPN_SCHEDULE_CALL_MARK . "\n\n" . '$authcfg = array();',
+		$patched
+	);
+
+	if ($patched === $current) {
+		openvpn_schedule_log('idempotency warning: generated patch unchanged, keeping existing file');
+		return true;
+	}
+
+	if (@file_put_contents(OVPN_SCHEDULE_TARGET, $patched) === false) {
+		openvpn_schedule_log('failed to write patched target, attempting rollback');
+		@copy($backup_file, OVPN_SCHEDULE_TARGET);
+		return false;
+	}
+
+	$manifest = openvpn_schedule_build_manifest($backup_file, $before_sha, $backup_sha);
+	file_put_contents(OVPN_SCHEDULE_MANIFEST, json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+	openvpn_schedule_log('runtime patch applied with backup ' . $backup_file);
+	return true;
+}
+
+function openvpn_schedule_restore_runtime_patch() {
+	$manifest = openvpn_schedule_read_manifest();
+	if (empty($manifest)) {
+		openvpn_schedule_log('no manifest found, trying inline rollback');
+		if (!file_exists(OVPN_SCHEDULE_TARGET)) {
+			return true;
+		}
+		$current = file_get_contents(OVPN_SCHEDULE_TARGET);
+		$current = str_replace("\n" . OVPN_SCHEDULE_REQUIRE_MARK, '', $current);
+		$current = str_replace(OVPN_SCHEDULE_CALL_MARK . "\n\n", '', $current);
+		return @file_put_contents(OVPN_SCHEDULE_TARGET, $current) !== false;
+	}
+
+	$backup = $manifest['backup'] ?? '';
+	if (empty($backup) || !file_exists($backup)) {
+		openvpn_schedule_log('deinstall abort: backup file is missing: ' . $backup);
+		return false;
+	}
+	$backup_sha = hash_file('sha256', $backup);
+	if ($backup_sha !== ($manifest['backup_sha256'] ?? '')) {
+		openvpn_schedule_log('deinstall abort: backup checksum mismatch for ' . $backup);
+		return false;
+	}
+	if (!@copy($backup, OVPN_SCHEDULE_TARGET)) {
+		openvpn_schedule_log('deinstall abort: failed restoring original file from backup');
+		return false;
+	}
+	@unlink($backup);
+	@unlink(OVPN_SCHEDULE_MANIFEST);
+	openvpn_schedule_log('runtime patch restored from backup');
+	return true;
+}

--- a/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule.xml
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE packagegui SYSTEM "../schema/packages.dtd">
+<?xml-stylesheet type="text/xsl" href="../xsl/package.xsl"?>
+<packagegui>
+	<name>openvpn_schedule</name>
+	<version>%%PKGVERSION%%</version>
+	<title>OpenVPN Login Schedule</title>
+	<aftersaveredirect>/openvpn_schedule.php</aftersaveredirect>
+	<include_file>/usr/local/pkg/openvpn_schedule.inc</include_file>
+	<menu>
+		<name>OpenVPN Schedule</name>
+		<section>VPN</section>
+		<url>/openvpn_schedule.php</url>
+	</menu>
+	<custom_php_resync_config_command>
+		openvpn_schedule_sync();
+	</custom_php_resync_config_command>
+</packagegui>

--- a/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule_hook.inc
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule_hook.inc
@@ -1,0 +1,97 @@
+<?php
+/*
+ * openvpn_schedule_hook.inc
+ * Loaded only from OpenVPN authentication flow.
+ */
+
+require_once('auth.inc');
+require_once('config.inc');
+require_once('util.inc');
+
+if (!function_exists('openvpn_schedule_log_runtime')) {
+	function openvpn_schedule_log_runtime($message) {
+		log_error('[openvpn_schedule] ' . $message);
+	}
+}
+
+if (!function_exists('openvpn_schedule_now_matches')) {
+	function openvpn_schedule_now_matches($schedule_name) {
+		if (empty($schedule_name)) {
+			return true;
+		}
+
+		// Reuse core schedule engine when available.
+		if (function_exists('filter_schedule_in_effect')) {
+			return filter_schedule_in_effect($schedule_name);
+		}
+		if (function_exists('is_schedule_in_time')) {
+			return is_schedule_in_time($schedule_name);
+		}
+
+		// Safe fallback: if schedule engine is unavailable, do not block logins.
+		openvpn_schedule_log_runtime("schedule engine not available for '{$schedule_name}', fallback allow");
+		return true;
+	}
+}
+
+if (!function_exists('openvpn_schedule_user_groups')) {
+	function openvpn_schedule_user_groups($username) {
+		$groups = [];
+		foreach (config_get_path('system/group', []) as $group) {
+			foreach (($group['member'] ?? []) as $member) {
+				if ($member === $username) {
+					$groups[] = $group['name'];
+				}
+			}
+		}
+		return $groups;
+	}
+}
+
+if (!function_exists('openvpn_schedule_find_policy')) {
+	function openvpn_schedule_find_policy($username) {
+		$pkg = config_get_path('installedpackages/openvpn_schedule/config/0', []);
+		$rules = $pkg['rule'] ?? [];
+		$default = $pkg['default_policy'] ?? 'allow';
+
+		foreach ($rules as $rule) {
+			if (($rule['type'] ?? '') === 'user' && ($rule['name'] ?? '') === $username) {
+				return ['match' => 'user', 'schedule' => ($rule['schedule'] ?? ''), 'default' => $default];
+			}
+		}
+
+		$user_groups = openvpn_schedule_user_groups($username);
+		foreach ($rules as $rule) {
+			if (($rule['type'] ?? '') === 'group' && in_array(($rule['name'] ?? ''), $user_groups, true)) {
+				return ['match' => 'group', 'schedule' => ($rule['schedule'] ?? ''), 'default' => $default];
+			}
+		}
+
+		return ['match' => 'default', 'schedule' => '', 'default' => $default];
+	}
+}
+
+if (!function_exists('openvpn_schedule_enforce_or_exit')) {
+	function openvpn_schedule_enforce_or_exit() {
+		$username = $_POST['username'] ?? $_ENV['username'] ?? '';
+		if (empty($username)) {
+			return;
+		}
+
+		$policy = openvpn_schedule_find_policy($username);
+		if ($policy['match'] === 'default') {
+			if ($policy['default'] === 'deny') {
+				openvpn_schedule_log_runtime("OpenVPN login denied for user '{$username}' by default deny policy");
+				exit(1);
+			}
+			return;
+		}
+
+		if (openvpn_schedule_now_matches($policy['schedule'])) {
+			return;
+		}
+
+		openvpn_schedule_log_runtime("OpenVPN login denied for user '{$username}' outside allowed schedule '{$policy['schedule']}' via {$policy['match']} rule");
+		exit(1);
+	}
+}

--- a/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/share/doc/Kontrol-pkg-OpenVPN-Schedule/README.md
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/share/doc/Kontrol-pkg-OpenVPN-Schedule/README.md
@@ -1,0 +1,40 @@
+# Kontrol OpenVPN Schedule Package
+
+## Visão geral
+Package para controle de login por horário **somente no OpenVPN**, reaproveitando os schedules do pfSense/Kontrol.
+
+## Instalação
+1. Instale o port `www/Kontrol-pkg-OpenVPN-Schedule` normalmente via pkg/ports.
+2. O `POST-INSTALL` chama `/etc/rc.packages` e executa `openvpn_schedule_install()`.
+3. O instalador valida compatibilidade do arquivo alvo e aplica patch idempotente com backup + checksum.
+
+## Configuração
+1. Acesse **VPN > OpenVPN Schedule**.
+2. Defina a política default (`allow` recomendado).
+3. Cadastre regras no formato `tipo,nome,schedule`:
+   - `user,alice,Comercial`
+   - `group,vpn-users,Noite`
+4. Prioridade de decisão:
+   1. regra de usuário
+   2. regra de grupo
+   3. política default
+
+## Como testar
+1. Crie/valide schedules em **System > Routing > Schedules**.
+2. Teste autenticação OpenVPN dentro do horário permitido.
+3. Teste autenticação OpenVPN fora do horário permitido.
+4. Verifique logs: mensagens com tag `[openvpn_schedule]`.
+
+## Desinstalação / rollback
+1. Remova o package.
+2. O `pkg-deinstall` executa `openvpn_schedule_deinstall()`.
+3. O deinstall restaura o arquivo original a partir de backup validado por checksum.
+4. Se checksum/backup falhar, rollback é abortado com log explícito para recuperação manual.
+
+## Upgrade
+- `POST-UPGRADE` executa migração de configuração e reaplica patch idempotente.
+- Backups e manifesto (`/var/db/openvpn_schedule/manifest.json`) são mantidos consistentes.
+
+## Limitações conhecidas
+- O patch runtime depende de âncoras conhecidas em `/etc/inc/openvpn.auth-user.php`.
+- Se o arquivo base mudar de forma incompatível, a instalação é abortada com erro de compatibilidade (comportamento seguro).

--- a/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/www/openvpn_schedule.php
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/www/openvpn_schedule.php
@@ -1,0 +1,100 @@
+<?php
+/*
+ * openvpn_schedule.php
+ * Package UI for OpenVPN schedule login control.
+ */
+
+require_once('guiconfig.inc');
+require_once('/usr/local/pkg/openvpn_schedule.inc');
+
+$pconfig = config_get_path('installedpackages/openvpn_schedule/config/0', []);
+if (!isset($pconfig['default_policy'])) {
+	$pconfig['default_policy'] = 'allow';
+}
+if (!isset($pconfig['rule'])) {
+	$pconfig['rule'] = [];
+}
+
+if ($_POST) {
+	$input_errors = [];
+	$rules = [];
+	$line_no = 0;
+	foreach (explode("\n", $_POST['rules_csv'] ?? '') as $line) {
+		$line_no++;
+		$line = trim($line);
+		if ($line === '') {
+			continue;
+		}
+		$parts = array_map('trim', explode(',', $line));
+		if (count($parts) !== 3) {
+			$input_errors[] = "Linha {$line_no}: formato inválido. Use tipo,nome,schedule.";
+			continue;
+		}
+		[$type, $name, $schedule] = $parts;
+		if (!in_array($type, ['user', 'group'], true)) {
+			$input_errors[] = "Linha {$line_no}: tipo deve ser user ou group.";
+		}
+		if ($name === '' || $schedule === '') {
+			$input_errors[] = "Linha {$line_no}: nome e schedule são obrigatórios.";
+		}
+		$rules[] = ['type' => $type, 'name' => $name, 'schedule' => $schedule];
+	}
+
+	if (empty($input_errors)) {
+		$pconfig['default_policy'] = ($_POST['default_policy'] ?? 'allow') === 'deny' ? 'deny' : 'allow';
+		$pconfig['rule'] = $rules;
+		config_set_path('installedpackages/openvpn_schedule/config/0', $pconfig);
+		write_config('Updated OpenVPN schedule package settings');
+		openvpn_schedule_sync();
+		header(url_safe('Location: /openvpn_schedule.php?save=1'));
+		exit;
+	}
+}
+
+$rules_csv = "";
+foreach (($pconfig['rule'] ?? []) as $rule) {
+	$rules_csv .= sprintf("%s,%s,%s\n", $rule['type'] ?? '', $rule['name'] ?? '', $rule['schedule'] ?? '');
+}
+
+$pgtitle = ['VPN', 'OpenVPN Schedule'];
+include('head.inc');
+
+if ($_GET['save'] ?? false) {
+	print_info_box('Configuração salva com sucesso.', 'success');
+}
+if (!empty($input_errors)) {
+	print_input_errors($input_errors);
+}
+
+$form = new Form(false);
+$section = new Form_Section('Política de Login OpenVPN por Horário');
+
+$section->addInput(new Form_Select(
+	'default_policy',
+	'Política default',
+	$pconfig['default_policy'],
+	[
+		'allow' => 'Permitir se não houver regra (recomendado)',
+		'deny' => 'Negar se não houver regra',
+	]
+));
+
+$section->addInput(new Form_Textarea(
+	'rules_csv',
+	'Regras (uma por linha)',
+	$rules_csv
+))->setHelp('Formato: tipo,nome,schedule. Ex.: user,alice,Comercial | group,vpn-users,Noite');
+
+$section->addInput(new Form_StaticText(
+	'Prioridade de decisão',
+	'1) regra de usuário, 2) regra de grupo, 3) política default.'
+));
+
+$section->addInput(new Form_StaticText(
+	'Observação',
+	'Este package atua apenas no fluxo de autenticação do OpenVPN e reutiliza schedules já existentes do sistema.'
+));
+
+$form->add($section);
+print($form);
+include('foot.inc');

--- a/www/Kontrol-pkg-OpenVPN-Schedule/pkg-descr
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/pkg-descr
@@ -1,0 +1,9 @@
+Kontrol OpenVPN Schedule package adds OpenVPN-only login-time enforcement using
+existing pfSense schedules (firewall_schedule/System > Routing > Schedules).
+
+Features:
+- Per-user and per-group schedule mapping
+- Deterministic priority (user > group > default allow)
+- Enforcement only in OpenVPN auth flow
+- Reversible, checksum-validated runtime patching with rollback
+- Clear denial logging for schedule-based rejects

--- a/www/Kontrol-pkg-OpenVPN-Schedule/pkg-plist
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/pkg-plist
@@ -1,0 +1,6 @@
+pkg/openvpn_schedule.xml
+pkg/openvpn_schedule.inc
+pkg/openvpn_schedule_hook.inc
+www/openvpn_schedule.php
+share/doc/Kontrol-pkg-OpenVPN-Schedule/README.md
+@dir /var/db/openvpn_schedule


### PR DESCRIPTION
### Motivation
- Provide OpenVPN-only login-time enforcement that reuses the system schedules (`System > Routing > Schedules`) without touching firewall modules or GUI/console auth. 
- Ensure strict reversibility and safe runtime patching so uninstall/rollback returns the system to its original state. 

### Description
- Add new port `www/Kontrol-pkg-OpenVPN-Schedule` with packaging metadata (`Makefile`, `pkg-descr`, `pkg-plist`) and lifecycle hooks (`pkg-install`, `pkg-deinstall`).
- Add package GUI entry (`files/usr/local/pkg/openvpn_schedule.xml`) and configuration page (`files/usr/local/www/openvpn_schedule.php`) to map `user/group -> schedule` and set `default_policy` with documented priority `user > group > default`.
- Implement runtime patch manager in `files/usr/local/pkg/openvpn_schedule.inc` that applies an idempotent, versioned patch to the OpenVPN auth flow target (`/etc/inc/openvpn.auth-user.php`), creating timestamped backups and a manifest with SHA256 checksums and supporting safe rollback.
- Implement enforcement hook `files/usr/local/pkg/openvpn_schedule_hook.inc` that is executed only from the OpenVPN auth flow, reuses core schedule functions when available, logs denials with tag `[openvpn_schedule]`, and uses fallback-safe behavior when schedule engine is unavailable.

### Testing
- Linted PHP files with `php -l` and confirmed no syntax errors for `openvpn_schedule.inc`, `openvpn_schedule_hook.inc`, and `openvpn_schedule.php` (all passed).
- Verified package files were created and the package XML includes a `custom_php_resync_config_command` that calls `openvpn_schedule_sync()` (inspection OK).
- Attempted to run `make -V PORTNAME -V PORTVERSION` in this Linux environment but the BSD `make` flags are not supported by GNU `make`, so a full ports build was not executed in this environment; install/upgrade/uninstall tests must be performed on a FreeBSD/pfSense host to validate runtime patching and full rollback behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc0b8d34a4832ea8e4cda8d928cf12)