### PR TITLE
OpenVPN-Schedule: simplify UI to single per-user schedule screen

### DIFF
--- a/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule.inc
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule.inc
@@ -61,11 +61,44 @@ function openvpn_schedule_migrate_config() {
 		write_config('Migrated OpenVPN schedule package configuration');
 		return;
 	}
-	if (!isset($cfg['config'][0]['default_policy'])) {
-		$cfg['config'][0]['default_policy'] = 'allow';
-		config_set_path('installedpackages/openvpn_schedule', $cfg);
-		write_config('Migrated OpenVPN schedule default policy');
+
+	$pkgcfg = $cfg['config'][0] ?? [];
+	if (!isset($pkgcfg['user_schedule']) || !is_array($pkgcfg['user_schedule'])) {
+		$pkgcfg['user_schedule'] = [];
 	}
+
+	// Backward compatibility: import legacy user rules into per-user schedules.
+	foreach (($pkgcfg['rule'] ?? []) as $rule) {
+		if (($rule['type'] ?? '') !== 'user') {
+			continue;
+		}
+		$username = trim($rule['name'] ?? '');
+		$schedule = trim($rule['schedule'] ?? '');
+		if ($username === '' || $schedule === '' || strcasecmp($schedule, 'none') === 0) {
+			continue;
+		}
+		$already_set = false;
+		foreach ($pkgcfg['user_schedule'] as $entry) {
+			if (($entry['username'] ?? '') === $username) {
+				$already_set = true;
+				break;
+			}
+		}
+		if (!$already_set) {
+			$pkgcfg['user_schedule'][] = [
+				'username' => $username,
+				'schedule' => $schedule,
+			];
+		}
+	}
+
+	// Keep defaults open (none) for users without explicit schedule.
+	unset($pkgcfg['default_policy']);
+	unset($pkgcfg['rule']);
+
+	$cfg['config'][0] = $pkgcfg;
+	config_set_path('installedpackages/openvpn_schedule', $cfg);
+	write_config('Migrated OpenVPN schedule package configuration');
 }
 
 function openvpn_schedule_build_manifest($backup_file, $target_sha256, $backup_sha256) {

--- a/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule.xml
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule.xml
@@ -9,36 +9,10 @@
 	<include_file>/usr/local/pkg/openvpn_schedule.inc</include_file>
 	<menu>
 		<name>OpenVPN Schedule</name>
-		<tooltiptext>Configure OpenVPN login schedule policy</tooltiptext>
+		<tooltiptext>Configure per-user OpenVPN login schedules</tooltiptext>
 		<section>VPN</section>
-		<url>/pkg_edit.php?xml=openvpn_schedule.xml&amp;id=0</url>
+		<url>/openvpn_schedule.php</url>
 	</menu>
-	<tabs>
-		<tab>
-			<text>General</text>
-			<url>/pkg_edit.php?xml=openvpn_schedule.xml&amp;id=0</url>
-			<active/>
-		</tab>
-		<tab>
-			<text>Schedule Policy</text>
-			<url>/openvpn_schedule.php</url>
-		</tab>
-	</tabs>
-	<fields>
-		<field>
-			<name>OpenVPN Schedule Package</name>
-			<type>listtopic</type>
-		</field>
-		<field>
-			<type>info</type>
-			<fielddescr>Configuração</fielddescr>
-			<description><![CDATA[
-				Use o botão abaixo para editar as regras de horário (usuário/grupo) do login OpenVPN.
-				<br/><br/>
-				<a class="btn btn-info" href="/openvpn_schedule.php">Abrir tela de configuração</a>
-			]]></description>
-		</field>
-	</fields>
 	<custom_php_resync_config_command>
 		openvpn_schedule_sync();
 	</custom_php_resync_config_command>

--- a/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule_hook.inc
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule_hook.inc
@@ -16,7 +16,8 @@ if (!function_exists('openvpn_schedule_log_runtime')) {
 
 if (!function_exists('openvpn_schedule_now_matches')) {
 	function openvpn_schedule_now_matches($schedule_name) {
-		if (empty($schedule_name)) {
+		$schedule_name = trim((string)$schedule_name);
+		if ($schedule_name === '' || strcasecmp($schedule_name, 'none') === 0) {
 			return true;
 		}
 
@@ -34,40 +35,24 @@ if (!function_exists('openvpn_schedule_now_matches')) {
 	}
 }
 
-if (!function_exists('openvpn_schedule_user_groups')) {
-	function openvpn_schedule_user_groups($username) {
-		$groups = [];
-		foreach (config_get_path('system/group', []) as $group) {
-			foreach (($group['member'] ?? []) as $member) {
-				if ($member === $username) {
-					$groups[] = $group['name'];
-				}
-			}
-		}
-		return $groups;
-	}
-}
-
 if (!function_exists('openvpn_schedule_find_policy')) {
 	function openvpn_schedule_find_policy($username) {
 		$pkg = config_get_path('installedpackages/openvpn_schedule/config/0', []);
-		$rules = $pkg['rule'] ?? [];
-		$default = $pkg['default_policy'] ?? 'allow';
 
-		foreach ($rules as $rule) {
+		foreach (($pkg['user_schedule'] ?? []) as $entry) {
+			if (($entry['username'] ?? '') === $username) {
+				return trim($entry['schedule'] ?? 'none');
+			}
+		}
+
+		// Backward compatibility with the previous user/group rule format.
+		foreach (($pkg['rule'] ?? []) as $rule) {
 			if (($rule['type'] ?? '') === 'user' && ($rule['name'] ?? '') === $username) {
-				return ['match' => 'user', 'schedule' => ($rule['schedule'] ?? ''), 'default' => $default];
+				return trim($rule['schedule'] ?? 'none');
 			}
 		}
 
-		$user_groups = openvpn_schedule_user_groups($username);
-		foreach ($rules as $rule) {
-			if (($rule['type'] ?? '') === 'group' && in_array(($rule['name'] ?? ''), $user_groups, true)) {
-				return ['match' => 'group', 'schedule' => ($rule['schedule'] ?? ''), 'default' => $default];
-			}
-		}
-
-		return ['match' => 'default', 'schedule' => '', 'default' => $default];
+		return 'none';
 	}
 }
 
@@ -78,20 +63,12 @@ if (!function_exists('openvpn_schedule_enforce_or_exit')) {
 			return;
 		}
 
-		$policy = openvpn_schedule_find_policy($username);
-		if ($policy['match'] === 'default') {
-			if ($policy['default'] === 'deny') {
-				openvpn_schedule_log_runtime("OpenVPN login denied for user '{$username}' by default deny policy");
-				exit(1);
-			}
+		$schedule = openvpn_schedule_find_policy($username);
+		if (openvpn_schedule_now_matches($schedule)) {
 			return;
 		}
 
-		if (openvpn_schedule_now_matches($policy['schedule'])) {
-			return;
-		}
-
-		openvpn_schedule_log_runtime("OpenVPN login denied for user '{$username}' outside allowed schedule '{$policy['schedule']}' via {$policy['match']} rule");
+		openvpn_schedule_log_runtime("OpenVPN login denied for user '{$username}' outside allowed schedule '{$schedule}'");
 		exit(1);
 	}
 }

--- a/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/share/Kontrol-pkg-OpenVPN-Schedule/info.xml
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/share/Kontrol-pkg-OpenVPN-Schedule/info.xml
@@ -2,7 +2,7 @@
 <pfsensepkgs>
 	<package>
 		<name>OpenVPN-Schedule</name>
-		<descr><![CDATA[OpenVPN login schedule policy package (user/group based using existing schedules).]]></descr>
+		<descr><![CDATA[OpenVPN per-user login schedule policy package using existing schedules.]]></descr>
 		<pkginfolink/>
 		<version>%%PKGVERSION%%</version>
 		<configurationfile>openvpn_schedule.xml</configurationfile>

--- a/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/share/doc/Kontrol-pkg-OpenVPN-Schedule/README.md
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/share/doc/Kontrol-pkg-OpenVPN-Schedule/README.md
@@ -1,40 +1,35 @@
 # Kontrol OpenVPN Schedule Package
 
-## Visão geral
-Package para controle de login por horário **somente no OpenVPN**, reaproveitando os schedules do pfSense/Kontrol.
+## Overview
+This package enforces OpenVPN login access windows using existing pfSense/Kontrol schedules.
 
-## Instalação
-1. Instale o port `www/Kontrol-pkg-OpenVPN-Schedule` normalmente via pkg/ports.
-2. O `POST-INSTALL` chama `/etc/rc.packages` e executa `openvpn_schedule_install()`.
-3. O instalador valida compatibilidade do arquivo alvo e aplica patch idempotente com backup + checksum.
+## Installation
+1. Install the `www/Kontrol-pkg-OpenVPN-Schedule` port via pkg/ports.
+2. `POST-INSTALL` calls `/etc/rc.packages` and runs `openvpn_schedule_install()`.
+3. The installer validates the target auth file and applies an idempotent patch with backup + checksum.
 
-## Configuração
-1. Acesse **VPN > OpenVPN Schedule**.
-2. Defina a política default (`allow` recomendado).
-3. Cadastre regras no formato `tipo,nome,schedule`:
-   - `user,alice,Comercial`
-   - `group,vpn-users,Noite`
-4. Prioridade de decisão:
-   1. regra de usuário
-   2. regra de grupo
-   3. política default
+## Configuration
+1. Open **VPN > OpenVPN Schedule**.
+2. The page lists non-admin local users.
+3. Select one schedule per user, or **None** for unrestricted access.
+4. If no schedules exist in **Firewall > Schedules**, all users remain on **None**.
 
-## Como testar
-1. Crie/valide schedules em **System > Routing > Schedules**.
-2. Teste autenticação OpenVPN dentro do horário permitido.
-3. Teste autenticação OpenVPN fora do horário permitido.
-4. Verifique logs: mensagens com tag `[openvpn_schedule]`.
+## How to test
+1. Create or validate schedules in **Firewall > Schedules**.
+2. Assign a schedule to one test user in **VPN > OpenVPN Schedule**.
+3. Test OpenVPN authentication inside and outside the allowed window.
+4. Review logs tagged with `[openvpn_schedule]`.
 
-## Desinstalação / rollback
-1. Remova o package.
-2. O `pkg-deinstall` executa `openvpn_schedule_deinstall()`.
-3. O deinstall restaura o arquivo original a partir de backup validado por checksum.
-4. Se checksum/backup falhar, rollback é abortado com log explícito para recuperação manual.
+## Deinstall / rollback
+1. Remove the package.
+2. `pkg-deinstall` runs `openvpn_schedule_deinstall()`.
+3. Deinstall restores the original auth file from a checksum-validated backup.
+4. If backup validation fails, rollback is aborted with explicit logs for manual recovery.
 
 ## Upgrade
-- `POST-UPGRADE` executa migração de configuração e reaplica patch idempotente.
-- Backups e manifesto (`/var/db/openvpn_schedule/manifest.json`) são mantidos consistentes.
+- `POST-UPGRADE` migrates legacy config to per-user schedule settings.
+- Backups and the manifest (`/var/db/openvpn_schedule/manifest.json`) remain consistent.
 
-## Limitações conhecidas
-- O patch runtime depende de âncoras conhecidas em `/etc/inc/openvpn.auth-user.php`.
-- Se o arquivo base mudar de forma incompatível, a instalação é abortada com erro de compatibilidade (comportamento seguro).
+## Known limitations
+- Runtime patching depends on known anchors in `/etc/inc/openvpn.auth-user.php`.
+- If the base file changes incompatibly, installation aborts with a compatibility error (safe behavior).

--- a/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/www/openvpn_schedule.php
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/www/openvpn_schedule.php
@@ -1,99 +1,177 @@
 <?php
 /*
  * openvpn_schedule.php
- * Package UI for OpenVPN schedule login control.
+ * Package UI for OpenVPN per-user login schedules.
  */
 
 require_once('guiconfig.inc');
 require_once('/usr/local/pkg/openvpn_schedule.inc');
 
-$pconfig = config_get_path('installedpackages/openvpn_schedule/config/0', []);
-if (!isset($pconfig['default_policy'])) {
-	$pconfig['default_policy'] = 'allow';
+function openvpn_schedule_get_all_schedule_names() {
+	$names = [];
+	foreach (config_get_path('schedules/schedule', []) as $schedule) {
+		$name = trim($schedule['name'] ?? '');
+		if ($name !== '') {
+			$names[] = $name;
+		}
+	}
+	sort($names, SORT_NATURAL | SORT_FLAG_CASE);
+	return $names;
 }
-if (!isset($pconfig['rule'])) {
-	$pconfig['rule'] = [];
+
+function openvpn_schedule_get_admin_members() {
+	$admins = [];
+	foreach (config_get_path('system/group', []) as $group) {
+		if (strcasecmp(($group['name'] ?? ''), 'admins') !== 0) {
+			continue;
+		}
+		foreach (($group['member'] ?? []) as $member) {
+			if ($member !== '') {
+				$admins[$member] = true;
+			}
+		}
+	}
+	return $admins;
 }
+
+function openvpn_schedule_get_visible_users() {
+	$visible_users = [];
+	$admins = openvpn_schedule_get_admin_members();
+
+	foreach (config_get_path('system/user', []) as $user) {
+		$username = trim($user['name'] ?? '');
+		if ($username === '') {
+			continue;
+		}
+		if (isset($admins[$username])) {
+			continue;
+		}
+		$visible_users[] = [
+			'name' => $username,
+			'descr' => trim($user['descr'] ?? ''),
+		];
+	}
+
+	usort($visible_users, static function($a, $b) {
+		return strcasecmp($a['name'], $b['name']);
+	});
+
+	return $visible_users;
+}
+
+function openvpn_schedule_build_user_map() {
+	$map = [];
+	$pkgcfg = config_get_path('installedpackages/openvpn_schedule/config/0', []);
+
+	foreach (($pkgcfg['user_schedule'] ?? []) as $entry) {
+		$username = trim($entry['username'] ?? '');
+		$schedule = trim($entry['schedule'] ?? '');
+		if ($username === '') {
+			continue;
+		}
+		if ($schedule === '' || strcasecmp($schedule, 'none') === 0) {
+			$map[$username] = 'none';
+		} else {
+			$map[$username] = $schedule;
+		}
+	}
+
+	return $map;
+}
+
+$schedule_names = openvpn_schedule_get_all_schedule_names();
+$schedule_options = ['none' => 'None'];
+foreach ($schedule_names as $schedule_name) {
+	$schedule_options[$schedule_name] = $schedule_name;
+}
+
+$users = openvpn_schedule_get_visible_users();
+$current_user_map = openvpn_schedule_build_user_map();
 
 if ($_POST) {
 	$input_errors = [];
-	$rules = [];
-	$line_no = 0;
-	foreach (explode("\n", $_POST['rules_csv'] ?? '') as $line) {
-		$line_no++;
-		$line = trim($line);
-		if ($line === '') {
+	$new_entries = [];
+
+	foreach ($users as $user) {
+		$username = $user['name'];
+		$field_name = 'schedule_' . preg_replace('/[^a-zA-Z0-9_]/', '_', $username);
+		$selected = trim($_POST[$field_name] ?? 'none');
+		if ($selected === '') {
+			$selected = 'none';
+		}
+		if (!array_key_exists($selected, $schedule_options)) {
+			$input_errors[] = sprintf("Invalid schedule '%s' selected for user '%s'.", htmlspecialchars($selected), htmlspecialchars($username));
 			continue;
 		}
-		$parts = array_map('trim', explode(',', $line));
-		if (count($parts) !== 3) {
-			$input_errors[] = "Linha {$line_no}: formato inválido. Use tipo,nome,schedule.";
-			continue;
+		if (strcasecmp($selected, 'none') !== 0) {
+			$new_entries[] = [
+				'username' => $username,
+				'schedule' => $selected,
+			];
+			$current_user_map[$username] = $selected;
+		} else {
+			$current_user_map[$username] = 'none';
 		}
-		[$type, $name, $schedule] = $parts;
-		if (!in_array($type, ['user', 'group'], true)) {
-			$input_errors[] = "Linha {$line_no}: tipo deve ser user ou group.";
-		}
-		if ($name === '' || $schedule === '') {
-			$input_errors[] = "Linha {$line_no}: nome e schedule são obrigatórios.";
-		}
-		$rules[] = ['type' => $type, 'name' => $name, 'schedule' => $schedule];
 	}
 
 	if (empty($input_errors)) {
-		$pconfig['default_policy'] = ($_POST['default_policy'] ?? 'allow') === 'deny' ? 'deny' : 'allow';
-		$pconfig['rule'] = $rules;
-		config_set_path('installedpackages/openvpn_schedule/config/0', $pconfig);
-		write_config('Updated OpenVPN schedule package settings');
+		config_set_path('installedpackages/openvpn_schedule/config/0/user_schedule', $new_entries);
+		write_config('Updated OpenVPN per-user schedule settings');
 		openvpn_schedule_sync();
 		header(url_safe('Location: /openvpn_schedule.php?save=1'));
 		exit;
 	}
 }
 
-$rules_csv = "";
-foreach (($pconfig['rule'] ?? []) as $rule) {
-	$rules_csv .= sprintf("%s,%s,%s\n", $rule['type'] ?? '', $rule['name'] ?? '', $rule['schedule'] ?? '');
-}
-
 $pgtitle = ['VPN', 'OpenVPN Schedule'];
 include('head.inc');
 
 if ($_GET['save'] ?? false) {
-	print_info_box('Configuração salva com sucesso.', 'success');
+	print_info_box('Settings saved successfully.', 'success');
 }
 if (!empty($input_errors)) {
 	print_input_errors($input_errors);
 }
 
 $form = new Form(false);
-$section = new Form_Section('Política de Login OpenVPN por Horário');
-
-$section->addInput(new Form_Select(
-	'default_policy',
-	'Política default',
-	$pconfig['default_policy'],
-	[
-		'allow' => 'Permitir se não houver regra (recomendado)',
-		'deny' => 'Negar se não houver regra',
-	]
-));
-
-$section->addInput(new Form_Textarea(
-	'rules_csv',
-	'Regras (uma por linha)',
-	$rules_csv
-))->setHelp('Formato: tipo,nome,schedule. Ex.: user,alice,Comercial | group,vpn-users,Noite');
-
+$section = new Form_Section('OpenVPN User Schedules');
 $section->addInput(new Form_StaticText(
-	'Prioridade de decisão',
-	'1) regra de usuário, 2) regra de grupo, 3) política default.'
+	'About',
+	'Assign an existing schedule to each OpenVPN user. Select "None" to allow login at any time.'
 ));
 
-$section->addInput(new Form_StaticText(
-	'Observação',
-	'Este package atua apenas no fluxo de autenticação do OpenVPN e reutiliza schedules já existentes do sistema.'
-));
+if (empty($schedule_names)) {
+	$section->addInput(new Form_StaticText(
+		'Schedules',
+		'No schedules were found under Firewall > Schedules. All users are currently set to "None".'
+	));
+}
+
+foreach ($users as $user) {
+	$label = $user['name'];
+	if ($user['descr'] !== '') {
+		$label .= ' (' . $user['descr'] . ')';
+	}
+	$field_name = 'schedule_' . preg_replace('/[^a-zA-Z0-9_]/', '_', $user['name']);
+	$current_value = $current_user_map[$user['name']] ?? 'none';
+	if (!array_key_exists($current_value, $schedule_options)) {
+		$current_value = 'none';
+	}
+
+	$section->addInput(new Form_Select(
+		$field_name,
+		$label,
+		$current_value,
+		$schedule_options
+	))->setHelp('Leave as "None" to keep OpenVPN access allowed at all times.');
+}
+
+if (empty($users)) {
+	$section->addInput(new Form_StaticText(
+		'Users',
+		'No non-admin local users were found.'
+	));
+}
 
 $form->add($section);
 print($form);


### PR DESCRIPTION
### Motivation
- Replace the previous rules-based UI with a single, simpler screen that shows local users and lets admins assign one schedule per user. 
- Ensure the default behavior is "None" (no schedule blocking) and that Admins are not shown in the list. 
- Reuse existing firewall schedules and keep backward compatibility with legacy per-user rules while simplifying package navigation. 
- Convert GUI text and package metadata to English.

### Description
- Rewrote `openvpn_schedule.php` to list non-admin local users and present a `Schedule` dropdown per user using helper functions `openvpn_schedule_get_all_schedule_names()`, `openvpn_schedule_get_visible_users()` and `openvpn_schedule_build_user_map()` and a `None` option for unrestricted access. 
- Changed package menu to point directly to `/openvpn_schedule.php` in `openvpn_schedule.xml` to provide a single screen UI. 
- Updated runtime enforcement in `openvpn_schedule_hook.inc` to treat `none` as unrestricted, use per-user `user_schedule` mappings, and preserve backward compatibility by importing legacy user rules. 
- Modified `openvpn_schedule_migrate_config()` in `openvpn_schedule.inc` to create and populate `user_schedule` from legacy `rule` entries (user type) and to remove old default/group policy fields. 
- Translated and updated package metadata and documentation to English (`info.xml` and `README.md`).

### Testing
- Performed PHP syntax checks with `php -l` on `www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/www/openvpn_schedule.php`, `www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule_hook.inc` and `www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule.inc`, all reported no syntax errors. 
- No automated GUI/browser tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc427fc744832ebd6dd35562093035)