### PR TITLE
Normalize input, switch to config helper functions, and bump port version to 1.5

### DIFF
--- a/www/Kontrol-pkg-OpenVPN-Schedule/Makefile
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	Kontrol-pkg-OpenVPN-Schedule
-PORTVERSION=	0.1.4
+PORTVERSION=	1.5
 PORTREVISION=	# empty
 CATEGORIES=	www
 MASTER_SITES=	# empty

--- a/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/www/openvpn_schedule.php
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/www/openvpn_schedule.php
@@ -7,30 +7,26 @@
 require_once('guiconfig.inc');
 require_once('/usr/local/pkg/openvpn_schedule.inc');
 
+function openvpn_schedule_normalize_text($value) {
+	$text = (string)$value;
+	if (function_exists('iconv')) {
+		$normalized = @iconv('UTF-8', 'UTF-8//IGNORE', $text);
+		if ($normalized !== false) {
+			$text = $normalized;
+		}
+	}
+	$text = preg_replace('/[^\x09\x0A\x0D\x20-\x{D7FF}\x{E000}-\x{FFFD}]/u', '', $text);
+	return trim((string)$text);
+}
 
 function openvpn_schedule_save_user_schedules(array $entries) {
-	global $config;
-
-	if (!isset($config['installedpackages']) || !is_array($config['installedpackages'])) {
-		$config['installedpackages'] = [];
-	}
-	if (!isset($config['installedpackages']['openvpn_schedule']) || !is_array($config['installedpackages']['openvpn_schedule'])) {
-		$config['installedpackages']['openvpn_schedule'] = [];
-	}
-	if (!isset($config['installedpackages']['openvpn_schedule']['config']) || !is_array($config['installedpackages']['openvpn_schedule']['config'])) {
-		$config['installedpackages']['openvpn_schedule']['config'] = [];
-	}
-	if (!isset($config['installedpackages']['openvpn_schedule']['config'][0]) || !is_array($config['installedpackages']['openvpn_schedule']['config'][0])) {
-		$config['installedpackages']['openvpn_schedule']['config'][0] = [];
-	}
-
-	$config['installedpackages']['openvpn_schedule']['config'][0]['user_schedule'] = $entries;
+	config_set_path('installedpackages/openvpn_schedule/config/0/user_schedule', $entries);
 }
 
 function openvpn_schedule_get_all_schedule_names() {
 	$names = [];
 	foreach (config_get_path('schedules/schedule', []) as $schedule) {
-		$name = trim($schedule['name'] ?? '');
+		$name = openvpn_schedule_normalize_text($schedule['name'] ?? '');
 		if ($name !== '') {
 			$names[] = $name;
 		}
@@ -51,7 +47,7 @@ function openvpn_schedule_get_admin_members() {
 			$members = [$members];
 		}
 		foreach ($members as $member) {
-			$member = trim((string)$member);
+			$member = openvpn_schedule_normalize_text($member);
 			if ($member !== '') {
 				$admins[$member] = true;
 			}
@@ -65,7 +61,7 @@ function openvpn_schedule_get_visible_users() {
 	$admins = openvpn_schedule_get_admin_members();
 
 	foreach (config_get_path('system/user', []) as $user) {
-		$username = trim((string)($user['name'] ?? ''));
+		$username = openvpn_schedule_normalize_text($user['name'] ?? '');
 		if ($username === '') {
 			continue;
 		}
@@ -81,7 +77,7 @@ function openvpn_schedule_get_visible_users() {
 
 		$visible_users[] = [
 			'name' => $username,
-			'descr' => trim((string)($user['descr'] ?? '')),
+			'descr' => openvpn_schedule_normalize_text($user['descr'] ?? ''),
 		];
 	}
 
@@ -97,8 +93,8 @@ function openvpn_schedule_build_user_map() {
 	$pkgcfg = config_get_path('installedpackages/openvpn_schedule/config/0', []);
 
 	foreach (($pkgcfg['user_schedule'] ?? []) as $entry) {
-		$username = trim($entry['username'] ?? '');
-		$schedule = trim($entry['schedule'] ?? '');
+		$username = openvpn_schedule_normalize_text($entry['username'] ?? '');
+		$schedule = openvpn_schedule_normalize_text($entry['schedule'] ?? '');
 		if ($username === '') {
 			continue;
 		}
@@ -125,10 +121,10 @@ if ($_POST) {
 	$input_errors = [];
 	$new_entries = [];
 
-	foreach ($users as $user) {
-		$username = $user['name'];
-		$field_name = 'schedule_' . preg_replace('/[^a-zA-Z0-9_]/', '_', $username);
-		$selected = trim($_POST[$field_name] ?? 'none');
+		foreach ($users as $user) {
+			$username = $user['name'];
+			$field_name = 'schedule_' . preg_replace('/[^a-zA-Z0-9_]/', '_', $username);
+			$selected = openvpn_schedule_normalize_text($_POST[$field_name] ?? 'none');
 		if ($selected === '') {
 			$selected = 'none';
 		}


### PR DESCRIPTION
### Motivation

- Ensure all user and config text is normalized and stripped of invalid Unicode/control characters to avoid malformed entries and improve robustness.
- Simplify and centralize configuration manipulation by using `config_get_path`/`config_set_path` helpers instead of manual array plumbing.
- Publish an updated package revision by bumping `PORTVERSION` to `1.5`.

### Description

- Added `openvpn_schedule_normalize_text()` to normalize strings using `iconv`, remove invalid Unicode/control characters, and trim results before use.
- Replaced multiple `trim()` calls with `openvpn_schedule_normalize_text()` for schedule names, group members, usernames, descriptions, and POST input handling.
- Replaced manual creation/manipulation of the nested `$config['installedpackages']` arrays in `openvpn_schedule_save_user_schedules()` with `config_set_path('installedpackages/openvpn_schedule/config/0/user_schedule', $entries)`.
- Used `config_get_path()` when reading schedules, system groups, users, and package config to simplify access and defaulting behavior.
- Bumped `PORTVERSION` from `0.1.4` to `1.5` in the Makefile.

### Testing

- Ran a PHP syntax check with `php -l files/usr/local/www/openvpn_schedule.php` and it succeeded without errors.
- Ran a local package make/build for the port directory with `make -C www/Kontrol-pkg-OpenVPN-Schedule` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc4f749eac832eb677a4bceb4662d5)