### PR TITLE
Normalize and migrate user_schedule structure, sanitize inputs, and bump port version to 1.6

### DIFF
--- a/www/Kontrol-pkg-OpenVPN-Schedule/Makefile
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	Kontrol-pkg-OpenVPN-Schedule
-PORTVERSION=	0.1.4
+PORTVERSION=	1.6
 PORTREVISION=	# empty
 CATEGORIES=	www
 MASTER_SITES=	# empty

--- a/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule.inc
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule.inc
@@ -18,6 +18,14 @@ function openvpn_schedule_log($message) {
 	log_error(OVPN_SCHEDULE_LOG_TAG . ' ' . $message);
 }
 
+function openvpn_schedule_user_schedule_entries($pkgcfg) {
+	$user_schedule = $pkgcfg['user_schedule'] ?? [];
+	if (is_array($user_schedule) && isset($user_schedule['item']) && is_array($user_schedule['item'])) {
+		return $user_schedule['item'];
+	}
+	return is_array($user_schedule) ? $user_schedule : [];
+}
+
 function openvpn_schedule_sync() {
 	openvpn_schedule_apply_runtime_patch();
 }
@@ -63,9 +71,7 @@ function openvpn_schedule_migrate_config() {
 	}
 
 	$pkgcfg = $cfg['config'][0] ?? [];
-	if (!isset($pkgcfg['user_schedule']) || !is_array($pkgcfg['user_schedule'])) {
-		$pkgcfg['user_schedule'] = [];
-	}
+	$entries = openvpn_schedule_user_schedule_entries($pkgcfg);
 
 	// Backward compatibility: import legacy user rules into per-user schedules.
 	foreach (($pkgcfg['rule'] ?? []) as $rule) {
@@ -78,19 +84,21 @@ function openvpn_schedule_migrate_config() {
 			continue;
 		}
 		$already_set = false;
-		foreach ($pkgcfg['user_schedule'] as $entry) {
+		foreach ($entries as $entry) {
 			if (($entry['username'] ?? '') === $username) {
 				$already_set = true;
 				break;
 			}
 		}
 		if (!$already_set) {
-			$pkgcfg['user_schedule'][] = [
+			$entries[] = [
 				'username' => $username,
 				'schedule' => $schedule,
 			];
 		}
 	}
+
+	$pkgcfg['user_schedule'] = ['item' => array_values($entries)];
 
 	// Keep defaults open (none) for users without explicit schedule.
 	unset($pkgcfg['default_policy']);

--- a/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule_hook.inc
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule_hook.inc
@@ -36,10 +36,18 @@ if (!function_exists('openvpn_schedule_now_matches')) {
 }
 
 if (!function_exists('openvpn_schedule_find_policy')) {
+	function openvpn_schedule_get_entries($pkg) {
+		$user_schedule = $pkg['user_schedule'] ?? [];
+		if (is_array($user_schedule) && isset($user_schedule['item']) && is_array($user_schedule['item'])) {
+			return $user_schedule['item'];
+		}
+		return is_array($user_schedule) ? $user_schedule : [];
+	}
+
 	function openvpn_schedule_find_policy($username) {
 		$pkg = config_get_path('installedpackages/openvpn_schedule/config/0', []);
 
-		foreach (($pkg['user_schedule'] ?? []) as $entry) {
+		foreach (openvpn_schedule_get_entries($pkg) as $entry) {
 			if (($entry['username'] ?? '') === $username) {
 				return trim($entry['schedule'] ?? 'none');
 			}

--- a/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/www/openvpn_schedule.php
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/www/openvpn_schedule.php
@@ -7,30 +7,34 @@
 require_once('guiconfig.inc');
 require_once('/usr/local/pkg/openvpn_schedule.inc');
 
+function openvpn_schedule_normalize_text($value) {
+	$text = (string)$value;
+	if (function_exists('iconv')) {
+		$normalized = @iconv('UTF-8', 'UTF-8//IGNORE', $text);
+		if ($normalized !== false) {
+			$text = $normalized;
+		}
+	}
+	$text = preg_replace('/[^\x09\x0A\x0D\x20-\x{D7FF}\x{E000}-\x{FFFD}]/u', '', $text);
+	return trim((string)$text);
+}
 
 function openvpn_schedule_save_user_schedules(array $entries) {
-	global $config;
+	config_set_path('installedpackages/openvpn_schedule/config/0/user_schedule', ['item' => array_values($entries)]);
+}
 
-	if (!isset($config['installedpackages']) || !is_array($config['installedpackages'])) {
-		$config['installedpackages'] = [];
+function openvpn_schedule_get_user_schedule_entries(array $pkgcfg) {
+	$user_schedule = $pkgcfg['user_schedule'] ?? [];
+	if (is_array($user_schedule) && isset($user_schedule['item']) && is_array($user_schedule['item'])) {
+		return $user_schedule['item'];
 	}
-	if (!isset($config['installedpackages']['openvpn_schedule']) || !is_array($config['installedpackages']['openvpn_schedule'])) {
-		$config['installedpackages']['openvpn_schedule'] = [];
-	}
-	if (!isset($config['installedpackages']['openvpn_schedule']['config']) || !is_array($config['installedpackages']['openvpn_schedule']['config'])) {
-		$config['installedpackages']['openvpn_schedule']['config'] = [];
-	}
-	if (!isset($config['installedpackages']['openvpn_schedule']['config'][0]) || !is_array($config['installedpackages']['openvpn_schedule']['config'][0])) {
-		$config['installedpackages']['openvpn_schedule']['config'][0] = [];
-	}
-
-	$config['installedpackages']['openvpn_schedule']['config'][0]['user_schedule'] = $entries;
+	return is_array($user_schedule) ? $user_schedule : [];
 }
 
 function openvpn_schedule_get_all_schedule_names() {
 	$names = [];
 	foreach (config_get_path('schedules/schedule', []) as $schedule) {
-		$name = trim($schedule['name'] ?? '');
+		$name = openvpn_schedule_normalize_text($schedule['name'] ?? '');
 		if ($name !== '') {
 			$names[] = $name;
 		}
@@ -51,7 +55,7 @@ function openvpn_schedule_get_admin_members() {
 			$members = [$members];
 		}
 		foreach ($members as $member) {
-			$member = trim((string)$member);
+			$member = openvpn_schedule_normalize_text($member);
 			if ($member !== '') {
 				$admins[$member] = true;
 			}
@@ -65,7 +69,7 @@ function openvpn_schedule_get_visible_users() {
 	$admins = openvpn_schedule_get_admin_members();
 
 	foreach (config_get_path('system/user', []) as $user) {
-		$username = trim((string)($user['name'] ?? ''));
+		$username = openvpn_schedule_normalize_text($user['name'] ?? '');
 		if ($username === '') {
 			continue;
 		}
@@ -81,7 +85,7 @@ function openvpn_schedule_get_visible_users() {
 
 		$visible_users[] = [
 			'name' => $username,
-			'descr' => trim((string)($user['descr'] ?? '')),
+			'descr' => openvpn_schedule_normalize_text($user['descr'] ?? ''),
 		];
 	}
 
@@ -96,9 +100,9 @@ function openvpn_schedule_build_user_map() {
 	$map = [];
 	$pkgcfg = config_get_path('installedpackages/openvpn_schedule/config/0', []);
 
-	foreach (($pkgcfg['user_schedule'] ?? []) as $entry) {
-		$username = trim($entry['username'] ?? '');
-		$schedule = trim($entry['schedule'] ?? '');
+	foreach (openvpn_schedule_get_user_schedule_entries($pkgcfg) as $entry) {
+		$username = openvpn_schedule_normalize_text($entry['username'] ?? '');
+		$schedule = openvpn_schedule_normalize_text($entry['schedule'] ?? '');
 		if ($username === '') {
 			continue;
 		}
@@ -128,7 +132,7 @@ if ($_POST) {
 	foreach ($users as $user) {
 		$username = $user['name'];
 		$field_name = 'schedule_' . preg_replace('/[^a-zA-Z0-9_]/', '_', $username);
-		$selected = trim($_POST[$field_name] ?? 'none');
+		$selected = openvpn_schedule_normalize_text($_POST[$field_name] ?? 'none');
 		if ($selected === '') {
 			$selected = 'none';
 		}


### PR DESCRIPTION
### Motivation
- Consolidate and normalize the `user_schedule` configuration representation to a consistent `['item' => [...]]` structure to support backward compatibility with legacy `rule` entries and avoid mixed array shapes.
- Prevent invalid/unsafe text from appearing in UI and configuration by normalizing and stripping problematic characters from schedule/user text inputs.
- Ensure runtime hook and UI use consistent accessors for the new data shape and update packaging metadata.

### Description
- Added helper accessors `openvpn_schedule_user_schedule_entries`, `openvpn_schedule_get_entries`, and `openvpn_schedule_get_user_schedule_entries` to read `user_schedule` uniformly whether it's legacy or new shape, and updated code paths to use them (in `openvpn_schedule.inc`, `openvpn_schedule_hook.inc`, and `openvpn_schedule.php`).
- Updated migration logic in `openvpn_schedule_migrate_config` to import legacy `rule` entries of type `user` into the new per-user `user_schedule` format and store as `['item' => array_values($entries)]`.
- Added `openvpn_schedule_normalize_text` to sanitize and trim UTF-8 text and applied it to schedule names, usernames, descriptions, and POST inputs in the UI to prevent invalid characters and encoding issues.
- Reworked saving of user schedules to use `config_set_path('installedpackages/openvpn_schedule/config/0/user_schedule', ['item' => ...])` and updated the UI to build user maps from the normalized entries.
- Updated runtime hook `openvpn_schedule_find_policy` to iterate entries via the new accessor and kept fallback compatibility for legacy `rule` entries.
- Bumped the port `PORTVERSION` in the `Makefile` from `0.1.4` to `1.6`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc4f749eac832eb677a4bceb4662d5)