### PR TITLE
www/Kontrol-pkg-OpenVPN-Schedule: fix SAVE action fatal error

### DIFF
--- a/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/www/openvpn_schedule.php
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/www/openvpn_schedule.php
@@ -155,7 +155,7 @@ if ($_POST) {
 		openvpn_schedule_save_user_schedules($new_entries);
 		write_config('Updated OpenVPN per-user schedule settings', false);
 		openvpn_schedule_sync();
-		header(url_safe('Location: /openvpn_schedule.php?save=1'));
+		header('Location: /openvpn_schedule.php?save=1');
 		exit;
 	}
 }


### PR DESCRIPTION
### Motivation
- Fix a PHP fatal error caused by calling an undefined helper `url_safe()` during the SAVE flow so the page can redirect cleanly after saving.

### Description
- Replace `header(url_safe('Location: /openvpn_schedule.php?save=1'));` with `header('Location: /openvpn_schedule.php?save=1');` in `www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/www/openvpn_schedule.php` to use a standard PHP redirect.

### Testing
- Ran `php -l www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/www/openvpn_schedule.php` which returned "No syntax errors detected" (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc62084f08832e84379bb789efb297)