### PR TITLE
OpenVPN Schedule: make patching robust, fix redirect header, bump PORTREVISION

### DIFF
--- a/www/Kontrol-pkg-OpenVPN-Schedule/Makefile
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	Kontrol-pkg-OpenVPN-Schedule
 PORTVERSION=	1.6
-PORTREVISION=	# empty
+PORTREVISION=	1
 CATEGORIES=	www
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule.inc
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule.inc
@@ -140,13 +140,6 @@ function openvpn_schedule_apply_runtime_patch() {
 		return true;
 	}
 
-	$has_anchor_require = strpos($current, "require_once('auth.inc');") !== false;
-	$has_anchor_call = strpos($current, '$authcfg = array();') !== false;
-	if (!$has_anchor_require || !$has_anchor_call) {
-		openvpn_schedule_log('compatibility error: unsupported openvpn auth file version, refusing to patch');
-		return false;
-	}
-
 	$before_sha = hash_file('sha256', OVPN_SCHEDULE_TARGET);
 	$backup_file = OVPN_SCHEDULE_STATE_DIR . '/openvpn.auth-user.php.' . gmdate('YmdHis') . '.bak';
 	if (!@copy(OVPN_SCHEDULE_TARGET, $backup_file)) {
@@ -155,16 +148,35 @@ function openvpn_schedule_apply_runtime_patch() {
 	}
 	$backup_sha = hash_file('sha256', $backup_file);
 
-	$patched = str_replace(
-		"require_once('auth.inc');",
-		"require_once('auth.inc');\n" . OVPN_SCHEDULE_REQUIRE_MARK,
-		$current
-	);
-	$patched = str_replace(
-		'$authcfg = array();',
-		OVPN_SCHEDULE_CALL_MARK . "\n\n" . '$authcfg = array();',
-		$patched
-	);
+	$patched = $current;
+
+	if (strpos($patched, OVPN_SCHEDULE_REQUIRE_MARK) === false) {
+		$patched = preg_replace(
+			"/(require_once\\((['\"])auth\\.inc\\2\\);\\s*)/m",
+			"$1" . OVPN_SCHEDULE_REQUIRE_MARK . "\n",
+			$patched,
+			1,
+			$require_count
+		);
+		if ((int)$require_count === 0) {
+			openvpn_schedule_log('compatibility error: auth include anchor not found, refusing to patch');
+			return false;
+		}
+	}
+
+	if (strpos($patched, OVPN_SCHEDULE_CALL_MARK) === false) {
+		$patched = preg_replace(
+			"/(\\$authcfg\\s*=\\s*(?:array\\s*\\(\\s*\\)|\\[\\s*\\])\\s*;)/m",
+			OVPN_SCHEDULE_CALL_MARK . "\n\n$1",
+			$patched,
+			1,
+			$call_count
+		);
+		if ((int)$call_count === 0) {
+			openvpn_schedule_log('compatibility error: authcfg initialization anchor not found, refusing to patch');
+			return false;
+		}
+	}
 
 	if ($patched === $current) {
 		openvpn_schedule_log('idempotency warning: generated patch unchanged, keeping existing file');

--- a/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/www/openvpn_schedule.php
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/www/openvpn_schedule.php
@@ -155,7 +155,7 @@ if ($_POST) {
 		openvpn_schedule_save_user_schedules($new_entries);
 		write_config('Updated OpenVPN per-user schedule settings', false);
 		openvpn_schedule_sync();
-		header(url_safe('Location: /openvpn_schedule.php?save=1'));
+		header('Location: /openvpn_schedule.php?save=1');
 		exit;
 	}
 }


### PR DESCRIPTION
### Motivation
- Improve compatibility and robustness of the runtime patching logic so the package can apply patches across different variants of the target file.  
- Fix an incorrect `header` call that previously wrapped its argument in `url_safe`, causing potential header formatting issues.  
- Bump `PORTREVISION` to indicate the package revision change.

### Description
- Replace fragile string `str_replace` anchors in `openvpn_schedule_apply_runtime_patch` with regex-based matching that handles single/double quotes for `require_once('auth.inc')` and accepts both `array()` and short `[]` initializers for `$authcfg`, and report specific compatibility errors if anchors are not found.  
- Add idempotency checks to skip patching when marks are already present and create a manifest/backup on successful patch application.  
- Change the redirect call in `openvpn_schedule.php` from `header(url_safe('Location: /openvpn_schedule.php?save=1'))` to the proper `header('Location: /openvpn_schedule.php?save=1')`.  
- Increment `PORTREVISION` from an empty placeholder to `1` in the `Makefile`.

### Testing
- Performed PHP syntax checks with `php -l` on the modified PHP files and they passed.  
- No package-level automated test suite was run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc62084f08832e84379bb789efb297)