### PR TITLE
OpenVPN Schedule: support modern auth-user anchor and bump PORTREVISION

### DIFF
--- a/www/Kontrol-pkg-OpenVPN-Schedule/Makefile
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	Kontrol-pkg-OpenVPN-Schedule
 PORTVERSION=	1.6
-PORTREVISION=	# empty
+PORTREVISION=	2
 CATEGORIES=	www
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule.inc
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule.inc
@@ -140,13 +140,6 @@ function openvpn_schedule_apply_runtime_patch() {
 		return true;
 	}
 
-	$has_anchor_require = strpos($current, "require_once('auth.inc');") !== false;
-	$has_anchor_call = strpos($current, '$authcfg = array();') !== false;
-	if (!$has_anchor_require || !$has_anchor_call) {
-		openvpn_schedule_log('compatibility error: unsupported openvpn auth file version, refusing to patch');
-		return false;
-	}
-
 	$before_sha = hash_file('sha256', OVPN_SCHEDULE_TARGET);
 	$backup_file = OVPN_SCHEDULE_STATE_DIR . '/openvpn.auth-user.php.' . gmdate('YmdHis') . '.bak';
 	if (!@copy(OVPN_SCHEDULE_TARGET, $backup_file)) {
@@ -155,16 +148,43 @@ function openvpn_schedule_apply_runtime_patch() {
 	}
 	$backup_sha = hash_file('sha256', $backup_file);
 
-	$patched = str_replace(
-		"require_once('auth.inc');",
-		"require_once('auth.inc');\n" . OVPN_SCHEDULE_REQUIRE_MARK,
-		$current
-	);
-	$patched = str_replace(
-		'$authcfg = array();',
-		OVPN_SCHEDULE_CALL_MARK . "\n\n" . '$authcfg = array();',
-		$patched
-	);
+	$patched = $current;
+
+	if (strpos($patched, OVPN_SCHEDULE_REQUIRE_MARK) === false) {
+		$patched = preg_replace(
+			"/(require_once\\((['\"])auth\\.inc\\2\\);\\s*)/m",
+			"$1" . OVPN_SCHEDULE_REQUIRE_MARK . "\n",
+			$patched,
+			1,
+			$require_count
+		);
+		if ((int)$require_count === 0) {
+			openvpn_schedule_log('compatibility error: auth include anchor not found, refusing to patch');
+			return false;
+		}
+	}
+
+	if (strpos($patched, OVPN_SCHEDULE_CALL_MARK) === false) {
+		$call_count = 0;
+		$call_anchors = [
+			// Older pfSense variants initialize $authcfg directly.
+			"/(\\$authcfg\\s*=\\s*(?:array\\s*\\(\\s*\\)|\\[\\s*\\])\\s*;)/m" =>
+				OVPN_SCHEDULE_CALL_MARK . "\n\n$1",
+			// Newer pfSense variants authenticate inside the authmodes loop.
+			"/(^\\s*foreach\\s*\\(\\s*\\$authmodes\\s+as\\s+\\$authmode\\s*\\)\\s*\\{)/m" =>
+				OVPN_SCHEDULE_CALL_MARK . "\n\n$1",
+		];
+		foreach ($call_anchors as $pattern => $replacement) {
+			$patched = preg_replace($pattern, $replacement, $patched, 1, $call_count);
+			if ((int)$call_count > 0) {
+				break;
+			}
+		}
+		if ((int)$call_count === 0) {
+			openvpn_schedule_log('compatibility error: no supported runtime auth anchor found, refusing to patch');
+			return false;
+		}
+	}
 
 	if ($patched === $current) {
 		openvpn_schedule_log('idempotency warning: generated patch unchanged, keeping existing file');

--- a/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/www/openvpn_schedule.php
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/www/openvpn_schedule.php
@@ -155,7 +155,7 @@ if ($_POST) {
 		openvpn_schedule_save_user_schedules($new_entries);
 		write_config('Updated OpenVPN per-user schedule settings', false);
 		openvpn_schedule_sync();
-		header(url_safe('Location: /openvpn_schedule.php?save=1'));
+		header('Location: /openvpn_schedule.php?save=1');
 		exit;
 	}
 }


### PR DESCRIPTION
### Motivation
- The package failed at SAVE with `compatibility error: authcfg initialization anchor not found, refusing to patch` on newer pfSense builds because `openvpn.auth-user.php` no longer initializes `$authcfg` the same way. 
- The port revision must be bumped so the fixed behavior is published to users via a new package revision.

### Description
- Updated `openvpn_schedule_apply_runtime_patch()` in `files/usr/local/pkg/openvpn_schedule.inc` to use regex-based anchors and a prioritized list of insertion points instead of a single fragile string match. 
- Added two call anchors: a legacy anchor matching `$authcfg = array()` / `[]` and a fallback anchor before `foreach ($authmodes as $authmode) {` for modern pfSense auth flow, and kept idempotency and safety checks that abort if no supported anchor is found. 
- Replaced simple `str_replace` for the `require_once('auth.inc')` insertion with a regex that accepts single or double quotes and reports a clear compatibility error if not found. 
- Bumped `PORTREVISION` to `2` in `Makefile` so the fix is published as a new port revision, and preserved the previously applied redirect fix in `files/usr/local/www/openvpn_schedule.php` (use of `header('Location: ...')`).

### Testing
- Ran PHP syntax checks with `php -l` on `files/usr/local/pkg/openvpn_schedule.inc` and `files/usr/local/www/openvpn_schedule.php`, both reported no syntax errors. 
- Validated the regex fallback against upstream `openvpn.auth-user.php` with a short PHP script which matched the new `foreach ($authmodes as $authmode)` anchor. 
- Confirmed the patching logic returns explicit compatibility logs and aborts when no supported anchor is present (behavior unchanged for unsupported variants).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc62084f08832e84379bb789efb297)