### PR TITLE
Detect alternate package key names and make runtime patching more robust; bump PORTREVISION

### DIFF
--- a/www/Kontrol-pkg-OpenVPN-Schedule/Makefile
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	Kontrol-pkg-OpenVPN-Schedule
 PORTVERSION=	1.6
-PORTREVISION=	# empty
+PORTREVISION=	3
 CATEGORIES=	www
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule.inc
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule.inc
@@ -18,6 +18,26 @@ function openvpn_schedule_log($message) {
 	log_error(OVPN_SCHEDULE_LOG_TAG . ' ' . $message);
 }
 
+function openvpn_schedule_normalized_package_key($key) {
+	return preg_replace('/[^a-z0-9]/', '', strtolower((string)$key));
+}
+
+function openvpn_schedule_detect_package_key() {
+	$installed = config_get_path('installedpackages', []);
+	if (is_array($installed)) {
+		foreach (array_keys($installed) as $key) {
+			if (openvpn_schedule_normalized_package_key($key) === 'openvpnschedule') {
+				return (string)$key;
+			}
+		}
+	}
+	return 'openvpn_schedule';
+}
+
+function openvpn_schedule_package_base_path() {
+	return 'installedpackages/' . openvpn_schedule_detect_package_key();
+}
+
 function openvpn_schedule_user_schedule_entries($pkgcfg) {
 	$user_schedule = $pkgcfg['user_schedule'] ?? [];
 	if (is_array($user_schedule) && isset($user_schedule['item']) && is_array($user_schedule['item'])) {
@@ -55,7 +75,7 @@ function openvpn_schedule_deinstall() {
 		openvpn_schedule_log('deinstall failed: could not restore original auth file. Manual recovery required from backup in ' . OVPN_SCHEDULE_STATE_DIR);
 		return;
 	}
-	config_del_path('installedpackages/openvpn_schedule');
+	config_del_path(openvpn_schedule_package_base_path());
 	write_config('Removed OpenVPN schedule package configuration');
 	@unlink(OVPN_SCHEDULE_MANIFEST);
 	@rmdir(OVPN_SCHEDULE_STATE_DIR);
@@ -63,9 +83,9 @@ function openvpn_schedule_deinstall() {
 }
 
 function openvpn_schedule_migrate_config() {
-	$cfg = config_get_path('installedpackages/openvpn_schedule', []);
+	$cfg = config_get_path(openvpn_schedule_package_base_path(), []);
 	if (!is_array($cfg)) {
-		config_set_path('installedpackages/openvpn_schedule', []);
+		config_set_path(openvpn_schedule_package_base_path(), []);
 		write_config('Migrated OpenVPN schedule package configuration');
 		return;
 	}
@@ -105,7 +125,7 @@ function openvpn_schedule_migrate_config() {
 	unset($pkgcfg['rule']);
 
 	$cfg['config'][0] = $pkgcfg;
-	config_set_path('installedpackages/openvpn_schedule', $cfg);
+	config_set_path(openvpn_schedule_package_base_path(), $cfg);
 	write_config('Migrated OpenVPN schedule package configuration');
 }
 
@@ -140,13 +160,6 @@ function openvpn_schedule_apply_runtime_patch() {
 		return true;
 	}
 
-	$has_anchor_require = strpos($current, "require_once('auth.inc');") !== false;
-	$has_anchor_call = strpos($current, '$authcfg = array();') !== false;
-	if (!$has_anchor_require || !$has_anchor_call) {
-		openvpn_schedule_log('compatibility error: unsupported openvpn auth file version, refusing to patch');
-		return false;
-	}
-
 	$before_sha = hash_file('sha256', OVPN_SCHEDULE_TARGET);
 	$backup_file = OVPN_SCHEDULE_STATE_DIR . '/openvpn.auth-user.php.' . gmdate('YmdHis') . '.bak';
 	if (!@copy(OVPN_SCHEDULE_TARGET, $backup_file)) {
@@ -155,16 +168,43 @@ function openvpn_schedule_apply_runtime_patch() {
 	}
 	$backup_sha = hash_file('sha256', $backup_file);
 
-	$patched = str_replace(
-		"require_once('auth.inc');",
-		"require_once('auth.inc');\n" . OVPN_SCHEDULE_REQUIRE_MARK,
-		$current
-	);
-	$patched = str_replace(
-		'$authcfg = array();',
-		OVPN_SCHEDULE_CALL_MARK . "\n\n" . '$authcfg = array();',
-		$patched
-	);
+	$patched = $current;
+
+	if (strpos($patched, OVPN_SCHEDULE_REQUIRE_MARK) === false) {
+		$patched = preg_replace(
+			"/(require_once\\((['\"])auth\\.inc\\2\\);\\s*)/m",
+			"$1" . OVPN_SCHEDULE_REQUIRE_MARK . "\n",
+			$patched,
+			1,
+			$require_count
+		);
+		if ((int)$require_count === 0) {
+			openvpn_schedule_log('compatibility error: auth include anchor not found, refusing to patch');
+			return false;
+		}
+	}
+
+	if (strpos($patched, OVPN_SCHEDULE_CALL_MARK) === false) {
+		$call_count = 0;
+		$call_anchors = [
+			// Older pfSense variants initialize $authcfg directly.
+			"/(\\$authcfg\\s*=\\s*(?:array\\s*\\(\\s*\\)|\\[\\s*\\])\\s*;)/m" =>
+				OVPN_SCHEDULE_CALL_MARK . "\n\n$1",
+			// Newer pfSense variants authenticate inside the authmodes loop.
+			"/(^\\s*foreach\\s*\\(\\s*\\$authmodes\\s+as\\s+\\$authmode\\s*\\)\\s*\\{)/m" =>
+				OVPN_SCHEDULE_CALL_MARK . "\n\n$1",
+		];
+		foreach ($call_anchors as $pattern => $replacement) {
+			$patched = preg_replace($pattern, $replacement, $patched, 1, $call_count);
+			if ((int)$call_count > 0) {
+				break;
+			}
+		}
+		if ((int)$call_count === 0) {
+			openvpn_schedule_log('compatibility error: no supported runtime auth anchor found, refusing to patch');
+			return false;
+		}
+	}
 
 	if ($patched === $current) {
 		openvpn_schedule_log('idempotency warning: generated patch unchanged, keeping existing file');

--- a/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule_hook.inc
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule_hook.inc
@@ -36,6 +36,22 @@ if (!function_exists('openvpn_schedule_now_matches')) {
 }
 
 if (!function_exists('openvpn_schedule_find_policy')) {
+	function openvpn_schedule_normalized_package_key($key) {
+		return preg_replace('/[^a-z0-9]/', '', strtolower((string)$key));
+	}
+
+	function openvpn_schedule_package_base_path() {
+		$installed = config_get_path('installedpackages', []);
+		if (is_array($installed)) {
+			foreach (array_keys($installed) as $key) {
+				if (openvpn_schedule_normalized_package_key($key) === 'openvpnschedule') {
+					return 'installedpackages/' . $key;
+				}
+			}
+		}
+		return 'installedpackages/openvpn_schedule';
+	}
+
 	function openvpn_schedule_get_entries($pkg) {
 		$user_schedule = $pkg['user_schedule'] ?? [];
 		if (is_array($user_schedule) && isset($user_schedule['item']) && is_array($user_schedule['item'])) {
@@ -45,7 +61,7 @@ if (!function_exists('openvpn_schedule_find_policy')) {
 	}
 
 	function openvpn_schedule_find_policy($username) {
-		$pkg = config_get_path('installedpackages/openvpn_schedule/config/0', []);
+		$pkg = config_get_path(openvpn_schedule_package_base_path() . '/config/0', []);
 
 		foreach (openvpn_schedule_get_entries($pkg) as $entry) {
 			if (($entry['username'] ?? '') === $username) {

--- a/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/www/openvpn_schedule.php
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/www/openvpn_schedule.php
@@ -19,8 +19,24 @@ function openvpn_schedule_normalize_text($value) {
 	return trim((string)$text);
 }
 
+function openvpn_schedule_normalized_package_key($key) {
+	return preg_replace('/[^a-z0-9]/', '', strtolower((string)$key));
+}
+
+function openvpn_schedule_package_base_path() {
+	$installed = config_get_path('installedpackages', []);
+	if (is_array($installed)) {
+		foreach (array_keys($installed) as $key) {
+			if (openvpn_schedule_normalized_package_key($key) === 'openvpnschedule') {
+				return 'installedpackages/' . $key;
+			}
+		}
+	}
+	return 'installedpackages/openvpn_schedule';
+}
+
 function openvpn_schedule_save_user_schedules(array $entries) {
-	config_set_path('installedpackages/openvpn_schedule/config/0/user_schedule', ['item' => array_values($entries)]);
+	config_set_path(openvpn_schedule_package_base_path() . '/config/0/user_schedule', ['item' => array_values($entries)]);
 }
 
 function openvpn_schedule_get_user_schedule_entries(array $pkgcfg) {
@@ -98,7 +114,7 @@ function openvpn_schedule_get_visible_users() {
 
 function openvpn_schedule_build_user_map() {
 	$map = [];
-	$pkgcfg = config_get_path('installedpackages/openvpn_schedule/config/0', []);
+	$pkgcfg = config_get_path(openvpn_schedule_package_base_path() . '/config/0', []);
 
 	foreach (openvpn_schedule_get_user_schedule_entries($pkgcfg) as $entry) {
 		$username = openvpn_schedule_normalize_text($entry['username'] ?? '');
@@ -155,7 +171,7 @@ if ($_POST) {
 		openvpn_schedule_save_user_schedules($new_entries);
 		write_config('Updated OpenVPN per-user schedule settings', false);
 		openvpn_schedule_sync();
-		header(url_safe('Location: /openvpn_schedule.php?save=1'));
+		header('Location: /openvpn_schedule.php?save=1');
 		exit;
 	}
 }
@@ -179,7 +195,7 @@ $section->addInput(new Form_StaticText(
 
 $section->addInput(new Form_StaticText(
 	'Storage',
-	'Settings are stored in config.xml under installedpackages/openvpn_schedule/config/0/user_schedule and are automatically removed when this package is uninstalled.'
+	'Settings are stored in config.xml under installedpackages/<openvpn_schedule>/config/0/user_schedule and are automatically removed when this package is uninstalled.'
 ));
 
 if (empty($schedule_names)) {


### PR DESCRIPTION
### Motivation

- Allow the package to work when the `installedpackages` key name differs (e.g. `openvpnschedule` vs `openvpn_schedule`) and make config path access resilient to such variations.
- Improve the runtime patching logic to support multiple variants of the OpenVPN auth file layout so the package can inject hooks on different pfSense versions.

### Description

- Added normalization and detection helpers `openvpn_schedule_normalized_package_key`, `openvpn_schedule_detect_package_key`, and `openvpn_schedule_package_base_path` and replaced hardcoded `installedpackages/openvpn_schedule` paths with calls to the dynamic base path in `openvpn_schedule.inc`, `openvpn_schedule_hook.inc`, and `openvpn_schedule.php`.
- Extended `openvpn_schedule_apply_runtime_patch` to use regex anchors and conditional insertion points, supporting both direct `$authcfg = array()` initialization and `foreach ($authmodes as $authmode) {` authentication flows, and added compatibility error logging when anchors are not found.
- Kept backward-compatibility migration of legacy `rule` entries into the new `user_schedule` structure while using the dynamic package path for config reads/writes and deletion on deinstall.
- Fixed redirect header call to use `header('Location: ...')` and updated the UI storage description to reflect the dynamic package key placeholder, and bumped `PORTREVISION` in the `Makefile`.

### Testing

- Ran PHP syntax checks (`php -l`) against the modified PHP files and they all passed successfully.
- No automated unit tests are present for this package beyond syntax validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc62084f08832e84379bb789efb297)