### PR TITLE
Normalize package config key, harden runtime patching, and bump PORTREVISION

### DIFF
--- a/www/Kontrol-pkg-OpenVPN-Schedule/Makefile
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	Kontrol-pkg-OpenVPN-Schedule
 PORTVERSION=	1.6
-PORTREVISION=	# empty
+PORTREVISION=	4
 CATEGORIES=	www
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule.inc
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule.inc
@@ -18,6 +18,26 @@ function openvpn_schedule_log($message) {
 	log_error(OVPN_SCHEDULE_LOG_TAG . ' ' . $message);
 }
 
+function openvpn_schedule_normalized_package_key($key) {
+	return preg_replace('/[^a-z0-9]/', '', strtolower((string)$key));
+}
+
+function openvpn_schedule_detect_package_key() {
+	$installed = config_get_path('installedpackages', []);
+	if (is_array($installed)) {
+		foreach (array_keys($installed) as $key) {
+			if (openvpn_schedule_normalized_package_key($key) === 'openvpnschedule') {
+				return (string)$key;
+			}
+		}
+	}
+	return 'openvpn_schedule';
+}
+
+function openvpn_schedule_package_base_path() {
+	return 'installedpackages/' . openvpn_schedule_detect_package_key();
+}
+
 function openvpn_schedule_user_schedule_entries($pkgcfg) {
 	$user_schedule = $pkgcfg['user_schedule'] ?? [];
 	if (is_array($user_schedule) && isset($user_schedule['item']) && is_array($user_schedule['item'])) {
@@ -55,7 +75,7 @@ function openvpn_schedule_deinstall() {
 		openvpn_schedule_log('deinstall failed: could not restore original auth file. Manual recovery required from backup in ' . OVPN_SCHEDULE_STATE_DIR);
 		return;
 	}
-	config_del_path('installedpackages/openvpn_schedule');
+	config_del_path(openvpn_schedule_package_base_path());
 	write_config('Removed OpenVPN schedule package configuration');
 	@unlink(OVPN_SCHEDULE_MANIFEST);
 	@rmdir(OVPN_SCHEDULE_STATE_DIR);
@@ -63,9 +83,9 @@ function openvpn_schedule_deinstall() {
 }
 
 function openvpn_schedule_migrate_config() {
-	$cfg = config_get_path('installedpackages/openvpn_schedule', []);
+	$cfg = config_get_path(openvpn_schedule_package_base_path(), []);
 	if (!is_array($cfg)) {
-		config_set_path('installedpackages/openvpn_schedule', []);
+		config_set_path(openvpn_schedule_package_base_path(), []);
 		write_config('Migrated OpenVPN schedule package configuration');
 		return;
 	}
@@ -105,7 +125,7 @@ function openvpn_schedule_migrate_config() {
 	unset($pkgcfg['rule']);
 
 	$cfg['config'][0] = $pkgcfg;
-	config_set_path('installedpackages/openvpn_schedule', $cfg);
+	config_set_path(openvpn_schedule_package_base_path(), $cfg);
 	write_config('Migrated OpenVPN schedule package configuration');
 }
 
@@ -140,13 +160,6 @@ function openvpn_schedule_apply_runtime_patch() {
 		return true;
 	}
 
-	$has_anchor_require = strpos($current, "require_once('auth.inc');") !== false;
-	$has_anchor_call = strpos($current, '$authcfg = array();') !== false;
-	if (!$has_anchor_require || !$has_anchor_call) {
-		openvpn_schedule_log('compatibility error: unsupported openvpn auth file version, refusing to patch');
-		return false;
-	}
-
 	$before_sha = hash_file('sha256', OVPN_SCHEDULE_TARGET);
 	$backup_file = OVPN_SCHEDULE_STATE_DIR . '/openvpn.auth-user.php.' . gmdate('YmdHis') . '.bak';
 	if (!@copy(OVPN_SCHEDULE_TARGET, $backup_file)) {
@@ -155,16 +168,43 @@ function openvpn_schedule_apply_runtime_patch() {
 	}
 	$backup_sha = hash_file('sha256', $backup_file);
 
-	$patched = str_replace(
-		"require_once('auth.inc');",
-		"require_once('auth.inc');\n" . OVPN_SCHEDULE_REQUIRE_MARK,
-		$current
-	);
-	$patched = str_replace(
-		'$authcfg = array();',
-		OVPN_SCHEDULE_CALL_MARK . "\n\n" . '$authcfg = array();',
-		$patched
-	);
+	$patched = $current;
+
+	if (strpos($patched, OVPN_SCHEDULE_REQUIRE_MARK) === false) {
+		$patched = preg_replace(
+			"/(require_once\\((['\"])auth\\.inc\\2\\);\\s*)/m",
+			"$1" . OVPN_SCHEDULE_REQUIRE_MARK . "\n",
+			$patched,
+			1,
+			$require_count
+		);
+		if ((int)$require_count === 0) {
+			openvpn_schedule_log('compatibility error: auth include anchor not found, refusing to patch');
+			return false;
+		}
+	}
+
+	if (strpos($patched, OVPN_SCHEDULE_CALL_MARK) === false) {
+		$call_count = 0;
+		$call_anchors = [
+			// Older pfSense variants initialize $authcfg directly.
+			"/(\\$authcfg\\s*=\\s*(?:array\\s*\\(\\s*\\)|\\[\\s*\\])\\s*;)/m" =>
+				OVPN_SCHEDULE_CALL_MARK . "\n\n$1",
+			// Newer pfSense variants authenticate inside the authmodes loop.
+			"/(^\\s*foreach\\s*\\(\\s*\\$authmodes\\s+as\\s+\\$authmode\\s*\\)\\s*\\{)/m" =>
+				OVPN_SCHEDULE_CALL_MARK . "\n\n$1",
+		];
+		foreach ($call_anchors as $pattern => $replacement) {
+			$patched = preg_replace($pattern, $replacement, $patched, 1, $call_count);
+			if ((int)$call_count > 0) {
+				break;
+			}
+		}
+		if ((int)$call_count === 0) {
+			openvpn_schedule_log('compatibility error: no supported runtime auth anchor found, refusing to patch');
+			return false;
+		}
+	}
 
 	if ($patched === $current) {
 		openvpn_schedule_log('idempotency warning: generated patch unchanged, keeping existing file');

--- a/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule_hook.inc
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule_hook.inc
@@ -36,6 +36,22 @@ if (!function_exists('openvpn_schedule_now_matches')) {
 }
 
 if (!function_exists('openvpn_schedule_find_policy')) {
+	function openvpn_schedule_hook_normalized_package_key($key) {
+		return preg_replace('/[^a-z0-9]/', '', strtolower((string)$key));
+	}
+
+	function openvpn_schedule_hook_package_base_path() {
+		$installed = config_get_path('installedpackages', []);
+		if (is_array($installed)) {
+			foreach (array_keys($installed) as $key) {
+				if (openvpn_schedule_hook_normalized_package_key($key) === 'openvpnschedule') {
+					return 'installedpackages/' . $key;
+				}
+			}
+		}
+		return 'installedpackages/openvpn_schedule';
+	}
+
 	function openvpn_schedule_get_entries($pkg) {
 		$user_schedule = $pkg['user_schedule'] ?? [];
 		if (is_array($user_schedule) && isset($user_schedule['item']) && is_array($user_schedule['item'])) {
@@ -45,7 +61,7 @@ if (!function_exists('openvpn_schedule_find_policy')) {
 	}
 
 	function openvpn_schedule_find_policy($username) {
-		$pkg = config_get_path('installedpackages/openvpn_schedule/config/0', []);
+		$pkg = config_get_path(openvpn_schedule_hook_package_base_path() . '/config/0', []);
 
 		foreach (openvpn_schedule_get_entries($pkg) as $entry) {
 			if (($entry['username'] ?? '') === $username) {

--- a/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/www/openvpn_schedule.php
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/www/openvpn_schedule.php
@@ -19,8 +19,24 @@ function openvpn_schedule_normalize_text($value) {
 	return trim((string)$text);
 }
 
+function openvpn_schedule_ui_normalized_package_key($key) {
+	return preg_replace('/[^a-z0-9]/', '', strtolower((string)$key));
+}
+
+function openvpn_schedule_ui_package_base_path() {
+	$installed = config_get_path('installedpackages', []);
+	if (is_array($installed)) {
+		foreach (array_keys($installed) as $key) {
+			if (openvpn_schedule_ui_normalized_package_key($key) === 'openvpnschedule') {
+				return 'installedpackages/' . $key;
+			}
+		}
+	}
+	return 'installedpackages/openvpn_schedule';
+}
+
 function openvpn_schedule_save_user_schedules(array $entries) {
-	config_set_path('installedpackages/openvpn_schedule/config/0/user_schedule', ['item' => array_values($entries)]);
+	config_set_path(openvpn_schedule_ui_package_base_path() . '/config/0/user_schedule', ['item' => array_values($entries)]);
 }
 
 function openvpn_schedule_get_user_schedule_entries(array $pkgcfg) {
@@ -98,7 +114,7 @@ function openvpn_schedule_get_visible_users() {
 
 function openvpn_schedule_build_user_map() {
 	$map = [];
-	$pkgcfg = config_get_path('installedpackages/openvpn_schedule/config/0', []);
+	$pkgcfg = config_get_path(openvpn_schedule_ui_package_base_path() . '/config/0', []);
 
 	foreach (openvpn_schedule_get_user_schedule_entries($pkgcfg) as $entry) {
 		$username = openvpn_schedule_normalize_text($entry['username'] ?? '');
@@ -155,7 +171,7 @@ if ($_POST) {
 		openvpn_schedule_save_user_schedules($new_entries);
 		write_config('Updated OpenVPN per-user schedule settings', false);
 		openvpn_schedule_sync();
-		header(url_safe('Location: /openvpn_schedule.php?save=1'));
+		header('Location: /openvpn_schedule.php?save=1');
 		exit;
 	}
 }
@@ -179,7 +195,7 @@ $section->addInput(new Form_StaticText(
 
 $section->addInput(new Form_StaticText(
 	'Storage',
-	'Settings are stored in config.xml under installedpackages/openvpn_schedule/config/0/user_schedule and are automatically removed when this package is uninstalled.'
+	'Settings are stored in config.xml under installedpackages/<openvpn_schedule>/config/0/user_schedule and are automatically removed when this package is uninstalled.'
 ));
 
 if (empty($schedule_names)) {


### PR DESCRIPTION
### Motivation
- Make the package robust to variations in the `installedpackages` XML key name and to different pfSense/OpenVPN auth file layouts so the package can reliably find its configuration and apply the runtime patch. 
- Improve compatibility and resilience when patching `/etc/inc/openvpn.auth-user.php` and fix a couple of UI issues, and increment the port revision.

### Description
- Bumped `PORTREVISION` to `4` in the `Makefile`.
- Replaced hard-coded `installedpackages/openvpn_schedule` paths with dynamic detection helpers that normalize package keys and compute the package base path in `openvpn_schedule.inc`, `openvpn_schedule_hook.inc`, and `openvpn_schedule.php` so the code works if the installedpackages key name differs.
- Hardened runtime patching in `openvpn_schedule.inc` by using regex anchors, supporting multiple insertion points for both the `require_once('auth.inc')` inclusion and the enforcement call, adding stricter anchor detection and idempotency checks, and keeping backup/manifest behavior.
- Added small UI fixes in `openvpn_schedule.php` including replacing `header(url_safe(...))` with `header('Location: ...')` and making the storage description generic about the `installedpackages/<openvpn_schedule>` location.

### Testing
- Ran PHP syntax checks with `php -l` on all modified PHP files and they returned no syntax errors.
- Performed a local port build invocation with `make` in the port directory to validate the `Makefile` changes and staging directory creation and the build step completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc62084f08832e84379bb789efb297)