### PR TITLE
OpenVPN Schedule: evaluate schedules using core config, make user matching case-insensitive, and improve UI labels

### DIFF
--- a/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule_hook.inc
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule_hook.inc
@@ -15,18 +15,54 @@ if (!function_exists('openvpn_schedule_log_runtime')) {
 }
 
 if (!function_exists('openvpn_schedule_now_matches')) {
+	function openvpn_schedule_get_schedule_config($schedule_name) {
+		foreach (config_get_path('schedules/schedule', []) as $schedule) {
+			if (strcasecmp(trim((string)($schedule['name'] ?? '')), $schedule_name) === 0) {
+				return is_array($schedule) ? $schedule : [];
+			}
+		}
+		return [];
+	}
+
+	function openvpn_schedule_eval_with_core_engine($schedule_name, array $schedule_cfg) {
+		if (function_exists('filter_schedule_in_effect')) {
+			foreach ([$schedule_cfg, $schedule_name] as $arg) {
+				try {
+					return (bool)filter_schedule_in_effect($arg);
+				} catch (Throwable $e) {
+					/* Ignore and continue trying compatibility signatures. */
+				}
+			}
+		}
+
+		if (function_exists('is_schedule_in_time')) {
+			foreach ([$schedule_cfg, $schedule_name] as $arg) {
+				try {
+					return (bool)is_schedule_in_time($arg);
+				} catch (Throwable $e) {
+					/* Ignore and continue trying compatibility signatures. */
+				}
+			}
+		}
+
+		return null;
+	}
+
 	function openvpn_schedule_now_matches($schedule_name) {
 		$schedule_name = trim((string)$schedule_name);
 		if ($schedule_name === '' || strcasecmp($schedule_name, 'none') === 0) {
 			return true;
 		}
 
-		// Reuse core schedule engine when available.
-		if (function_exists('filter_schedule_in_effect')) {
-			return filter_schedule_in_effect($schedule_name);
+		$schedule_cfg = openvpn_schedule_get_schedule_config($schedule_name);
+		if (empty($schedule_cfg)) {
+			openvpn_schedule_log_runtime("schedule '{$schedule_name}' not found, denying login");
+			return false;
 		}
-		if (function_exists('is_schedule_in_time')) {
-			return is_schedule_in_time($schedule_name);
+
+		$core_match = openvpn_schedule_eval_with_core_engine($schedule_name, $schedule_cfg);
+		if ($core_match !== null) {
+			return (bool)$core_match;
 		}
 
 		// Safe fallback: if schedule engine is unavailable, do not block logins.
@@ -64,14 +100,14 @@ if (!function_exists('openvpn_schedule_find_policy')) {
 		$pkg = config_get_path(openvpn_schedule_hook_package_base_path() . '/config/0', []);
 
 		foreach (openvpn_schedule_get_entries($pkg) as $entry) {
-			if (($entry['username'] ?? '') === $username) {
+			if (strcasecmp((string)($entry['username'] ?? ''), $username) === 0) {
 				return trim($entry['schedule'] ?? 'none');
 			}
 		}
 
 		// Backward compatibility with the previous user/group rule format.
 		foreach (($pkg['rule'] ?? []) as $rule) {
-			if (($rule['type'] ?? '') === 'user' && ($rule['name'] ?? '') === $username) {
+			if (($rule['type'] ?? '') === 'user' && strcasecmp((string)($rule['name'] ?? ''), $username) === 0) {
 				return trim($rule['schedule'] ?? 'none');
 			}
 		}

--- a/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/www/openvpn_schedule.php
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/www/openvpn_schedule.php
@@ -139,6 +139,14 @@ function openvpn_schedule_build_user_map() {
 	return $map;
 }
 
+function openvpn_schedule_user_label(array $user) {
+	$label = '👤 ' . $user['name'];
+	if ($user['descr'] !== '') {
+		$label .= ' (' . $user['descr'] . ')';
+	}
+	return $label;
+}
+
 $schedule_names = openvpn_schedule_get_all_schedule_names();
 $schedule_options = ['none' => 'None'];
 foreach ($schedule_names as $schedule_name) {
@@ -218,10 +226,7 @@ if (empty($schedule_names)) {
 }
 
 foreach ($users as $user) {
-	$label = $user['name'];
-	if ($user['descr'] !== '') {
-		$label .= ' (' . $user['descr'] . ')';
-	}
+	$label = openvpn_schedule_user_label($user);
 	$field_name = 'schedule_' . preg_replace('/[^a-zA-Z0-9_]/', '_', $user['name']);
 	$current_value = $current_user_map[$user['name']] ?? 'none';
 	if (!array_key_exists($current_value, $schedule_options)) {


### PR DESCRIPTION
### Motivation
- Ensure schedule evaluation reuses the core firewall schedule definitions rather than only using a schedule name string.
- Avoid false negatives due to case differences when matching usernames to schedule entries.
- Improve the user list UI by showing a clearer label that includes an icon and the user description.

### Description
- Added `openvpn_schedule_get_schedule_config` and `openvpn_schedule_eval_with_core_engine` to fetch a schedule config and attempt evaluation via core functions (`filter_schedule_in_effect` and `is_schedule_in_time`) while supporting multiple function signatures and catching `Throwable` errors.
- Updated `openvpn_schedule_now_matches` to fetch the schedule config, deny login if the named schedule is missing, use the core schedule engine when available, and otherwise fall back to allowing logins with a runtime log entry.
- Made username comparisons in `openvpn_schedule_find_policy` case-insensitive by switching to `strcasecmp` for both the newer user_schedule entries and the legacy `rule` format.
- Added `openvpn_schedule_user_label` and switched the UI to use it so user rows show an icon and include the user description when present.

### Testing
- Performed a PHP syntax check with `php -l` on the modified files and they passed without syntax errors.
- No automated unit tests were present for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc834ba840832e9fbc91b93c627a01)