### PR TITLE
Add cron watcher to disconnect out-of-schedule OpenVPN users and harden auth hook/UI

### DIFF
--- a/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule.inc
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule.inc
@@ -6,6 +6,7 @@
 
 require_once('config.inc');
 require_once('util.inc');
+require_once('/usr/local/pkg/openvpn_schedule_hook.inc');
 
 const OVPN_SCHEDULE_LOG_TAG = '[openvpn_schedule]';
 const OVPN_SCHEDULE_STATE_DIR = '/var/db/openvpn_schedule';
@@ -13,6 +14,7 @@ const OVPN_SCHEDULE_MANIFEST = '/var/db/openvpn_schedule/manifest.json';
 const OVPN_SCHEDULE_TARGET = '/etc/inc/openvpn.auth-user.php';
 const OVPN_SCHEDULE_REQUIRE_MARK = "require_once('/usr/local/pkg/openvpn_schedule_hook.inc');";
 const OVPN_SCHEDULE_CALL_MARK = "openvpn_schedule_enforce_or_exit();";
+const OVPN_SCHEDULE_CRON_COMMAND = '/usr/local/bin/php -f /usr/local/pkg/openvpn_schedule_cron.php';
 
 function openvpn_schedule_log($message) {
 	log_error(OVPN_SCHEDULE_LOG_TAG . ' ' . $message);
@@ -48,6 +50,7 @@ function openvpn_schedule_user_schedule_entries($pkgcfg) {
 
 function openvpn_schedule_sync() {
 	openvpn_schedule_apply_runtime_patch();
+	openvpn_schedule_setup_cron(true);
 }
 
 function openvpn_schedule_install() {
@@ -56,6 +59,7 @@ function openvpn_schedule_install() {
 		openvpn_schedule_log('install failed: patch apply unsuccessful');
 		return;
 	}
+	openvpn_schedule_setup_cron(true);
 	openvpn_schedule_log('install done');
 }
 
@@ -66,6 +70,7 @@ function openvpn_schedule_upgrade() {
 		openvpn_schedule_log('upgrade failed: patch apply unsuccessful');
 		return;
 	}
+	openvpn_schedule_setup_cron(true);
 	openvpn_schedule_log('upgrade done');
 }
 
@@ -75,6 +80,7 @@ function openvpn_schedule_deinstall() {
 		openvpn_schedule_log('deinstall failed: could not restore original auth file. Manual recovery required from backup in ' . OVPN_SCHEDULE_STATE_DIR);
 		return;
 	}
+	openvpn_schedule_setup_cron(false);
 	config_del_path(openvpn_schedule_package_base_path());
 	write_config('Removed OpenVPN schedule package configuration');
 	@unlink(OVPN_SCHEDULE_MANIFEST);
@@ -292,4 +298,120 @@ function openvpn_schedule_restore_runtime_patch() {
 	@unlink(OVPN_SCHEDULE_MANIFEST);
 	openvpn_schedule_log('runtime patch restored from backup');
 	return true;
+}
+
+function openvpn_schedule_has_enforced_user_schedules() {
+	$pkgcfg = config_get_path(openvpn_schedule_package_base_path() . '/config/0', []);
+	foreach (openvpn_schedule_user_schedule_entries($pkgcfg) as $entry) {
+		$schedule = trim((string)($entry['schedule'] ?? ''));
+		if ($schedule !== '' && strcasecmp($schedule, 'none') !== 0) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function openvpn_schedule_setup_cron($active = true) {
+	$should_enable = (bool)$active && openvpn_schedule_has_enforced_user_schedules();
+	if ($should_enable) {
+		install_cron_job(OVPN_SCHEDULE_CRON_COMMAND, true, '*/5', '*', '*', '*', '*', 'root');
+		openvpn_schedule_log('cron watcher enabled (every 5 minutes)');
+		return;
+	}
+	install_cron_job(OVPN_SCHEDULE_CRON_COMMAND, false);
+	openvpn_schedule_log('cron watcher disabled');
+}
+
+function openvpn_schedule_collect_connected_users_from_status($status_file) {
+	$users = [];
+	$inside_client_list = false;
+	$lines = @file($status_file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+	if (!is_array($lines)) {
+		return [];
+	}
+
+	foreach ($lines as $line) {
+		$line = trim((string)$line);
+		if ($line === '') {
+			continue;
+		}
+		if (strpos($line, 'Common Name,') === 0) {
+			$inside_client_list = true;
+			continue;
+		}
+		if (!$inside_client_list) {
+			continue;
+		}
+		if (strpos($line, 'ROUTING TABLE') === 0 || $line === 'GLOBAL STATS' || $line === 'END') {
+			break;
+		}
+
+		$columns = str_getcsv($line);
+		$username = trim((string)($columns[0] ?? ''));
+		if ($username !== '' && strcasecmp($username, 'UNDEF') !== 0) {
+			$users[$username] = true;
+		}
+	}
+
+	return array_keys($users);
+}
+
+function openvpn_schedule_collect_connected_users() {
+	$users = [];
+	$status_files = array_merge(
+		glob('/var/etc/openvpn/*.status') ?: [],
+		glob('/var/etc/openvpn/status*') ?: [],
+		glob('/tmp/openvpn-status*') ?: []
+	);
+	$status_files = array_unique($status_files);
+
+	foreach ($status_files as $status_file) {
+		foreach (openvpn_schedule_collect_connected_users_from_status($status_file) as $username) {
+			$users[$username] = true;
+		}
+	}
+
+	return array_keys($users);
+}
+
+function openvpn_schedule_disconnect_user_from_openvpn($username) {
+	$sockets = glob('/var/etc/openvpn/server*.sock') ?: [];
+	$disconnected = false;
+
+	foreach ($sockets as $socket_file) {
+		$socket = @stream_socket_client('unix://' . $socket_file, $errno, $errstr, 1);
+		if ($socket === false) {
+			continue;
+		}
+		fwrite($socket, "kill {$username}\n");
+		fwrite($socket, "quit\n");
+		fclose($socket);
+		$disconnected = true;
+	}
+
+	return $disconnected;
+}
+
+function openvpn_schedule_disconnect_out_of_schedule_users() {
+	$connected_users = openvpn_schedule_collect_connected_users();
+	if (empty($connected_users)) {
+		openvpn_schedule_log('cron watcher: no connected users found');
+		return;
+	}
+
+	foreach ($connected_users as $username) {
+		$schedule = openvpn_schedule_find_policy($username);
+		if (strcasecmp($schedule, 'none') === 0) {
+			continue;
+		}
+		if (openvpn_schedule_now_matches($schedule)) {
+			continue;
+		}
+
+		if (openvpn_schedule_disconnect_user_from_openvpn($username)) {
+			openvpn_schedule_log("cron watcher: disconnected user '{$username}' outside schedule '{$schedule}'");
+		} else {
+			openvpn_schedule_log("cron watcher: unable to disconnect user '{$username}' outside schedule '{$schedule}' (management socket unavailable)");
+		}
+	}
 }

--- a/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule_cron.php
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule_cron.php
@@ -1,0 +1,9 @@
+<?php
+/*
+ * openvpn_schedule_cron.php
+ * Disconnects already connected OpenVPN users that are currently outside allowed schedules.
+ */
+
+require_once('/usr/local/pkg/openvpn_schedule.inc');
+
+openvpn_schedule_disconnect_out_of_schedule_users();

--- a/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule_hook.inc
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule_hook.inc
@@ -15,18 +15,54 @@ if (!function_exists('openvpn_schedule_log_runtime')) {
 }
 
 if (!function_exists('openvpn_schedule_now_matches')) {
+	function openvpn_schedule_get_schedule_config($schedule_name) {
+		foreach (config_get_path('schedules/schedule', []) as $schedule) {
+			if (strcasecmp(trim((string)($schedule['name'] ?? '')), $schedule_name) === 0) {
+				return is_array($schedule) ? $schedule : [];
+			}
+		}
+		return [];
+	}
+
+	function openvpn_schedule_eval_with_core_engine($schedule_name, array $schedule_cfg) {
+		if (function_exists('filter_schedule_in_effect')) {
+			foreach ([$schedule_cfg, $schedule_name] as $arg) {
+				try {
+					return (bool)filter_schedule_in_effect($arg);
+				} catch (Throwable $e) {
+					/* Ignore and continue trying compatibility signatures. */
+				}
+			}
+		}
+
+		if (function_exists('is_schedule_in_time')) {
+			foreach ([$schedule_cfg, $schedule_name] as $arg) {
+				try {
+					return (bool)is_schedule_in_time($arg);
+				} catch (Throwable $e) {
+					/* Ignore and continue trying compatibility signatures. */
+				}
+			}
+		}
+
+		return null;
+	}
+
 	function openvpn_schedule_now_matches($schedule_name) {
 		$schedule_name = trim((string)$schedule_name);
 		if ($schedule_name === '' || strcasecmp($schedule_name, 'none') === 0) {
 			return true;
 		}
 
-		// Reuse core schedule engine when available.
-		if (function_exists('filter_schedule_in_effect')) {
-			return filter_schedule_in_effect($schedule_name);
+		$schedule_cfg = openvpn_schedule_get_schedule_config($schedule_name);
+		if (empty($schedule_cfg)) {
+			openvpn_schedule_log_runtime("schedule '{$schedule_name}' not found, denying login");
+			return false;
 		}
-		if (function_exists('is_schedule_in_time')) {
-			return is_schedule_in_time($schedule_name);
+
+		$core_match = openvpn_schedule_eval_with_core_engine($schedule_name, $schedule_cfg);
+		if ($core_match !== null) {
+			return (bool)$core_match;
 		}
 
 		// Safe fallback: if schedule engine is unavailable, do not block logins.
@@ -64,14 +100,14 @@ if (!function_exists('openvpn_schedule_find_policy')) {
 		$pkg = config_get_path(openvpn_schedule_hook_package_base_path() . '/config/0', []);
 
 		foreach (openvpn_schedule_get_entries($pkg) as $entry) {
-			if (($entry['username'] ?? '') === $username) {
+			if (strcasecmp((string)($entry['username'] ?? ''), $username) === 0) {
 				return trim($entry['schedule'] ?? 'none');
 			}
 		}
 
 		// Backward compatibility with the previous user/group rule format.
 		foreach (($pkg['rule'] ?? []) as $rule) {
-			if (($rule['type'] ?? '') === 'user' && ($rule['name'] ?? '') === $username) {
+			if (($rule['type'] ?? '') === 'user' && strcasecmp((string)($rule['name'] ?? ''), $username) === 0) {
 				return trim($rule['schedule'] ?? 'none');
 			}
 		}
@@ -81,9 +117,58 @@ if (!function_exists('openvpn_schedule_find_policy')) {
 }
 
 if (!function_exists('openvpn_schedule_enforce_or_exit')) {
+	function openvpn_schedule_extract_username_from_argv_file() {
+		$argv = $_SERVER['argv'] ?? [];
+		if (!is_array($argv)) {
+			return '';
+		}
+
+		foreach ($argv as $idx => $arg) {
+			if ($idx === 0) {
+				continue;
+			}
+			$path = trim((string)$arg);
+			if ($path === '' || !is_file($path) || !is_readable($path)) {
+				continue;
+			}
+			$lines = @file($path, FILE_IGNORE_NEW_LINES);
+			if (!is_array($lines) || !isset($lines[0])) {
+				continue;
+			}
+			$username = trim((string)$lines[0]);
+			if ($username !== '') {
+				return $username;
+			}
+		}
+
+		return '';
+	}
+
+	function openvpn_schedule_extract_username() {
+		$candidates = [
+			$_POST['username'] ?? '',
+			$_REQUEST['username'] ?? '',
+			$_ENV['username'] ?? '',
+			$_SERVER['username'] ?? '',
+			$_SERVER['common_name'] ?? '',
+			getenv('username') ?: '',
+			$GLOBALS['username'] ?? '',
+		];
+
+		foreach ($candidates as $candidate) {
+			$username = trim((string)$candidate);
+			if ($username !== '') {
+				return $username;
+			}
+		}
+
+		return openvpn_schedule_extract_username_from_argv_file();
+	}
+
 	function openvpn_schedule_enforce_or_exit() {
-		$username = $_POST['username'] ?? $_ENV['username'] ?? '';
+		$username = openvpn_schedule_extract_username();
 		if (empty($username)) {
+			openvpn_schedule_log_runtime('username is empty at auth hook, skipping schedule check');
 			return;
 		}
 

--- a/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/share/doc/Kontrol-pkg-OpenVPN-Schedule/README.md
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/share/doc/Kontrol-pkg-OpenVPN-Schedule/README.md
@@ -2,6 +2,7 @@
 
 ## Overview
 This package enforces OpenVPN login access windows using existing pfSense/Kontrol schedules.
+It also can disconnect active sessions that become out-of-schedule.
 
 ## Installation
 1. Install the `www/Kontrol-pkg-OpenVPN-Schedule` port via pkg/ports.
@@ -19,6 +20,12 @@ This package enforces OpenVPN login access windows using existing pfSense/Kontro
 2. Assign a schedule to one test user in **VPN > OpenVPN Schedule**.
 3. Test OpenVPN authentication inside and outside the allowed window.
 4. Review logs tagged with `[openvpn_schedule]`.
+5. Keep a test user connected past the schedule end time and confirm the periodic watcher disconnects the session.
+
+## Periodic disconnect watcher
+- A cron task is automatically installed when at least one user has a non-`None` schedule.
+- The watcher runs every 5 minutes and checks currently connected OpenVPN users.
+- If a connected user is outside the configured schedule window, the package sends a management `kill` command to OpenVPN server sockets.
 
 ## Deinstall / rollback
 1. Remove the package.

--- a/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/www/openvpn_schedule.php
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/www/openvpn_schedule.php
@@ -139,6 +139,14 @@ function openvpn_schedule_build_user_map() {
 	return $map;
 }
 
+function openvpn_schedule_user_label(array $user) {
+	$label = '👤 ' . $user['name'];
+	if ($user['descr'] !== '') {
+		$label .= ' (' . $user['descr'] . ')';
+	}
+	return $label;
+}
+
 $schedule_names = openvpn_schedule_get_all_schedule_names();
 $schedule_options = ['none' => 'None'];
 foreach ($schedule_names as $schedule_name) {
@@ -218,10 +226,7 @@ if (empty($schedule_names)) {
 }
 
 foreach ($users as $user) {
-	$label = $user['name'];
-	if ($user['descr'] !== '') {
-		$label .= ' (' . $user['descr'] . ')';
-	}
+	$label = openvpn_schedule_user_label($user);
 	$field_name = 'schedule_' . preg_replace('/[^a-zA-Z0-9_]/', '_', $user['name']);
 	$current_value = $current_user_map[$user['name']] ?? 'none';
 	if (!array_key_exists($current_value, $schedule_options)) {

--- a/www/Kontrol-pkg-OpenVPN-Schedule/pkg-plist
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/pkg-plist
@@ -1,6 +1,7 @@
 pkg/openvpn_schedule.xml
 pkg/openvpn_schedule.inc
 pkg/openvpn_schedule_hook.inc
+pkg/openvpn_schedule_cron.php
 www/openvpn_schedule.php
 /etc/inc/priv/openvpn_schedule.priv.inc
 share/doc/Kontrol-pkg-OpenVPN-Schedule/README.md


### PR DESCRIPTION
### Motivation
- Enforce schedule policies not only at login but also for already-connected users by periodically disconnecting sessions that fall outside allowed schedules.
- Improve robustness of the OpenVPN auth hook by better username extraction and case-insensitive matching to avoid missed enforcement.
- Wire up install/upgrade/deinstall to manage the periodic watcher lifecycle and document the feature.

### Description
- Added a cron-based watcher: new `openvpn_schedule_cron.php` and `openvpn_schedule_setup_cron()` that installs/removes a cron job (`/usr/local/bin/php -f /usr/local/pkg/openvpn_schedule_cron.php`) when at least one user has a non-`None` schedule, running every 5 minutes.
- Implemented connected-session handling in `openvpn_schedule.inc` including `openvpn_schedule_collect_connected_users_from_status()`, `openvpn_schedule_collect_connected_users()`, `openvpn_schedule_disconnect_user_from_openvpn()` and `openvpn_schedule_disconnect_out_of_schedule_users()` to locate connected users and issue management `kill` commands to server sockets.
- Hardened runtime auth logic in `openvpn_schedule_hook.inc` by adding case-insensitive username matching, safe reuse of core schedule engine (`filter_schedule_in_effect` / `is_schedule_in_time`), more robust schedule lookup, and improved username extraction via request/env/argv-file parsing in `openvpn_schedule_extract_username()`.
- Made `openvpn_schedule_enforce_or_exit()` use the safer extractor and added explicit runtime logging for empty usernames or missing schedules.
- Added manifest/cron constants and ensured `openvpn_schedule_setup_cron(true|false)` is invoked during `openvpn_schedule_sync()`, `openvpn_schedule_install()`, `openvpn_schedule_upgrade()`, and `openvpn_schedule_deinstall()`.
- Small UI improvement: added `openvpn_schedule_user_label()` to include user description in the selection label and updated `pkg-plist` and `README.md` to document the periodic disconnect watcher.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc834ba840832e9fbc91b93c627a01)