### PR TITLE
www/Kontrol-pkg-OpenVPN-Schedule: always clean config and cron on deinstall

### DIFF
--- a/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule.inc
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule.inc
@@ -76,16 +76,25 @@ function openvpn_schedule_upgrade() {
 
 function openvpn_schedule_deinstall() {
 	openvpn_schedule_log('deinstall start');
-	if (!openvpn_schedule_restore_runtime_patch()) {
-		openvpn_schedule_log('deinstall failed: could not restore original auth file. Manual recovery required from backup in ' . OVPN_SCHEDULE_STATE_DIR);
-		return;
+	$runtime_restored = openvpn_schedule_restore_runtime_patch();
+	if (!$runtime_restored) {
+		openvpn_schedule_log('deinstall warning: could not restore original auth file. Manual recovery may be required from backup in ' . OVPN_SCHEDULE_STATE_DIR);
 	}
+
+	/*
+	 * Always continue package cleanup even when runtime patch rollback fails.
+	 * This prevents stale config.xml/package cron leftovers after uninstall.
+	 */
 	openvpn_schedule_setup_cron(false);
 	config_del_path(openvpn_schedule_package_base_path());
 	write_config('Removed OpenVPN schedule package configuration');
 	@unlink(OVPN_SCHEDULE_MANIFEST);
 	@rmdir(OVPN_SCHEDULE_STATE_DIR);
-	openvpn_schedule_log('deinstall done');
+	if ($runtime_restored) {
+		openvpn_schedule_log('deinstall done');
+	} else {
+		openvpn_schedule_log('deinstall done with warnings');
+	}
 }
 
 function openvpn_schedule_migrate_config() {


### PR DESCRIPTION
### Motivation
- The previous `openvpn_schedule_deinstall()` returned early when `openvpn_schedule_restore_runtime_patch()` failed, which could leave `installedpackages/openvpn_schedule` in `config.xml` and stale cron entries after uninstall.

### Description
- Change `openvpn_schedule_deinstall()` to capture the result of `openvpn_schedule_restore_runtime_patch()` and continue cleanup even on failure.
- Always run `openvpn_schedule_setup_cron(false)`, `config_del_path(openvpn_schedule_package_base_path())`, `write_config(...)`, and remove manifest/state artifacts to ensure cron and config are cleaned up.
- Emit `deinstall warning` when rollback fails and log either `deinstall done` or `deinstall done with warnings` depending on the outcome.

### Testing
- Ran `php -l www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule.inc` and it reported `No syntax errors detected` (success).
- Verified repository status with `git -C /workspace/FreeBSD-ports status --short` and committed the change with `git -C /workspace/FreeBSD-ports commit` (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd55c774c4832ea1548349399c0a11)