### PR TITLE
www/Kontrol-pkg-OpenVPN-Schedule: add reversible auth debug and stricter schedule evaluation

### DIFF
--- a/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule_hook.inc
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule_hook.inc
@@ -14,7 +14,48 @@ if (!function_exists('openvpn_schedule_log_runtime')) {
 	}
 }
 
+if (!function_exists('openvpn_schedule_hook_debug_enabled')) {
+	function openvpn_schedule_hook_debug_enabled() {
+		$pkg = config_get_path(openvpn_schedule_hook_package_base_path() . '/config/0', []);
+		$debug_flag = trim((string)($pkg['debug_auth'] ?? ''));
+		return in_array(strtolower($debug_flag), ['1', 'yes', 'on', 'true'], true);
+	}
+
+	function openvpn_schedule_log_debug($message) {
+		if (openvpn_schedule_hook_debug_enabled()) {
+			openvpn_schedule_log_runtime('[debug] ' . $message);
+		}
+	}
+}
+
 if (!function_exists('openvpn_schedule_now_matches')) {
+	function openvpn_schedule_hook_eval_to_bool($value) {
+		if (is_bool($value)) {
+			return $value;
+		}
+
+		if (is_int($value) || is_float($value)) {
+			if ((int)$value === 0) {
+				return false;
+			}
+			if ((int)$value === 1) {
+				return true;
+			}
+		}
+
+		if (is_string($value)) {
+			$normalized = strtolower(trim($value));
+			if (in_array($normalized, ['0', 'no', 'off', 'false'], true)) {
+				return false;
+			}
+			if (in_array($normalized, ['1', 'yes', 'on', 'true'], true)) {
+				return true;
+			}
+		}
+
+		return null;
+	}
+
 	function openvpn_schedule_get_schedule_config($schedule_name) {
 		foreach (config_get_path('schedules/schedule', []) as $schedule) {
 			if (strcasecmp(trim((string)($schedule['name'] ?? '')), $schedule_name) === 0) {
@@ -28,9 +69,16 @@ if (!function_exists('openvpn_schedule_now_matches')) {
 		if (function_exists('filter_schedule_in_effect')) {
 			foreach ([$schedule_cfg, $schedule_name] as $arg) {
 				try {
-					return (bool)filter_schedule_in_effect($arg);
+					$raw = filter_schedule_in_effect($arg);
+					$normalized = openvpn_schedule_hook_eval_to_bool($raw);
+					if ($normalized !== null) {
+						openvpn_schedule_log_debug("schedule '{$schedule_name}' evaluated by filter_schedule_in_effect(" . gettype($arg) . ') => ' . ($normalized ? 'allow' : 'deny'));
+						return $normalized;
+					}
+					openvpn_schedule_log_debug("schedule '{$schedule_name}' returned non-boolean from filter_schedule_in_effect(" . gettype($arg) . '), trying fallback signatures');
 				} catch (Throwable $e) {
 					/* Ignore and continue trying compatibility signatures. */
+					openvpn_schedule_log_debug("filter_schedule_in_effect(" . gettype($arg) . ') failed for schedule ' . "'{$schedule_name}': " . $e->getMessage());
 				}
 			}
 		}
@@ -38,9 +86,16 @@ if (!function_exists('openvpn_schedule_now_matches')) {
 		if (function_exists('is_schedule_in_time')) {
 			foreach ([$schedule_cfg, $schedule_name] as $arg) {
 				try {
-					return (bool)is_schedule_in_time($arg);
+					$raw = is_schedule_in_time($arg);
+					$normalized = openvpn_schedule_hook_eval_to_bool($raw);
+					if ($normalized !== null) {
+						openvpn_schedule_log_debug("schedule '{$schedule_name}' evaluated by is_schedule_in_time(" . gettype($arg) . ') => ' . ($normalized ? 'allow' : 'deny'));
+						return $normalized;
+					}
+					openvpn_schedule_log_debug("schedule '{$schedule_name}' returned non-boolean from is_schedule_in_time(" . gettype($arg) . '), trying fallback signatures');
 				} catch (Throwable $e) {
 					/* Ignore and continue trying compatibility signatures. */
+					openvpn_schedule_log_debug("is_schedule_in_time(" . gettype($arg) . ') failed for schedule ' . "'{$schedule_name}': " . $e->getMessage());
 				}
 			}
 		}
@@ -178,6 +233,7 @@ if (!function_exists('openvpn_schedule_enforce_or_exit')) {
 
 		$schedule = openvpn_schedule_find_policy($username);
 		$allowed = openvpn_schedule_now_matches($schedule);
+		openvpn_schedule_log_debug("auth intercept user='{$username}' schedule='{$schedule}' decision=" . ($allowed ? 'allow' : 'deny'));
 		if ($allowed) {
 			if (strcasecmp($schedule, 'none') !== 0) {
 				openvpn_schedule_log_runtime("OpenVPN login allowed for user '{$username}' inside schedule '{$schedule}'");
@@ -185,7 +241,7 @@ if (!function_exists('openvpn_schedule_enforce_or_exit')) {
 			return;
 		}
 
-		openvpn_schedule_log_runtime("OpenVPN login denied for user '{$username}' outside allowed schedule '{$schedule}'");
+		openvpn_schedule_log_runtime("OpenVPN login denied for user '{$username}' outside allowed schedule '{$schedule}' (reason: schedule not active at authentication time)");
 		exit(1);
 	}
 }

--- a/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/www/openvpn_schedule.php
+++ b/www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/www/openvpn_schedule.php
@@ -46,6 +46,10 @@ function openvpn_schedule_save_user_schedules(array $entries) {
 	config_set_path(openvpn_schedule_ui_package_base_path() . '/config/0/user_schedule', ['item' => array_values($entries)]);
 }
 
+function openvpn_schedule_save_debug_flag($enabled) {
+	config_set_path(openvpn_schedule_ui_package_base_path() . '/config/0/debug_auth', $enabled ? 'yes' : '');
+}
+
 function openvpn_schedule_get_user_schedule_entries(array $pkgcfg) {
 	$user_schedule = $pkgcfg['user_schedule'] ?? [];
 	if (is_array($user_schedule) && isset($user_schedule['item']) && is_array($user_schedule['item'])) {
@@ -155,6 +159,7 @@ foreach ($schedule_names as $schedule_name) {
 
 $users = openvpn_schedule_get_visible_users();
 $current_user_map = openvpn_schedule_build_user_map();
+$debug_auth_enabled = trim((string)config_get_path(openvpn_schedule_ui_package_base_path() . '/config/0/debug_auth', '')) !== '';
 foreach ($current_user_map as $saved_schedule) {
 	if ($saved_schedule !== 'none' && !array_key_exists($saved_schedule, $schedule_options)) {
 		$schedule_options[$saved_schedule] = $saved_schedule . ' (missing schedule)';
@@ -189,6 +194,8 @@ if ($_POST) {
 
 	if (empty($input_errors)) {
 		openvpn_schedule_save_user_schedules($new_entries);
+		$debug_auth_enabled = isset($_POST['debug_auth']) && $_POST['debug_auth'] === 'yes';
+		openvpn_schedule_save_debug_flag($debug_auth_enabled);
 		write_config('Updated OpenVPN per-user schedule settings', false);
 		openvpn_schedule_sync();
 		header('Location: /openvpn_schedule.php?save=1');
@@ -217,6 +224,14 @@ $section->addInput(new Form_StaticText(
 	'Storage',
 	'Settings are stored in config.xml under installedpackages/<openvpn_schedule>/config/0/user_schedule and are automatically removed when this package is uninstalled.'
 ));
+
+$section->addInput(new Form_Checkbox(
+	'debug_auth',
+	'Auth Debug',
+	'Enable verbose authentication debug logs (temporarily)',
+	$debug_auth_enabled,
+	'yes'
+))->setHelp('When enabled, extra [debug] entries are written to the system log for each authentication intercept. Disable after troubleshooting.');
 
 if (empty($schedule_names)) {
 	$section->addInput(new Form_StaticText(


### PR DESCRIPTION
### Motivation
- Users reported that OpenVPN logins were not consistently blocked outside configured schedules and needed reversible debug logging to troubleshoot the auth hook behavior. 
- The change aims to ensure schedule helper return values are interpreted strictly to avoid accidental allow due to unexpected return types and to provide clear, reversible debug output for investigations.

### Description
- Added a UI checkbox `Auth Debug` and persisted `debug_auth` to the package config via `openvpn_schedule_save_debug_flag()` so debug logging can be enabled and disabled without code changes. 
- Implemented `openvpn_schedule_hook_debug_enabled()` and `openvpn_schedule_log_debug()` to emit extra `[debug]`-tagged entries when the debug flag is active. 
- Added `openvpn_schedule_hook_eval_to_bool()` to normalize and strictly accept boolean-like results from core schedule helpers and updated calls to `filter_schedule_in_effect()` and `is_schedule_in_time()` to use this normalization and log their outcomes. 
- Logged the auth intercept decision (`allow`/`deny`) at debug level and strengthened the denial message to always include an explicit reason (`reason: schedule not active at authentication time`).

### Testing
- Ran `php -l www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/pkg/openvpn_schedule_hook.inc` and it reported no syntax errors. 
- Ran `php -l www/Kontrol-pkg-OpenVPN-Schedule/files/usr/local/www/openvpn_schedule.php` and it reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd611d8c40832eb1c308eed7308c02)