### PR TITLE
www/Kontrol-pkg-sarg: ignore VuXML vulnerability checks during build

### DIFF
--- a/www/Kontrol-pkg-sarg/Makefile
+++ b/www/Kontrol-pkg-sarg/Makefile
@@ -13,6 +13,9 @@ COMMENT=	Kontrol SARG Package
 
 LICENSE=	APACHE20
 
+# Allow this meta-port to build even when a dependency is flagged in VuXML.
+DISABLE_VULNERABILITIES=	yes
+
 RUN_DEPENDS=	${LOCALBASE}/bin/sarg:www/sarg
 
 NO_BUILD=	yes


### PR DESCRIPTION
### Motivation
- Building the meta-port stops when a dependency (for example `devel/py-wheel`) is flagged in VuXML, so the port must be allowed to proceed despite vulnerability advisories.

### Description
- Added `DISABLE_VULNERABILITIES=yes` to `www/Kontrol-pkg-sarg/Makefile` to bypass the ports vulnerability gate for this port during builds.

### Testing
- Attempted to query the variable with `make -C www/Kontrol-pkg-sarg -V DISABLE_VULNERABILITIES`, which failed because the environment provides GNU `make` instead of FreeBSD `bmake`, so no build verification was performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce6884076c832ebecf13963f8fbf20)