### PR TITLE
Allow building py-wheel and Kontrol-pkg-Sarg despite VuXML advisories

### DIFF
--- a/devel/py-wheel/Makefile
+++ b/devel/py-wheel/Makefile
@@ -11,6 +11,9 @@ WWW=		https://github.com/pypa/wheel
 
 LICENSE=	MIT
 
+# Local build override: allow build to continue despite VuXML advisory.
+DISABLE_VULNERABILITIES=	yes
+
 BUILD_DEPENDS=	${PYTHON_PKGNAMEPREFIX}flit-core>=3.8:devel/py-flit-core@${PY_FLAVOR}
 
 USES=		python

--- a/www/Kontrol-pkg-sarg/Makefile
+++ b/www/Kontrol-pkg-sarg/Makefile
@@ -13,6 +13,9 @@ COMMENT=	Kontrol SARG Package
 
 LICENSE=	APACHE20
 
+# Allow this meta-port to build even when a dependency is flagged in VuXML.
+DISABLE_VULNERABILITIES=	yes
+
 RUN_DEPENDS=	${LOCALBASE}/bin/sarg:www/sarg
 
 NO_BUILD=	yes


### PR DESCRIPTION
### Motivation
- Permit building these ports locally even when dependencies are flagged in VuXML by disabling vulnerability blocking during the build.

### Description
- Add `DISABLE_VULNERABILITIES= yes` with a short explanatory comment to `devel/py-wheel/Makefile` and `www/Kontrol-pkg-sarg/Makefile` so the ports continue to build despite VuXML advisories.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce6884076c832ebecf13963f8fbf20)