### PR TITLE
sysutils/lcdproc: add libusb1 dependency for USB builds

### DIFF
--- a/sysutils/lcdproc/Makefile
+++ b/sysutils/lcdproc/Makefile
@@ -1,7 +1,7 @@
 PORTNAME=	lcdproc
 DISTVERSIONPREFIX=	v
 DISTVERSION=	0.5.9
-PORTREVISION=	4
+PORTREVISION=	5
 CATEGORIES=	sysutils
 
 MAINTAINER=	contato@kontrol.com.br
@@ -103,6 +103,7 @@ USE_GCC=	yes
 .endif
 
 .if ${PORT_OPTIONS:MUSB}
+LIB_DEPENDS+=		libusb-1.0.so:devel/libusb1
 CONFIGURE_ARGS+=	--enable-libusb --enable-libusb-1-0
 PLIST_SUB+=		USB=""
 LCDPROC_DRIVERS+=IOWarrior \


### PR DESCRIPTION
### Motivation
- Corrigir falha de compilação ao habilitar a opção `USB` porque o port ativava `--enable-libusb-1-0` mas não declarava a dependência de `devel/libusb1`, levando a `fatal error: 'libusb-1.0/libusb.h' file not found`.

### Description
- Aumentei `PORTREVISION` para `5` e adicionei `LIB_DEPENDS+=	libusb-1.0.so:devel/libusb1` dentro do bloco `.if ${PORT_OPTIONS:MUSB}` em `sysutils/lcdproc/Makefile` para garantir que os headers/libs do libusb-1.0 sejam instalados para builds com USB.

### Testing
- Verifiquei o conteúdo modificado do `Makefile` com comandos (`nl`, `sed`) e confirmei o commit; tentativa de verificar variáveis de build com `make -C sysutils/lcdproc -V PORTREVISION`/`-V LIB_DEPENDS` falhou no ambiente porque a `make` disponível é GNU `make` e não o `bmake` do FreeBSD, portanto não foi possível executar um build completo do port aqui.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea5bb88710832eaae8f3092082f693)