### PR TITLE
lcdproc: add libusb1 dependency, adjust libusb include for FreeBSD, bump portrev

### DIFF
--- a/sysutils/lcdproc/Makefile
+++ b/sysutils/lcdproc/Makefile
@@ -1,7 +1,7 @@
 PORTNAME=	lcdproc
 DISTVERSIONPREFIX=	v
 DISTVERSION=	0.5.9
-PORTREVISION=	4
+PORTREVISION=	6
 CATEGORIES=	sysutils
 
 MAINTAINER=	contato@kontrol.com.br
@@ -103,6 +103,7 @@ USE_GCC=	yes
 .endif
 
 .if ${PORT_OPTIONS:MUSB}
+LIB_DEPENDS+=		libusb-1.0.so:devel/libusb1
 CONFIGURE_ARGS+=	--enable-libusb --enable-libusb-1-0
 PLIST_SUB+=		USB=""
 LCDPROC_DRIVERS+=IOWarrior \

--- a/sysutils/lcdproc/files/patch-server_drivers_hd44780-low.h
+++ b/sysutils/lcdproc/files/patch-server_drivers_hd44780-low.h
@@ -1,0 +1,15 @@
+--- server/drivers/hd44780-low.h.orig	2026-04-23 00:00:00 UTC
++++ server/drivers/hd44780-low.h
+@@ -15,7 +15,11 @@
+ #endif
+ 
+ #ifdef HAVE_LIBUSB_1_0
+-# include <libusb-1.0/libusb.h>
++# ifdef __FreeBSD__
++#  include <libusb.h>
++# else
++#  include <libusb-1.0/libusb.h>
++# endif
+ #endif
+ 
+ #if TIME_WITH_SYS_TIME


### PR DESCRIPTION
### Motivation
- Fix build/runtime issues when USB support is enabled by ensuring the correct `libusb` header is included on FreeBSD and that `libusb1` is declared as a dependency, and update the port revision.

### Description
- Increment `PORTREVISION` from `4` to `6` in `sysutils/lcdproc/Makefile`.
- Add `LIB_DEPENDS+= libusb-1.0.so:devel/libusb1` under the `PORT_OPTIONS:MUSB` branch in `sysutils/lcdproc/Makefile` and add a new patch `sysutils/lcdproc/files/patch-server_drivers_hd44780-low.h` that uses `#include <libusb.h>` on FreeBSD and `#include <libusb-1.0/libusb.h>` elsewhere.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea5bb88710832eaae8f3092082f693)