### PR TITLE
sysutils/lcdproc: drop nonexistent devel/libusb1 dependency and bump PORTREVISION

### DIFF
--- a/sysutils/lcdproc/Makefile
+++ b/sysutils/lcdproc/Makefile
@@ -1,7 +1,7 @@
 PORTNAME=	lcdproc
 DISTVERSIONPREFIX=	v
 DISTVERSION=	0.5.9
-PORTREVISION=	7
+PORTREVISION=	8
 CATEGORIES=	sysutils
 
 MAINTAINER=	contato@kontrol.com.br
@@ -103,7 +103,6 @@ USE_GCC=	yes
 .endif
 
 .if ${PORT_OPTIONS:MUSB}
-LIB_DEPENDS+=		libusb-1.0.so:devel/libusb1
 CONFIGURE_ARGS+=	--enable-libusb --enable-libusb-1-0
 PLIST_SUB+=		USB=""
 LCDPROC_DRIVERS+=IOWarrior \


### PR DESCRIPTION
### Motivation
- The port `sysutils/lcdproc` declared `LIB_DEPENDS+= libusb-1.0.so:devel/libusb1`, but `devel/libusb1` does not exist in this ports tree and caused `depends on nonexistent origin` build failures.
- The intent is to keep USB support enabled while removing the invalid package-level dependency that breaks port builds.

### Description
- Removed the `LIB_DEPENDS+= libusb-1.0.so:devel/libusb1` line from `sysutils/lcdproc/Makefile` so the port no longer depends on a nonexistent origin.
- Left `CONFIGURE_ARGS+= --enable-libusb --enable-libusb-1-0` in place so USB support is still requested at configure time and will use the system-provided libusb.
- Incremented `PORTREVISION` from `7` to `8` to record the packaging fix.

### Testing
- Ran `rg -n "libusb1|devel/libusb1|libusb" sysutils/lcdproc` to confirm the explicit `devel/libusb1` origin was removed, which succeeded.
- Inspected the Makefile with `nl -ba sysutils/lcdproc/Makefile | sed -n '1,140p'` to confirm `PORTREVISION= 8` and that `--enable-libusb` remains in `CONFIGURE_ARGS`, which succeeded.
- Attempted `make -C sysutils/lcdproc -V PORTREVISION -V LIB_DEPENDS -V CONFIGURE_ARGS` to query make variables but this failed because the environment uses GNU `make` which does not support the FreeBSD `-V` syntax, so variable validation could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea70e172a4832ea77331af0198ca31)