### PR TITLE
www/Kontrol-pkg-E2guardian54: make listener mapping explicit for single-port multi-interface

### DIFF
--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.conf.template
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.conf.template
@@ -176,6 +176,7 @@ dstatinterval = {$dstatinterval}
 # If disabled will listen on all filterports on all filterips.
 # on (default) | off
 #mapportstoips = off
+{$mapportstoips}
 
 #port for transparent https
 #if defined enables tranparent https

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc
@@ -2195,16 +2195,15 @@ EOF;
 	}
 	$filtergroups = ($count > 1?($count -1):1);
 	$filterip = "";
-	$filterports = "";
+	$filterports = "filterports = " . $filterport;
+	$mapportstoips = "mapportstoips = off";
 	foreach (explode(",", $e2guardian['interface']) as $i => $iface) {
 		$real_ifaces[] = dg_get_real_interface_address($iface);
 		if ($real_ifaces[$i][0]) {
 			$filterip .= "filterip = " . $real_ifaces[$i][0] . "\n";
 		}
-		$filterports .= "filterports = " . $filterport . "\n";
 	}
 	$filterip = ($filterip == "" ? "filterip = " : $filterip);
-	$filterports = ($filterports == "" ? "filterports = $filterport" : $filterports);
 	$ssl_proxy_port = $e2guardian['ssl_proxy_port'] ? $e2guardian['ssl_proxy_port'] : "8081";
 	include(E2GUARDIAN_PKGDIR . "/e2guardian.conf.template");
 


### PR DESCRIPTION
### Motivation
- The current config generation repeated `filterports` per interface while not declaring `mapportstoips`, which can create ambiguous listener combinations in multi-interface transparent proxy setups using the same port. 
- The GUI currently exposes a single global port value; the generator must produce an unambiguous layout that matches e2guardian core expectations for this scenario.

### Description
- Stop repeating `filterports` inside the interface loop in `files/usr/local/pkg/e2guardian.inc` and instead generate a single `filterports = <porta>` line for the global-port GUI model. 
- Add an explicit `mapportstoips = off` assignment in `files/usr/local/pkg/e2guardian.inc` for the single-port-multiple-interfaces scenario. 
- Insert a placeholder `{$mapportstoips}` into `files/usr/local/pkg/e2guardian.conf.template` so the generated `e2guardian.conf` contains an explicit mapping-mode line rather than relying on a commented default. 
- No changes were made to PF/rdr rules, SSL bump/intercept logic, ACL XML field names, or single-interface behavior.

### Testing
- Ran syntax checks on modified files with `php -l files/usr/local/pkg/e2guardian.inc` which returned `No syntax errors detected`.
- Ran syntax checks on the template with `php -l files/usr/local/pkg/e2guardian.conf.template` which returned `No syntax errors detected`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efbe5bebb8832eaa045b5d5d56e482)