### PR TITLE
www/e2guardian54: remove missing manpage entry from pkg-plist

### DIFF
--- a/www/e2guardian54/pkg-plist
+++ b/www/e2guardian54/pkg-plist
@@ -241,7 +241,6 @@
 @sample %%ETCDIR%%/lists/urlredirectregexplist.sample
 @sample %%ETCDIR%%/lists/urlregexplist.sample
 @sample %%ETCDIR%%/lists/weightedphraselist.sample
-man/man8/e2guardian.8.gz
 sbin/e2guardian
 %%PORTDOCS%%%%DOCSDIR%%/AuthPlugins
 %%PORTDOCS%%%%DOCSDIR%%/ContentScanners


### PR DESCRIPTION
### Motivation
- The package build failed in the `package` phase because `pkg-static` expected `usr/local/man/man8/e2guardian.8.gz` in the stage but the manpage was not installed, so the plist must not require it.

### Description
- Removed `man/man8/e2guardian.8.gz` from `www/e2guardian54/pkg-plist` to stop packaging from depending on a non-existent manpage file.

### Testing
- Verified the removal by running `rg -n 'man/man8/e2guardian\.8\.gz' www/e2guardian54/pkg-plist` to confirm no match, inspected the change with `git diff -- www/e2guardian54/pkg-plist`, and committed the change with `git commit`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0f8541b9c832e81c6fcb0c87f6afe)