### PR TITLE
www/Kontrol-pkg-E2guardian54: fix CA handling for pfSense RELENG_2_8_1

### DIFF
--- a/www/Kontrol-pkg-E2guardian54/Makefile
+++ b/www/Kontrol-pkg-E2guardian54/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	Kontrol-pkg-E2guardian54
 PORTVERSION=	0.6.6.10
-PORTREVISION=	# empty
+PORTREVISION=	1
 CATEGORIES=	www
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc
@@ -1155,16 +1155,21 @@ function sync_package_e2guardian($via_rpc = "no", $install_process = false) {
 
         $enablessl = (e2g_ssl_intercept_is_enabled($e2guardian) ? "on" : "off");
 	$ca_cert = lookup_ca($e2guardian["dca"]);
-	if ($ca_cert != false) {
-		if (base64_decode($ca_cert['prv'])) {
-			file_put_contents("/etc/ssl/demoCA/private/cakey.pem", base64_decode($ca_cert['prv']));
+	if (is_array($ca_cert) && array_key_exists('item', $ca_cert) && is_array($ca_cert['item'])) {
+		$ca_cert = $ca_cert['item'];
+	}
+	if (is_array($ca_cert) && !empty($ca_cert)) {
+		$ca_prv = isset($ca_cert['prv']) ? base64_decode($ca_cert['prv']) : false;
+		if ($ca_prv !== false && $ca_prv !== "") {
+			file_put_contents("/etc/ssl/demoCA/private/cakey.pem", $ca_prv);
 			$ca_pk = "caprivatekeypath = '/etc/ssl/demoCA/private/cakey.pem'";
 		}
-		if (base64_decode($ca_cert['crt'])) {
+		$ca_crt = isset($ca_cert['crt']) ? base64_decode($ca_cert['crt']) : false;
+		if ($ca_crt !== false && $ca_crt !== "") {
 			$cert_hash = array();
-			file_put_contents("/etc/ssl/demoCA/cacert.pem", base64_decode($ca_cert['crt']));
+			file_put_contents("/etc/ssl/demoCA/cacert.pem", $ca_crt);
 			exec("/usr/bin/openssl x509 -hash -noout -in /etc/ssl/demoCA/cacert.pem", $cert_hash);
-			file_put_contents(E2GUARDIAN_CERTSDIR . "/" . $cert_hash[0] . ".0", base64_decode($ca_cert['crt']));
+			file_put_contents(E2GUARDIAN_CERTSDIR . "/" . $cert_hash[0] . ".0", $ca_crt);
 			$ca_pem = "cacertificatepath = '/etc/ssl/demoCA/cacert.pem'";
 			$generatedcertpath= "generatedcertpath = '" . $e2guardian_dir . "/ssl/generatedcerts'";
 		}


### PR DESCRIPTION
### Motivation
- pfSense RELENG_2_8_1 changed `lookup_ca()` return shape (wrapper with `item`) which broke the package's CA extraction and caused invalid/empty MITM CA files for e2guardian. 
- The result prevented correct generation of `cacert.pem`/`cakey.pem` and the associated generated certificate store, leading to runtime SSL MITM failures.

### Description
- Update `e2guardian.inc` to accept both legacy direct-array CA format and the RELENG_2_8_1 `['idx' => ..., 'item' => ...]` wrapper by unwrapping `item` when present. 
- Decode `prv` and `crt` exactly once and validate decoded content before writing to `/etc/ssl/demoCA/private/cakey.pem`, `/etc/ssl/demoCA/cacert.pem` and `E2GUARDIAN_CERTSDIR` to avoid writing empty/invalid files. 
- Restore generation of `cacertificatepath` and `generatedcertpath` entries when valid CA data is present so e2guardian can enable SSL MITM correctly. 
- Bump `PORTREVISION` in `www/Kontrol-pkg-E2guardian54/Makefile` to publish the fix.

### Testing
- Ran PHP syntax check `php -l www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc` and it reported `No syntax errors detected`, so the updated file is syntactically valid.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1038fb534832e98e5cf94b587dbe2)