### PR TITLE
Harden e2guardian watchdog to prevent duplicate starts

### DIFF
--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc
@@ -610,9 +610,11 @@ function e2g_watchdog_script($wpid, $wcmd, $winfo){
 	$wlog = "/var/log/e2guardian/start.log";
 	$wscript = <<<EOF
 # watchdog script for {$winfo}
-	if [ -f {$wpid} ];then
-		cat {$wpid} | xargs ps
-		if [ $? -ne 0 ]; then
+	if [ -f {$wpid} ]; then
+		wpid_value=\$(/bin/cat {$wpid} 2>/dev/null)
+		if [ -n "\${wpid_value}" ] && /bin/kill -0 "\${wpid_value}" 2>/dev/null; then
+			:
+		else
 			{$wcmd}
 			echo "`date +'%a %b %d %T %Y'` {$winfo} start" >> {$wlog}
 		fi
@@ -2244,9 +2246,11 @@ EOF;
 			}
 		}
 		$watchdog  =  "#!/bin/sh\n";
+		$watchdog .= "/usr/bin/lockf -st 0 /var/run/e2g_watchdog.lock /bin/sh -c '\n";
 		$watchdog .= "for a in 00 10 20 30 40 50\ndo\n";
 		$watchdog .= "\t{$watchdog_e2g}\n\t{$watchdog_parent}\n\t{$watchdog_squid}\n";
 		$watchdog .= "\tsleep 10\ndone\n";
+		$watchdog .= "'\n";
 		file_put_contents($cron_cmd, $watchdog, LOCK_EX);
 	} else {
 		e2g_stop_watchdog_processes();
@@ -2393,7 +2397,7 @@ function e2g_check_cron($cron_cmd, $action, $min = "*", $hour = "*", $mday = "*"
 
 function e2g_stop_watchdog_processes() {
 	$watchdog_cmd = E2GUARDIAN_BINDIR . "/e2g_watchdog.sh";
-	mwexec("/usr/bin/pgrep -f {$watchdog_cmd} | /usr/bin/xargs /bin/kill 2>/dev/null");
+	mwexec("/usr/bin/pkill -f {$watchdog_cmd} 2>/dev/null");
 }
 
 function e2guardian_check_config() {


### PR DESCRIPTION
### Motivation
- Cron-invoked watchdog instances could overlap and spawn concurrent `e2g_watchdog.sh` runs, causing multiple `e2guardian.sh start` invocations and duplicated `e2guardian`/watchdog processes as shown in the provided `ps` logs.
- The previous pidfile check relied on `cat pid | xargs ps`, which is fragile with empty/stale pidfiles and pipeline/race conditions and can produce false negatives that trigger unnecessary restarts.
- The goal is to make the watchdog deterministic and ensure only one watchdog execution can act on service restarts.

### Description
- Replaced the fragile pidfile check in the generated watchdog snippet with reading the pid into `wpid_value` and verifying liveness via `/bin/kill -0` before calling the start command.
- Wrapped the generated `e2g_watchdog.sh` body with a non-blocking lock using `/usr/bin/lockf -st 0 /var/run/e2g_watchdog.lock` so concurrent cron invocations cannot run in parallel and spawn duplicate starts.
- Replaced the `pgrep | xargs kill` teardown with a direct `/usr/bin/pkill -f` call inside `e2g_stop_watchdog_processes()` for safer and simpler process termination.
- The change was implemented in `www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc` where watchdog content is generated and managed.

### Testing
- Ran `php -l www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc` and it reported no syntax errors (success).
- No additional automated runtime tests were executed in this environment; the changes are defensive shell-level adjustments intended to prevent cron overlap and race conditions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3c7aef594832ebb7bee2a15849765)