### PR TITLE
Improve watchdog script: robust PID check, locking, and safer termination

### DIFF
--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc
@@ -610,15 +610,17 @@ function e2g_watchdog_script($wpid, $wcmd, $winfo){
 	$wlog = "/var/log/e2guardian/start.log";
 	$wscript = <<<EOF
 # watchdog script for {$winfo}
-	if [ -f {$wpid} ];then
-		cat {$wpid} | xargs ps
-		if [ $? -ne 0 ]; then
+	if [ -f {$wpid} ]; then
+		wpid_value=\$(/bin/cat {$wpid} 2>/dev/null)
+		if [ -n "\${wpid_value}" ] && /bin/kill -0 "\${wpid_value}" 2>/dev/null; then
+			:
+		else
 			{$wcmd}
-			echo "`date +'%a %b %d %T %Y'` {$winfo} start" >> {$wlog}
+			echo "\$(date '+%a %b %d %T %Y') {$winfo} start" >> {$wlog}
 		fi
 	else
 		{$wcmd}
-		echo "`date +'%a %b %d %T %Y'` {$winfo} start" >> {$wlog}
+		echo "\$(date '+%a %b %d %T %Y') {$winfo} start" >> {$wlog}
 	fi
 EOF;
 	return($wscript);
@@ -2244,6 +2246,9 @@ EOF;
 			}
 		}
 		$watchdog  =  "#!/bin/sh\n";
+		$watchdog .= "if [ \"\$1\" != \"--locked\" ]; then\n";
+		$watchdog .= "\texec /usr/bin/lockf -st 0 /var/run/e2g_watchdog.lock /bin/sh \"\$0\" --locked\n";
+		$watchdog .= "fi\n";
 		$watchdog .= "for a in 00 10 20 30 40 50\ndo\n";
 		$watchdog .= "\t{$watchdog_e2g}\n\t{$watchdog_parent}\n\t{$watchdog_squid}\n";
 		$watchdog .= "\tsleep 10\ndone\n";
@@ -2393,7 +2398,7 @@ function e2g_check_cron($cron_cmd, $action, $min = "*", $hour = "*", $mday = "*"
 
 function e2g_stop_watchdog_processes() {
 	$watchdog_cmd = E2GUARDIAN_BINDIR . "/e2g_watchdog.sh";
-	mwexec("/usr/bin/pgrep -f {$watchdog_cmd} | /usr/bin/xargs /bin/kill 2>/dev/null");
+	mwexec("/usr/bin/pkill -f {$watchdog_cmd} 2>/dev/null");
 }
 
 function e2guardian_check_config() {


### PR DESCRIPTION
### Motivation

- Reduce false positives and race conditions in the generated watchdog script by performing a robust PID existence check and preventing concurrent watchdog runs.
- Replace an unsafe process-kill pipeline with a simpler, more reliable command to stop watchdog processes.

### Description

- Update `e2g_watchdog_script()` to read the PID into a variable and use `/bin/kill -0` to verify the process exists instead of relying on `ps` via `xargs` and exit codes. 
- Add a lock protection block to the generated watchdog script that re-execs under `lockf` when not already locked to ensure a single instance (`/var/run/e2g_watchdog.lock`) runs at a time. 
- Normalize logging date expansion to use `$(date '+...')` and adjust minor shell formatting for clarity. 
- Replace the previous `pgrep | xargs kill` pipeline with a single `/usr/bin/pkill -f` call in `e2g_stop_watchdog_processes()` to stop the watchdog more reliably.

### Testing

- Ran PHP syntax check with `php -l` on the modified file and it returned no syntax errors. 
- Generated the watchdog script and performed a shell syntax check with `sh -n` on the produced script and it reported no syntax errors. 
- No unit tests were present for these changes; the above automated static checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3c7aef594832ebb7bee2a15849765)