### PR TITLE
e2guardian: stop/start watchdog during log rotation and bump package version to 0.6.5.33

### DIFF
--- a/www/Kontrol-pkg-E2guardian54/Makefile
+++ b/www/Kontrol-pkg-E2guardian54/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	Kontrol-pkg-E2guardian54
-PORTVERSION=	0.6.5.32
+PORTVERSION=	0.6.5.33
 PORTREVISION=	# empty
 CATEGORIES=	www
 MASTER_SITES=	# empty

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/www/e2guardian_logrotate.php
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/www/e2guardian_logrotate.php
@@ -35,8 +35,12 @@ require_once("xmlrpc_client.inc");
 require_once("e2guardian.inc");
 require_once("service-utils.inc");
 
+$e2guardian_cfg = $config['installedpackages']['e2guardian']['config'][0];
+$watchdog_cmd = "/usr/local/bin/e2g_watchdog.sh";
 
 log_error("e2guardian - rotating logs.");
+log_error("e2guardian - stopping watchdog processes before rotation.");
+mwexec("/usr/bin/pkill -f {$watchdog_cmd} 2>/dev/null");
 
 //TODO: Make all of this less hardcoded and hacky
 service_control_stop("e2guardian", array());
@@ -70,6 +74,14 @@ if (file_exists($log)){
 
 log_error("e2guardian - starting");
 service_control_start("e2guardian", array());
+
+$e2guardian_cfg = $config['installedpackages']['e2guardian']['config'][0];
+if ($e2guardian_cfg['watchdog'] == "on") {
+	log_error("e2guardian - restarting watchdog after rotation.");
+	mwexec_bg("/bin/sh {$watchdog_cmd}");
+} else {
+	log_error("e2guardian - watchdog remains disabled after rotation.");
+}
 
 log_error("e2guardian - log rotation complete.");
 ?>


### PR DESCRIPTION
### Motivation
- Prevent the e2guardian watchdog process from interfering with log rotation by stopping it prior to rotation and restarting it only when configured to run.
- Make the package release reflect the latest changes by updating the `PORTVERSION` to `0.6.5.33`.

### Description
- Bumped `PORTVERSION` from `0.6.5.32` to `0.6.5.33` in `Makefile` for `Kontrol-pkg-E2guardian54`.
- Added retrieval of the e2guardian configuration and a `watchdog` command path (`/usr/local/bin/e2g_watchdog.sh`) to the log rotation script `e2guardian_logrotate.php`.
- Added a `pkill -f` invocation to stop watchdog processes before rotating logs and added conditional logic to restart the watchdog with `mwexec_bg` only if `$e2guardian_cfg['watchdog'] == "on"` with additional log messages.
- Preserved the existing `service_control_stop`/`service_control_start` call sequence around the log rotation logic.

### Testing
- Ran a PHP syntax check with `php -l files/usr/local/www/e2guardian_logrotate.php` which completed successfully with no parse errors.
- No automated package regression tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f405a6f318832e91cf1b080fadbaaf)