### PR TITLE
Improve watchdog handling during log rotation, stagger blacklist cron, and bump package version

### DIFF
--- a/www/Kontrol-pkg-E2guardian54/Makefile
+++ b/www/Kontrol-pkg-E2guardian54/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	Kontrol-pkg-E2guardian54
-PORTVERSION=	0.6.5.32
+PORTVERSION=	0.6.5.33
 PORTREVISION=	# empty
 CATEGORIES=	www
 MASTER_SITES=	# empty

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc
@@ -608,19 +608,26 @@ function e2g_check_logdeniedcgi($logdeniedcgi) {
 
 function e2g_watchdog_script($wpid, $wcmd, $winfo){
 	$wlog = "/var/log/e2guardian/start.log";
+	$wprocess = ($winfo == "e2guardian" ? "^/usr/local/sbin/e2guardian$" : "");
 	$wscript = <<<EOF
 # watchdog script for {$winfo}
 	if [ -f {$wpid} ]; then
 		wpid_value=\$(/bin/cat {$wpid} 2>/dev/null)
 		if [ -n "\${wpid_value}" ] && /bin/kill -0 "\${wpid_value}" 2>/dev/null; then
 			:
+		elif [ -n "{$wprocess}" ] && /usr/bin/pgrep -f "{$wprocess}" >/dev/null 2>&1; then
+			/usr/bin/pgrep -f "{$wprocess}" | /usr/bin/head -n1 > {$wpid}
 		else
 			{$wcmd}
 			echo "\$(date) {$winfo} start" >> {$wlog}
 		fi
 	else
-		{$wcmd}
-		echo "\$(date) {$winfo} start" >> {$wlog}
+		if [ -n "{$wprocess}" ] && /usr/bin/pgrep -f "{$wprocess}" >/dev/null 2>&1; then
+			/usr/bin/pgrep -f "{$wprocess}" | /usr/bin/head -n1 > {$wpid}
+		else
+			{$wcmd}
+			echo "\$(date) {$winfo} start" >> {$wlog}
+		fi
 	fi
 EOF;
 	return($wscript);
@@ -2284,7 +2291,7 @@ EOF;
 	}
         $cron_cmd = E2GUARDIAN_BINDIR . "/php " . E2GUARDIAN_WWWDIR . "/e2guardian.php fetch_blacklist";
 	if ($e2guardian_blacklist['cron']) {
-		e2g_check_cron($cron_cmd, "create", "0", "0", $cron_field[$e2guardian_blacklist['cron']]);
+		e2g_check_cron($cron_cmd, "create", "20", "0", $cron_field[$e2guardian_blacklist['cron']]);
 	} else {
 		e2g_check_cron($cron_cmd, "remove");
 	}

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/www/e2guardian_logrotate.php
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/www/e2guardian_logrotate.php
@@ -35,8 +35,12 @@ require_once("xmlrpc_client.inc");
 require_once("e2guardian.inc");
 require_once("service-utils.inc");
 
+$e2guardian_cfg = $config['installedpackages']['e2guardian']['config'][0];
+$watchdog_cmd = "/usr/local/bin/e2g_watchdog.sh";
 
 log_error("e2guardian - rotating logs.");
+log_error("e2guardian - stopping watchdog processes before rotation.");
+mwexec("/usr/bin/pkill -f {$watchdog_cmd} 2>/dev/null");
 
 //TODO: Make all of this less hardcoded and hacky
 service_control_stop("e2guardian", array());
@@ -70,6 +74,32 @@ if (file_exists($log)){
 
 log_error("e2guardian - starting");
 service_control_start("e2guardian", array());
+
+$e2guardian_pid_file = "/var/run/e2guardian.pid";
+$e2guardian_ready = false;
+for ($i = 0; $i < 30; $i++) {
+	clearstatcache();
+	if (file_exists($e2guardian_pid_file)) {
+		$pid = trim(@file_get_contents($e2guardian_pid_file));
+		if (!empty($pid) && ctype_digit($pid) && posix_kill((int)$pid, 0)) {
+			$e2guardian_ready = true;
+			break;
+		}
+	}
+	sleep(1);
+}
+
+$e2guardian_cfg = $config['installedpackages']['e2guardian']['config'][0];
+if ($e2guardian_cfg['watchdog'] == "on") {
+	if ($e2guardian_ready) {
+		log_error("e2guardian - restarting watchdog after rotation.");
+		mwexec_bg("/bin/sh {$watchdog_cmd}");
+	} else {
+		log_error("e2guardian - watchdog restart deferred: e2guardian pid not ready.");
+	}
+} else {
+	log_error("e2guardian - watchdog remains disabled after rotation.");
+}
 
 log_error("e2guardian - log rotation complete.");
 ?>


### PR DESCRIPTION
### Motivation
- Prevent orphaned or stale watchdog processes and ensure the watchdog is restarted only after `e2guardian` is actually up following log rotation.
- Stagger the blacklist fetch cron to run at minute `20` instead of `0` to avoid scheduling collisions.
- Publish these fixes in the next port release by bumping the package version.

### Description
- Bumped `PORTVERSION` from `0.6.5.32` to `0.6.5.33` in `Makefile`.
- Enhanced `e2g_watchdog_script()` in `files/usr/local/pkg/e2guardian.inc` to detect running `e2guardian` processes via `pgrep -f` and populate the pid file when appropriate.
- Changed the blacklist fetch cron invocation in `files/usr/local/pkg/e2guardian.inc` to call `e2guardian.php fetch_blacklist` at minute `20` instead of `0`.
- Updated `files/usr/local/www/e2guardian_logrotate.php` to kill existing watchdog processes before rotating logs, wait up to 30 seconds for the `e2guardian` pid to become active, and only restart the watchdog (via `/bin/sh e2g_watchdog.sh`) if the service is confirmed running and the watchdog is enabled.

### Testing
- Performed PHP syntax checks with `php -l` against the modified PHP files and they reported no syntax errors.
- No integration or runtime tests were executed in this rollout; changes are limited to watchdog orchestration and cron timing and require runtime validation in a staging environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f405a6f318832e91cf1b080fadbaaf)