### PR TITLE
Corrige lookup de CA/cert e dnshaper para RELENG_2_8_1; atualiza para 6.6.14

### DIFF
--- a/www/Kontrol-pkg-E2guardian54/Makefile
+++ b/www/Kontrol-pkg-E2guardian54/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	Kontrol-pkg-E2guardian54
-PORTVERSION=	0.6.6.12
+PORTVERSION=	6.6.14
 PORTREVISION=	# empty
 CATEGORIES=	www
 MASTER_SITES=	# empty

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc
@@ -81,6 +81,21 @@ function e2g_ssl_intercept_is_enabled(array $config): bool
     }
 }
 
+if (!function_exists('e2g_extract_certmanager_item')) {
+    function e2g_extract_certmanager_item($certmanager_result)
+    {
+        if (!is_array($certmanager_result)) {
+            return false;
+        }
+
+        if (array_key_exists('item', $certmanager_result)) {
+            return is_array($certmanager_result['item']) ? $certmanager_result['item'] : false;
+        }
+
+        return $certmanager_result;
+    }
+}
+
 function e2g_normalize_bypass_entries($list_string, $context = 'bypass list')
 {
     $valid_entries = array();
@@ -1163,8 +1178,8 @@ function sync_package_e2guardian($via_rpc = "no", $install_process = false) {
 	}
 
         $enablessl = (e2g_ssl_intercept_is_enabled($e2guardian) ? "on" : "off");
-	$ca_cert = lookup_ca($e2guardian["dca"]);
-	if ($ca_cert != false) {
+	$ca_cert = e2g_extract_certmanager_item(lookup_ca($e2guardian["dca"]));
+	if ($ca_cert !== false) {
 		if (base64_decode($ca_cert['prv'])) {
 			file_put_contents("/etc/ssl/demoCA/private/cakey.pem", base64_decode($ca_cert['prv']));
 			$ca_pk = "caprivatekeypath = '/etc/ssl/demoCA/private/cakey.pem'";
@@ -1183,8 +1198,8 @@ function sync_package_e2guardian($via_rpc = "no", $install_process = false) {
 		}
 		$cert_key = "certprivatekeypath = '{$certprivatekeypath}' ";
 		/*
-		$svr_cert = lookup_cert($e2guardian_config["dcert"]);
-		if ($svr_cert != false) {
+		$svr_cert = e2g_extract_certmanager_item(lookup_cert($e2guardian_config["dcert"]));
+		if ($svr_cert !== false) {
 			if (base64_decode($svr_cert['prv'])) {
 				file_put_contents("/etc/ssl/demoCA/private/serverkey.pem", base64_decode($svr_cert['prv']) . base64_decode($svr_cert['crt']));
 				$cert_key = "certprivatekeypath = '/etc/ssl/demoCA/private/serverkey.pem' ";

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.xml
@@ -149,7 +149,7 @@
 					Do not forget to apply a mask on limiter if you want to define a per user/ip limit. and check Allow Users on Interface option above.<br>
 					<b>NOTE: </b> To match transparent clients too, apply limiters under <b>firewall -> rules</b> that allows access to this firewall(127.0.0.1) under Listen port(s).]]></description>
 			<type>select_source</type>
-			<source><![CDATA[$config['dnshaper']['queue']]]></source>
+			<source><![CDATA[config_get_path('dnshaper/queue', [])]]></source>
 			<source_name>name</source_name>
 			<source_value>number</source_value>
 			<show_disable_value>none</show_disable_value>
@@ -160,7 +160,7 @@
 			<description><![CDATA[Choose the Out queue/Virtual interface only if In is also selected.<br>
 				The Out selection is applied to traffic leaving the interface where the rule is created, the In selection is applied to traffic coming into the chosen interface.]]></description>
 			<type>select_source</type>
-			<source><![CDATA[$config['dnshaper']['queue']]]></source>
+			<source><![CDATA[config_get_path('dnshaper/queue', [])]]></source>
 			<source_name>name</source_name>
 			<source_value>number</source_value>
 			<show_disable_value>none</show_disable_value>
@@ -288,7 +288,7 @@
                                 <button class="btn btn-danger btn-sm" name='clear_cert_cache' id='force_update' type='submit' value='clear_cert_cache'>
                                 <i class="fa fa-trash icon-embed-btn"></i>Clear MITM certificate cache data</button>]]></description>
                         <type>select_source</type>
-                        <source><![CDATA[$config['ca']]]></source>
+                        <source><![CDATA[config_get_path('ca', [])]]></source>
                         <source_name>descr</source_name>
                         <source_value>refid</source_value>
                 </field>


### PR DESCRIPTION
### Motivation
- O port parou de iniciar devido a erros relacionados a certificados MITM e ao campo `dnshaper` no config (PHP: "Cannot access offset of type string on string" e e2guardian exigindo caminhos de CA). 
- Esses erros ocorreram porque o código do port foi copiado de outro branch e o `lookup_ca()`/`lookup_cert()` no RELENG_2_8_1 devolvem um wrapper com `item`, e `dnshaper` pode existir como escalar vazio no config. 
- É necessário alinhar onde o port busca CAs/certs e onde as listas de limiters são lidas para compatibilidade com Kontrol/pfSense 2.8.1.

### Description
- Atualiza a versão do port em `Makefile` para `PORTVERSION=6.6.14` para recompilação. 
- Adiciona a função utilitária `e2g_extract_certmanager_item()` e passa a extrair corretamente o payload retornado por `lookup_ca()`/`lookup_cert()` antes de usar `prv`/`crt`, evitando tentar acessar offsets em strings/estruturas inesperadas. 
- Substitui referências XML de fontes que usavam `$config['dnshaper']['queue']` e `$config['ca']` por `config_get_path('dnshaper/queue', [])` e `config_get_path('ca', [])` para evitar warnings quando `dnshaper`/`ca` não são arrays (compatível com a API `config_get_path` do RELENG_2_8_1). 

### Testing
- Executado `php -l` no arquivo modificado `e2guardian.inc` e não foram detectados erros de sintaxe (OK). 
- Parse XML com `python3`/`xml.etree.ElementTree` para `e2guardian.xml` e `info.xml`, ambos analisados com sucesso (OK). 
- Verificado `git diff --check`/diffstat para garantir diffs limpos; não foram encontrados problemas de checagem automática (OK). 
- Observação: `make -V PKGVERSION` do FreeBSD make não pôde ser executado neste contêiner Linux porque a `make` disponível é GNU make e não aceita `-V`, portanto a validação de `make` específica do FreeBSD não foi possível aqui.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb492d6f10832e955acf476107f428)