### PR TITLE
www/Kontrol-pkg-E2guardian54: reduzir severidade de logs rotineiros

### DIFF
--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc
@@ -33,6 +33,19 @@ $pfs_version = substr(trim(file_get_contents("/etc/version")),0,3);
 require_once("xmlrpc_client.inc");
 
 /*Chamadas array*/
+
+if (!function_exists('e2g_log_info')) {
+    function e2g_log_info($message) {
+        syslog(LOG_INFO, $message);
+    }
+}
+
+if (!function_exists('e2g_log_warning')) {
+    function e2g_log_warning($message) {
+        syslog(LOG_WARNING, $message);
+    }
+}
+
 if (! function_exists("bp_in_array")) {
  function bp_in_array($field, $array) {
     if (is_array($array)) {
@@ -248,7 +261,7 @@ function e2g_copy_sample_if_needed($sample_path, $target_path, array $options = 
     }
 
     @chmod($target_path, 0640);
-    log_error("{$options['log_prefix']} Updated {$target_path} from sample " . basename($sample_path));
+    e2g_log_info("{$options['log_prefix']} Updated {$target_path} from sample " . basename($sample_path));
 
     return true;
 }
@@ -866,7 +879,7 @@ function sync_package_e2guardian($via_rpc = "no", $install_process = false) {
         log_error("[E2guardian] - Aborting config file generation");
 		return;
 	} else {
-		log_error("[E2guardian] - Save settings package call pr:" . is_process_running('e2guardian') . " bp:" . isset($boot_process) . " rpc:" . $via_rpc);
+		e2g_log_info("[E2guardian] - Save settings package call pr:" . is_process_running('e2guardian') . " bp:" . isset($boot_process) . " rpc:" . $via_rpc);
 	}
 
 	// assign xml arrays
@@ -2233,11 +2246,11 @@ EOF;
 
 
 	//log rotation script
-    	log_error("Checking log rotation");
+	e2g_log_info("Checking log rotation");
 	$lrt_file = E2GUARDIAN_WWWDIR . "/e2guardian_logrotate.php";
 	$cron_cmd = E2GUARDIAN_BINDIR . "/php -q {$lrt_file}";
 	if ($logrotate == "on") {
-        log_error("Log rotate on");
+        e2g_log_info("Log rotate on");
 		e2g_check_cron($cron_cmd, "create", $cronminute, $cronhour);
 	} else {
 		file_put_contents($lrt_file, "", LOCK_EX);
@@ -2501,17 +2514,17 @@ function e2guardian_start($via_rpc = "no", $install_process = false, $force_star
 		if (is_process_running('e2guardian')) {
 			switch ($e2g_cfg['applyaction']){
 				case "rc.d":
-					log_error("Restarting e2g with rc.d script");
+					e2g_log_info("Restarting e2g with rc.d script");
 					mwexec("$script stop");
 					sleep(2);
                      			mwexec_bg("$script start");
 					break;
 				case "-r":
-					log_error("Sending USR1 to e2g processes");
+					e2g_log_info("Sending USR1 to e2g processes");
                                         mwexec_bg("$max_threads;" . E2GUARDIAN_SBINDIR . "/e2guardian -g");
 					break;
 				default:
-					log_error("Restarting e2g by sending -Q action to e2g binaries");
+					e2g_log_info("Restarting e2g by sending -Q action to e2g binaries");
                                         mwexec_bg("$max_threads;" . E2GUARDIAN_SBINDIR . "/e2guardian -Q");
 					break;
 			}

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/www/e2guardian_logrotate.php
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/www/e2guardian_logrotate.php
@@ -38,14 +38,14 @@ require_once("service-utils.inc");
 $e2guardian_cfg = $config['installedpackages']['e2guardian']['config'][0];
 $watchdog_cmd = "/usr/local/bin/e2g_watchdog.sh";
 
-log_error("e2guardian - rotating logs.");
-log_error("e2guardian - stopping watchdog processes before rotation.");
+e2g_log_info("e2guardian - rotating logs.");
+e2g_log_info("e2guardian - stopping watchdog processes before rotation.");
 mwexec("/usr/bin/pkill -f {$watchdog_cmd} 2>/dev/null");
 
 //TODO: Make all of this less hardcoded and hacky
 service_control_stop("e2guardian", array());
 
-log_error("e2guardian - stoping");
+e2g_log_info("e2guardian - stopping");
 $e2guardian_log = $config['installedpackages']['e2guardianlog']['config'][0];
 $logfilecount = ($e2guardian_log['logcount'] ? $e2guardian_log['logcount'] : "30");
 $log="/var/log/e2guardian/access.log";
@@ -72,7 +72,7 @@ if (file_exists($log)){
 //$result = system($script);
 //log_error("e2guardian - Rotate command result: " . $result);
 
-log_error("e2guardian - starting");
+e2g_log_info("e2guardian - starting");
 service_control_start("e2guardian", array());
 
 $e2guardian_pid_file = "/var/run/e2guardian.pid";
@@ -92,14 +92,14 @@ for ($i = 0; $i < 30; $i++) {
 $e2guardian_cfg = $config['installedpackages']['e2guardian']['config'][0];
 if ($e2guardian_cfg['watchdog'] == "on") {
 	if ($e2guardian_ready) {
-		log_error("e2guardian - restarting watchdog after rotation.");
+		e2g_log_info("e2guardian - restarting watchdog after rotation.");
 		mwexec_bg("/bin/sh {$watchdog_cmd}");
 	} else {
-		log_error("e2guardian - watchdog restart deferred: e2guardian pid not ready.");
+		e2g_log_warning("e2guardian - watchdog restart deferred: e2guardian pid not ready.");
 	}
 } else {
-	log_error("e2guardian - watchdog remains disabled after rotation.");
+	e2g_log_info("e2guardian - watchdog remains disabled after rotation.");
 }
 
-log_error("e2guardian - log rotation complete.");
+e2g_log_info("e2guardian - log rotation complete.");
 ?>

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/www/e2guardian_scheds.php
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/www/e2guardian_scheds.php
@@ -49,7 +49,7 @@ if (file_exists($file)) {
 
 
 if ($last_scheds !== $e2g_sched_in_use) {
-	log_error("e2guardian - change on schedules, reapplying config.");
+	e2g_log_info("e2guardian - change on schedules, reapplying config.");
 	print "changes on schedule\n";
 	//update acl files
 	sync_package_e2guardian("yes");


### PR DESCRIPTION
### Motivation
- Rotinas do pacote estavam registrando mensagens informativas com `log_error()`, fazendo com que entradas normais de operação aparecessem como erro nos logs; isso causou ruído e confusão no diagnóstico. 
- A intenção é separar eventos verdadeiramente errôneos de mensagens de fluxo normal (save/apply, rotação de logs, reinício, atualização de samples, mudança de schedules). 

### Description
- Adicionadas helpers `e2g_log_info()` e `e2g_log_warning()` que escrevem em syslog com `LOG_INFO` e `LOG_WARNING`. 
- Substituídas chamadas de rotina de `log_error()` por `e2g_log_info()` em mensagens de fluxo normal dentro de `files/usr/local/pkg/e2guardian.inc`. 
- Ajustadas mensagens no script de rotação `files/usr/local/www/e2guardian_logrotate.php` para usar `e2g_log_info()` e alterar o caso “pid not ready” para `e2g_log_warning()`. 
- Ajustada a mensagem de mudança de schedules em `files/usr/local/www/e2guardian_scheds.php` para `e2g_log_info()`, mantendo falhas reais em `log_error()`. 

### Testing
- Executado `php -l` em `www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc` e não foram detectados erros de sintaxe. (sucesso) 
- Executado `php -l` em `www/Kontrol-pkg-E2guardian54/files/usr/local/www/e2guardian_logrotate.php` e não foram detectados erros de sintaxe. (sucesso) 
- Executado `php -l` em `www/Kontrol-pkg-E2guardian54/files/usr/local/www/e2guardian_scheds.php` e não foram detectados erros de sintaxe. (sucesso) 
- Executado verificação de espaçamento/sintaxe (`git diff --check`) e corrigidos problemas de indentação reportados; nenhuma verificação automática falhou. (sucesso)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb51bcc780832ea27115372c172393)