### PR TITLE
Add E2guardian Force Restart action and GUI button

### DIFF
--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc
@@ -2416,6 +2416,81 @@ function e2g_stop_watchdog_processes() {
 	mwexec("/usr/bin/pkill -f {$watchdog_cmd} 2>/dev/null");
 }
 
+function e2guardian_processes_running() {
+	$pattern = '^' . E2GUARDIAN_SBINDIR . '/e2guardian';
+	exec('/usr/bin/pgrep -f ' . escapeshellarg($pattern) . ' >/dev/null 2>&1', $output, $retval);
+
+	return ($retval == 0);
+}
+
+function e2guardian_wait_for_process_state($running, $timeout) {
+	$deadline = time() + $timeout;
+	do {
+		if (e2guardian_processes_running() == $running) {
+			return true;
+		}
+		sleep(1);
+	} while (time() < $deadline);
+
+	return (e2guardian_processes_running() == $running);
+}
+
+function e2guardian_force_restart() {
+	// Force Restart is an operational recovery path when reload/rc restart leaves stuck workers behind.
+	$script = E2GUARDIAN_RCDIR . '/e2guardian.sh';
+	$pidfile = '/var/run/e2guardian.pid';
+	$process_pattern = '^' . E2GUARDIAN_SBINDIR . '/e2guardian';
+	$stop_timeout = 15;
+	$start_timeout = 5;
+
+	log_error('[E2guardian] Force restart requested from GUI');
+	log_error('[E2guardian] Stopping watchdog before force restart');
+	e2g_stop_watchdog_processes();
+
+	if (file_exists($script)) {
+		log_error('[E2guardian] Stopping e2guardian via rc.d script before force restart');
+		mwexec($script . ' stop');
+	} else {
+		log_error('[E2guardian] rc.d script not found, using direct signals for force restart stop');
+	}
+
+	if (e2guardian_processes_running()) {
+		log_error('[E2guardian] Sending TERM to e2guardian processes');
+		mwexec('/usr/bin/pkill -TERM -f ' . escapeshellarg($process_pattern) . ' 2>/dev/null');
+	}
+
+	if (!e2guardian_wait_for_process_state(false, $stop_timeout)) {
+		log_error('[E2guardian] Sending KILL to remaining e2guardian processes');
+		mwexec('/usr/bin/pkill -KILL -f ' . escapeshellarg($process_pattern) . ' 2>/dev/null');
+		sleep(2);
+	}
+
+	if (e2guardian_processes_running()) {
+		log_error('[E2guardian] e2guardian processes still exist after KILL during force restart');
+	}
+
+	if (file_exists($pidfile)) {
+		log_error('[E2guardian] Removing stale pidfile before force restart start');
+		unlink_if_exists($pidfile);
+	}
+
+	if (!file_exists($script)) {
+		log_error('[E2guardian] Cannot start e2guardian after force restart because rc.d script is missing');
+		return gettext('Force Restart failed: E2guardian rc.d script was not found. Apply the package configuration and try again.');
+	}
+
+	log_error('[E2guardian] Starting e2guardian after force restart');
+	mwexec_bg($script . ' start');
+
+	if (e2guardian_wait_for_process_state(true, $start_timeout)) {
+		log_error('[E2guardian] Force restart completed and e2guardian is running');
+		return gettext('Force Restart completed. E2guardian was stopped forcefully and started again.');
+	}
+
+	log_error('[E2guardian] e2guardian did not return after force restart start command');
+	return gettext('Force Restart executed, but E2guardian does not appear to be running. Check the E2guardian logs.');
+}
+
 function e2guardian_check_config() {
 	global $savemsg, $config;
 

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.xml
@@ -426,6 +426,9 @@
 		</field>
 	</fields>
 	<custom_php_command_before_form>
+		if (isset($_POST['e2g_force_restart']) and $_POST['e2g_force_restart'] == 'yes') {
+			$savemsg = e2guardian_force_restart();
+		}
 		e2guardian_check_config();
 	</custom_php_command_before_form>
 	<custom_php_install_command>
@@ -444,6 +447,54 @@
 	</custom_php_resync_config_command>
 	<custom_php_command_after_form>
 		e2guardian_check_dirty();
+		$e2g_force_restart_label = json_encode(gettext('Force Restart'));
+		$e2g_force_restart_title = json_encode(gettext('Forcefully stop all E2guardian processes and start the service again. Use when normal restart/reload does not recover the proxy.'));
+		$e2g_force_restart_confirm = json_encode(gettext('Force Restart will terminate active E2guardian connections, stop all E2guardian processes, remove the pidfile, and start the service again. Continue?'));
+		echo &lt;&lt;&lt;EOD
+&lt;script type=&quot;text/javascript&quot;&gt;
+//&lt;![CDATA[
+var addE2guardianForceRestartButton = function() {
+	var form = document.querySelector('form');
+	if (!form || document.getElementById('e2g-force-restart-button')) {
+		return;
+	}
+
+	var button = document.createElement('button');
+	button.type = 'button';
+	button.id = 'e2g-force-restart-button';
+	button.className = 'btn btn-warning btn-sm';
+	button.title = {$e2g_force_restart_title};
+	button.textContent = {$e2g_force_restart_label};
+	button.onclick = function() {
+		if (!confirm({$e2g_force_restart_confirm})) {
+			return;
+		}
+
+		var action = document.createElement('input');
+		action.type = 'hidden';
+		action.name = 'e2g_force_restart';
+		action.value = 'yes';
+		form.appendChild(action);
+		form.submit();
+	};
+
+	var target = document.querySelector('.panel-heading .pull-right, .page-heading .pull-right, .content-box-header .pull-right');
+	if (target) {
+		target.insertBefore(button, target.firstChild);
+		target.insertBefore(document.createTextNode(' '), button.nextSibling);
+	} else {
+		form.parentNode.insertBefore(button, form);
+	}
+};
+
+if (typeof events !== 'undefined') {
+	events.push(addE2guardianForceRestartButton);
+} else {
+	document.addEventListener('DOMContentLoaded', addE2guardianForceRestartButton);
+}
+//]]&gt;
+&lt;/script&gt;
+EOD;
 	</custom_php_command_after_form>
 	<filter_rules_needed>e2g_generate_rules</filter_rules_needed>
 </packagegui>


### PR DESCRIPTION
### Motivation
- Provide an explicit operational recovery action on the E2guardian Daemon page to forcefully stop stuck E2guardian worker processes and start the service again when gentle reloads (USR1) or normal restarts do not recover the proxy.
- Ensure the new action is separate from the existing "Apply action" semantics and preserves existing behavior while stopping the watchdog and cleaning stale pidfiles to avoid misleading status.

### Description
- Added helper functions in `e2guardian.inc`: `e2guardian_processes_running()`, `e2guardian_wait_for_process_state()`, and the new `e2guardian_force_restart()` implementing: stop watchdog, attempt rc.d stop, send `TERM` then `KILL` to remaining `/usr/local/sbin/e2guardian` processes (via `pgrep`/`pkill`), remove `/var/run/e2guardian.pid`, start via `e2guardian.sh start`, and log clear messages using `log_error()` at each step.
- Wired the Daemon page (`e2guardian.xml`) to accept a POST flag and call `e2guardian_force_restart()` through the existing page form/CSRF flow; added a localized button injected by JavaScript with label, tooltip and confirmation prompt before submitting the POST.
- Kept the existing `Apply action` behavior unchanged and intentionally did not alter `e2parent.sh` lifecycle to avoid surprising changes to parent/local squid handling; added short comment in the code explaining Force Restart is an operational recovery path.
- Followed package conventions: used defined constants (`E2GUARDIAN_RCDIR`, `E2GUARDIAN_SBINDIR`), `log_error()`, `mwexec()`/`mwexec_bg()`, `gettext()`/`json_encode(gettext())`, and avoided shell interpolation by using `escapeshellarg()` where appropriate.

### Testing
- Ran `git diff --check` with no warnings (success).
- Ran `php -l www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc` with no syntax errors (success).
- Validated `www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.xml` parses as XML using Python's `xml.etree.ElementTree` (success: "XML parse OK").

Files changed: `www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc`, `www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.xml`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe0dc1b64c832eaf62d144d92393f1)