### PR TITLE
Add Force Restart action to E2guardian GUI and implement forced-restart logic

### DIFF
--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc
@@ -2416,6 +2416,81 @@ function e2g_stop_watchdog_processes() {
 	mwexec("/usr/bin/pkill -f {$watchdog_cmd} 2>/dev/null");
 }
 
+function e2guardian_processes_running() {
+	$pattern = '^' . E2GUARDIAN_SBINDIR . '/e2guardian';
+	exec('/usr/bin/pgrep -f ' . escapeshellarg($pattern) . ' >/dev/null 2>&1', $output, $retval);
+
+	return ($retval == 0);
+}
+
+function e2guardian_wait_for_process_state($running, $timeout) {
+	$deadline = time() + $timeout;
+	do {
+		if (e2guardian_processes_running() == $running) {
+			return true;
+		}
+		sleep(1);
+	} while (time() < $deadline);
+
+	return (e2guardian_processes_running() == $running);
+}
+
+function e2guardian_force_restart() {
+	// Force Restart is an operational recovery path when reload/rc restart leaves stuck workers behind.
+	$script = E2GUARDIAN_RCDIR . '/e2guardian.sh';
+	$pidfile = '/var/run/e2guardian.pid';
+	$process_pattern = '^' . E2GUARDIAN_SBINDIR . '/e2guardian';
+	$stop_timeout = 15;
+	$start_timeout = 5;
+
+	log_error('[E2guardian] Force restart requested from GUI');
+	log_error('[E2guardian] Stopping watchdog before force restart');
+	e2g_stop_watchdog_processes();
+
+	if (file_exists($script)) {
+		log_error('[E2guardian] Stopping e2guardian via rc.d script before force restart');
+		mwexec($script . ' stop');
+	} else {
+		log_error('[E2guardian] rc.d script not found, using direct signals for force restart stop');
+	}
+
+	if (e2guardian_processes_running()) {
+		log_error('[E2guardian] Sending TERM to e2guardian processes');
+		mwexec('/usr/bin/pkill -TERM -f ' . escapeshellarg($process_pattern) . ' 2>/dev/null');
+	}
+
+	if (!e2guardian_wait_for_process_state(false, $stop_timeout)) {
+		log_error('[E2guardian] Sending KILL to remaining e2guardian processes');
+		mwexec('/usr/bin/pkill -KILL -f ' . escapeshellarg($process_pattern) . ' 2>/dev/null');
+		sleep(2);
+	}
+
+	if (e2guardian_processes_running()) {
+		log_error('[E2guardian] e2guardian processes still exist after KILL during force restart');
+	}
+
+	if (file_exists($pidfile)) {
+		log_error('[E2guardian] Removing stale pidfile before force restart start');
+		unlink_if_exists($pidfile);
+	}
+
+	if (!file_exists($script)) {
+		log_error('[E2guardian] Cannot start e2guardian after force restart because rc.d script is missing');
+		return gettext('Force Restart failed: E2guardian rc.d script was not found. Apply the package configuration and try again.');
+	}
+
+	log_error('[E2guardian] Starting e2guardian after force restart');
+	mwexec_bg($script . ' start');
+
+	if (e2guardian_wait_for_process_state(true, $start_timeout)) {
+		log_error('[E2guardian] Force restart completed and e2guardian is running');
+		return gettext('Force Restart completed. E2guardian was stopped forcefully and started again.');
+	}
+
+	log_error('[E2guardian] e2guardian did not return after force restart start command');
+	return gettext('Force Restart executed, but E2guardian does not appear to be running. Check the E2guardian logs.');
+}
+
 function e2guardian_check_config() {
 	global $savemsg, $config;
 

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.xml
@@ -113,6 +113,17 @@
 			<description><![CDATA[Enable or disable E2guardian service.]]></description>
 		</field>
 		<field>
+			<fielddescr>Force Restart</fielddescr>
+			<fieldname>e2g_force_restart_action</fieldname>
+			<type>info</type>
+			<description><![CDATA[
+				<button type="submit" name="e2g_force_restart" value="yes" class="btn btn-warning" title="Forcefully stop all E2guardian processes and start the service again. Use when normal restart/reload does not recover the proxy." onclick="return confirm('Force Restart will terminate active E2guardian connections, stop all E2guardian processes, remove the pidfile, and start the service again. Continue?');">
+					<i class="fa fa-exclamation-triangle icon-embed-btn"></i>Force Restart
+				</button>
+				<p class="help-block">Forcefully stop all E2guardian processes and start the service again. Use when normal restart/reload does not recover the proxy.</p>
+			]]></description>
+		</field>
+		<field>
 			<fielddescr>Listen Interface(s)</fielddescr>
 			<fieldname>interface</fieldname>
 			<description><![CDATA[Default: <strong>LAN</strong><br>Select interface(s) that you want to e2guardian to listen on.<br>
@@ -426,6 +437,9 @@
 		</field>
 	</fields>
 	<custom_php_command_before_form>
+		if (isset($_POST['e2g_force_restart']) and $_POST['e2g_force_restart'] == 'yes') {
+			$savemsg = e2guardian_force_restart();
+		}
 		e2guardian_check_config();
 	</custom_php_command_before_form>
 	<custom_php_install_command>


### PR DESCRIPTION
### Motivation
- Provide an operational recovery path when normal restart/reload leaves e2guardian worker processes stuck.  
- Expose a GUI control to forcefully stop all e2guardian processes, remove stale pidfile, and start the service again.  

### Description
- Implemented `e2guardian_processes_running()`, `e2guardian_wait_for_process_state()` and `e2guardian_force_restart()` in `e2guardian.inc` to detect processes, wait for state transitions, stop the watchdog, send `TERM`/`KILL` via `pkill`, remove stale pidfile, and restart via the rc.d script.  
- Added a `Force Restart` info field and a submit button (`name="e2g_force_restart" value="yes"`) in `e2guardian.xml` to trigger the operation from the package GUI.  
- Wired the GUI action by invoking `e2guardian_force_restart()` from `custom_php_command_before_form` when the POST flag is present and surface user messages via `$savemsg`.  
- Added logging calls and timeout handling for stop/start phases and clear handling when the rc.d script is missing.  

### Testing
- Ran PHP syntax checks (`php -l`) on the modified files and they passed.  
- Verified the modified `e2guardian.xml` is well-formed and the new GUI field is injected into the form definition.  
- No additional automated runtime integration tests were added for process lifecycle; manual verification is recommended in a controlled environment before production use.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe0dc1b64c832eaf62d144d92393f1)