### PR TITLE
Adicionar botão 'Force Restart' e implementar restart forçado (kill -KILL)

### DIFF
--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc
@@ -2416,11 +2416,52 @@ function e2g_stop_watchdog_processes() {
 	mwexec("/usr/bin/pkill -f {$watchdog_cmd} 2>/dev/null");
 }
 
-function e2guardian_processes_running() {
-	$pattern = '^' . E2GUARDIAN_SBINDIR . '/e2guardian';
-	exec('/usr/bin/pgrep -f ' . escapeshellarg($pattern) . ' >/dev/null 2>&1', $output, $retval);
+function e2guardian_pid_is_e2guardian($pid) {
+	if (!is_numeric($pid) || ((int)$pid <= 0)) {
+		return false;
+	}
 
-	return ($retval == 0);
+	$command = array();
+	exec('/bin/ps -p ' . escapeshellarg((string)((int)$pid)) . ' -o args= 2>/dev/null', $command, $retval);
+	if ($retval != 0 || empty($command)) {
+		return false;
+	}
+
+	$command = trim(implode(' ', $command));
+	return (strpos($command, E2GUARDIAN_SBINDIR . '/e2guardian') === 0 || preg_match('/(^|[[:space:]])e2guardian([[:space:]]|$)/', $command));
+}
+
+function e2guardian_running_pids() {
+	$pids = array();
+	$pidfile = '/var/run/e2guardian.pid';
+
+	if (file_exists($pidfile)) {
+		$pid = trim(@file_get_contents($pidfile));
+		if (e2guardian_pid_is_e2guardian($pid)) {
+			$pids[] = (int)$pid;
+		}
+	}
+
+	$process_pattern = '^' . E2GUARDIAN_SBINDIR . '/e2guardian([[:space:]]|$)';
+	exec('/usr/bin/pgrep -f ' . escapeshellarg($process_pattern) . ' 2>/dev/null', $pgrep_pids);
+	exec('/usr/bin/pgrep -x e2guardian 2>/dev/null', $name_pids);
+
+	foreach (array_merge($pgrep_pids, $name_pids) as $pid) {
+		$pid = trim($pid);
+		if (is_numeric($pid)) {
+			$pids[] = (int)$pid;
+		}
+	}
+
+	$pids = array_values(array_unique(array_filter($pids, function($pid) {
+		return ($pid > 0);
+	})));
+
+	return $pids;
+}
+
+function e2guardian_processes_running() {
+	return (count(e2guardian_running_pids()) > 0);
 }
 
 function e2guardian_wait_for_process_state($running, $timeout) {
@@ -2439,34 +2480,35 @@ function e2guardian_force_restart() {
 	// Force Restart is an operational recovery path when reload/rc restart leaves stuck workers behind.
 	$script = E2GUARDIAN_RCDIR . '/e2guardian.sh';
 	$pidfile = '/var/run/e2guardian.pid';
-	$process_pattern = '^' . E2GUARDIAN_SBINDIR . '/e2guardian';
-	$stop_timeout = 15;
+	$stop_timeout = 5;
 	$start_timeout = 5;
 
 	log_error('[E2guardian] Force restart requested from GUI');
 	log_error('[E2guardian] Stopping watchdog before force restart');
 	e2g_stop_watchdog_processes();
 
-	if (file_exists($script)) {
-		log_error('[E2guardian] Stopping e2guardian via rc.d script before force restart');
-		mwexec($script . ' stop');
+	$pids = e2guardian_running_pids();
+	if (count($pids) > 0) {
+		$pid_list = implode(' ', $pids);
+		log_error('[E2guardian] Force killing e2guardian PID(s): ' . $pid_list);
+		mwexec('/bin/kill -KILL ' . $pid_list . ' 2>/dev/null');
 	} else {
-		log_error('[E2guardian] rc.d script not found, using direct signals for force restart stop');
-	}
-
-	if (e2guardian_processes_running()) {
-		log_error('[E2guardian] Sending TERM to e2guardian processes');
-		mwexec('/usr/bin/pkill -TERM -f ' . escapeshellarg($process_pattern) . ' 2>/dev/null');
+		log_error('[E2guardian] No running e2guardian PID found before force restart');
 	}
 
 	if (!e2guardian_wait_for_process_state(false, $stop_timeout)) {
-		log_error('[E2guardian] Sending KILL to remaining e2guardian processes');
-		mwexec('/usr/bin/pkill -KILL -f ' . escapeshellarg($process_pattern) . ' 2>/dev/null');
-		sleep(2);
+		$pids = e2guardian_running_pids();
+		if (count($pids) > 0) {
+			$pid_list = implode(' ', $pids);
+			log_error('[E2guardian] Retrying KILL for remaining e2guardian PID(s): ' . $pid_list);
+			mwexec('/bin/kill -KILL ' . $pid_list . ' 2>/dev/null');
+			sleep(1);
+		}
 	}
 
 	if (e2guardian_processes_running()) {
 		log_error('[E2guardian] e2guardian processes still exist after KILL during force restart');
+		return gettext('Force Restart failed: E2guardian process(es) still exist after kill -KILL. Check the E2guardian logs.');
 	}
 
 	if (file_exists($pidfile)) {
@@ -2484,7 +2526,7 @@ function e2guardian_force_restart() {
 
 	if (e2guardian_wait_for_process_state(true, $start_timeout)) {
 		log_error('[E2guardian] Force restart completed and e2guardian is running');
-		return gettext('Force Restart completed. E2guardian was stopped forcefully and started again.');
+		return gettext('Force Restart completed. E2guardian PID(s) were killed forcefully and the service was started again.');
 	}
 
 	log_error('[E2guardian] e2guardian did not return after force restart start command');


### PR DESCRIPTION
### Motivation
- Melhorar a recuperação operacional quando o E2guardian fica travado e não responde a `rc.d stop`, `-Q`, `reload` ou reinício normal. 
- Evitar matar PIDs inválidos lidos de `pidfile` ao validar explicitamente se um PID pertence ao processo `e2guardian` antes de aplicar `kill -KILL`.

### Description
- Alterado o menu Daemon em `www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.xml` para adicionar um campo `Force Restart` (`fieldname`=`e2g_force_restart_action`, `type`=`info`) com um botão `submit` com `name="e2g_force_restart"`, `value="yes"`, `class="btn btn-warning"`, ícone `fa fa-exclamation-triangle icon-embed-btn`, `title`/tooltip e `onclick` com confirmação, e uma `help-block` explicativa. 
- Tratamento do POST adicionado em `<custom_php_command_before_form>` para chamar `e2guardian_force_restart()` quando `$_POST['e2g_force_restart'] == 'yes'` antes de `e2guardian_check_config()` em `e2guardian.xml`.
- Em `www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc` foram adicionadas as funções auxiliares `e2guardian_pid_is_e2guardian($pid)` e `e2guardian_running_pids()` e `e2guardian_processes_running()` foi ajustada para usar a lista real de PIDs; a função `e2guardian_wait_for_process_state($running, $timeout)` foi mantida/confirmada para aguardar estados com `sleep(1)`.
- Substituída a lógica de `e2guardian_force_restart()` para: parar o watchdog com `e2g_stop_watchdog_processes()`, localizar PIDs validados via `e2guardian_running_pids()`, executar `/bin/kill -KILL <pid1> <pid2> ...` (com log dos PIDs), aguardar até `stop_timeout` e re-tentar KILL se necessário, abortar o start se processos persistirem, remover `'/var/run/e2guardian.pid'` obsoleto, validar existência do script rc.d e iniciar com `mwexec_bg($script . ' start')`, e aguardar `start_timeout` para confirmação de retorno.
- Mantidos logs com prefixo `[E2guardian]` e cuidados para não iniciar o serviço se PIDs ainda existirem.

### Testing
- Executado `php -l www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc` e não houve erros de sintaxe. (sucesso)
- Executado `git diff --check` e não foram relatados warnings/errores no diff. (sucesso)
- As alterações foram commitadas com a mensagem `Force kill e2guardian on GUI restart` e o arquivo modificado foi `www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc` e `www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.xml`. (commit criado)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff8a8da884832e884a35bbfe2a4f95)