### PR TITLE
www: add Kontrol-pkg-pppoeHA port from upstream pfSense package

### DIFF
--- a/www/Kontrol-pkg-pppoeHA/Makefile
+++ b/www/Kontrol-pkg-pppoeHA/Makefile
@@ -1,0 +1,48 @@
+# $FreeBSD$
+
+PORTNAME=	Kontrol-pkg-pppoeHA
+PORTVERSION=	0.1.2
+CATEGORIES=	www
+MASTER_SITES=	# empty
+DISTFILES=	# empty
+EXTRACT_ONLY=	# empty
+
+MAINTAINER=	contato@kontrol.com.br
+COMMENT=	Kontrol PPPoE high availability package for CARP-based failover
+LICENSE=	APACHE20
+
+NO_BUILD=	yes
+NO_MTREE=	yes
+
+SUB_FILES=	pkg-install pkg-deinstall
+SUB_LIST=	PORTNAME=${PORTNAME}
+
+do-extract:
+	${MKDIR} ${WRKSRC}
+
+do-install:
+	${MKDIR} ${STAGEDIR}${PREFIX}/pkg
+	${MKDIR} ${STAGEDIR}${PREFIX}/sbin
+	${MKDIR} ${STAGEDIR}${PREFIX}/etc/rc.d
+	${MKDIR} ${STAGEDIR}${PREFIX}/etc/devd
+	${MKDIR} ${STAGEDIR}${PREFIX}/share/Kontrol-pkg-pppoeHA
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/pppoe_ha.xml \
+		${STAGEDIR}${PREFIX}/pkg
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/pppoe_ha.inc \
+		${STAGEDIR}${PREFIX}/pkg
+	${INSTALL_SCRIPT} ${FILESDIR}${PREFIX}/sbin/pppoe_ha_event \
+		${STAGEDIR}${PREFIX}/sbin
+	${INSTALL_SCRIPT} ${FILESDIR}${PREFIX}/sbin/pppoe_ha_event.php \
+		${STAGEDIR}${PREFIX}/sbin
+	${INSTALL_SCRIPT} ${FILESDIR}${PREFIX}/etc/rc.d/pppoe_ha \
+		${STAGEDIR}${PREFIX}/etc/rc.d
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/etc/devd/pppoe_ha.conf \
+		${STAGEDIR}${PREFIX}/etc/devd
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/share/Kontrol-pkg-pppoeHA/info.xml \
+		${STAGEDIR}${PREFIX}/share/Kontrol-pkg-pppoeHA
+	@${REINPLACE_CMD} -i '' -e "s|%%PKGVERSION%%|${PKGVERSION}|" \
+		${STAGEDIR}${PREFIX}/pkg/pppoe_ha.xml
+	@${REINPLACE_CMD} -i '' -e "s|%%PKGVERSION%%|${PKGVERSION}|" \
+		${STAGEDIR}${PREFIX}/share/Kontrol-pkg-pppoeHA/info.xml
+
+.include <bsd.port.mk>

--- a/www/Kontrol-pkg-pppoeHA/files/pkg-deinstall.in
+++ b/www/Kontrol-pkg-pppoeHA/files/pkg-deinstall.in
@@ -1,0 +1,35 @@
+#!/bin/sh
+set -e
+
+PHP_BIN="%%PREFIX%%/bin/php"; [ -x "$PHP_BIN" ] || PHP_BIN="%%PREFIX%%/sbin/php"
+
+"$PHP_BIN" -r '
+  require_once("config.inc");
+  require_once("util.inc");
+  global $config;
+
+  $config = parse_config(true);
+  $menus = config_get_path("installedpackages/menu", []);
+  if (!is_array($menus)) { $menus = []; }
+
+  $targetUrl = "/pkg_edit.php?xml=pppoe_ha.xml&id=0";
+  $filtered = [];
+  $changed = false;
+  foreach ($menus as $m) {
+    if (is_array($m) && ($m["url"] ?? "") === $targetUrl) {
+      $changed = true;
+      continue;
+    }
+    $filtered[] = $m;
+  }
+
+  if ($changed) {
+    config_set_path("installedpackages/menu", $filtered);
+    write_config("Remove PPPoE HA menu");
+  }
+' >/dev/null 2>&1 || true
+
+service devd reload >/dev/null 2>&1 || true
+rm -f /tmp/*menu* /tmp/.menu* >/dev/null 2>&1 || true
+
+exit 0

--- a/www/Kontrol-pkg-pppoeHA/files/pkg-install.in
+++ b/www/Kontrol-pkg-pppoeHA/files/pkg-install.in
@@ -1,0 +1,46 @@
+#!/bin/sh
+set -e
+
+PKGNAME="%%PORTNAME%%"
+PHP_BIN="${PKG_ROOTDIR}%%PREFIX%%/bin/php"; [ -x "$PHP_BIN" ] || PHP_BIN="%%PREFIX%%/bin/php"
+RC_PACKAGES="${PKG_ROOTDIR}/etc/rc.packages"; [ -x "$RC_PACKAGES" ] || RC_PACKAGES="/etc/rc.packages"
+
+if [ -x "$PHP_BIN" ] && [ -f "$RC_PACKAGES" ]; then
+  "$PHP_BIN" -f "$RC_PACKAGES" "$PKGNAME" POST-INSTALL >/dev/null 2>&1 || true
+fi
+
+"$PHP_BIN" -r '
+  require_once("config.inc");
+  require_once("util.inc");
+  global $config;
+
+  $config = parse_config(true);
+  $menus = config_get_path("installedpackages/menu", []);
+  if (!is_array($menus)) { $menus = []; }
+
+  $targetUrl = "/pkg_edit.php?xml=pppoe_ha.xml&id=0";
+  $exists = false;
+  foreach ($menus as $m) {
+    if (is_array($m) && ($m["url"] ?? "") === $targetUrl) { $exists = true; break; }
+  }
+
+  if (!$exists) {
+    $menus[] = [
+      "name"        => "PPPoE High Availability",
+      "tooltiptext" => "Enable/disable PPPoE by CARP state",
+      "section"     => "Services",
+      "url"         => $targetUrl,
+    ];
+    config_set_path("installedpackages/menu", $menus);
+    write_config("Add PPPoE HA menu");
+  }
+' >/dev/null 2>&1 || true
+
+rm -f /tmp/*menu* /tmp/.menu* >/dev/null 2>&1 || true
+service devd restart >/dev/null 2>&1 || true
+
+if [ -x %%PREFIX%%/sbin/pppoe_ha_event ]; then
+    %%PREFIX%%/sbin/pppoe_ha_event reconcile >/dev/null 2>&1 || true
+fi
+
+exit 0

--- a/www/Kontrol-pkg-pppoeHA/files/usr/local/etc/devd/pppoe_ha.conf
+++ b/www/Kontrol-pkg-pppoeHA/files/usr/local/etc/devd/pppoe_ha.conf
@@ -1,0 +1,17 @@
+# PPPoE HA CARP hook (Kontrol-pkg-pppoeHA)
+# devd runs ONLY the highest numeric priority match; 200 > 100, so this wins.
+notify 200 {
+    match "system" "CARP";
+    match "type"   "MASTER";
+    action "/usr/local/sbin/pfSctl -c 'interface carpmaster '$subsystem; /usr/local/sbin/pppoe_ha_event carp $subsystem $type";
+};
+notify 200 {
+    match "system" "CARP";
+    match "type"   "BACKUP";
+    action "/usr/local/sbin/pfSctl -c 'interface carpbackup '$subsystem; /usr/local/sbin/pppoe_ha_event carp $subsystem $type";
+};
+notify 200 {
+    match "system" "CARP";
+    match "type"   "INIT";
+    action "/usr/local/sbin/pfSctl -c 'interface carpbackup '$subsystem; /usr/local/sbin/pppoe_ha_event carp $subsystem $type";
+};

--- a/www/Kontrol-pkg-pppoeHA/files/usr/local/etc/rc.d/pppoe_ha
+++ b/www/Kontrol-pkg-pppoeHA/files/usr/local/etc/rc.d/pppoe_ha
@@ -1,0 +1,28 @@
+#!/bin/sh
+# PROVIDE: pppoe_ha
+# REQUIRE: DAEMON
+# KEYWORD: nojail
+
+. /etc/rc.subr
+
+name="pppoe_ha"
+rcvar="${name}_enable"
+
+load_rc_config $name
+
+: ${pppoe_ha_enable:=YES}
+
+start_cmd="${name}_start"
+stop_cmd=":"
+
+pppoe_ha_start()
+{
+    # (Re)load devd rule (in case devd doesn't auto-pick /usr/local/etc/devd/*.conf)
+    if service devd rcvar >/dev/null 2>&1; then
+        service devd reload >/dev/null 2>&1
+    fi
+    # Reconcile PPPoE iface states with current CARP state
+    /usr/local/sbin/pppoe_ha_event reconcile >/dev/null 2>&1
+}
+
+run_rc_command "$1"

--- a/www/Kontrol-pkg-pppoeHA/files/usr/local/pkg/pppoe_ha.inc
+++ b/www/Kontrol-pkg-pppoeHA/files/usr/local/pkg/pppoe_ha.inc
@@ -1,0 +1,185 @@
+<?php
+require_once("util.inc");
+require_once("config.inc");
+require_once("interfaces.inc");
+
+/* --------------------------------------------------------------------
+ * Config base path handling
+ * ------------------------------------------------------------------*/
+
+/**
+ * Return the canonical base path for our package config, creating the
+ * chosen node if none exist yet.
+ *
+ * We prefer an existing node among:
+ *   installedpackages/pppoe_ha/config/0
+ *   installedpackages/pppoeha/config/0
+ *   installedpackages/pppoe-ha/config/0
+ *
+ * If none exist, we adopt: installedpackages/pppoeha/config/0
+ */
+function ppha_cfg_basepath() {
+    static $base = null;
+    if ($base !== null) {
+        return $base;
+    }
+    $candidates = [
+        'installedpackages/pppoe_ha/config/0',
+        'installedpackages/pppoeha/config/0',   // <- this matches your current system
+        'installedpackages/pppoe-ha/config/0',
+    ];
+    foreach ($candidates as $p) {
+        $node = config_get_path($p, null);
+        if (is_array($node)) {
+            $base = $p;
+            return $base;
+        }
+    }
+    // None exist yet: adopt the no-underscore form as canonical
+    $base = 'installedpackages/pppoeha/config/0';
+    // Ensure parent nodes exist so later set_path doesn’t fail
+    $cur = config_get_path($base, null);
+    if (!is_array($cur)) {
+        config_set_path($base, []);
+        write_config('PPPoE HA: initialize config node');
+    }
+    return $base;
+}
+
+/** Read all mapping rows (returns [] if none). */
+function ppha_get_rows() {
+    $rows = config_get_path(ppha_cfg_basepath() . '/row', []);
+    return is_array($rows) ? $rows : [];
+}
+
+/** Write mapping rows (array of rows). */
+function ppha_set_rows(array $rows) {
+    config_set_path(ppha_cfg_basepath() . '/row', $rows);
+}
+
+/* --------------------------------------------------------------------
+ * GUI dynamic option builders
+ * ------------------------------------------------------------------*/
+
+/* Build CARP VIP options for rowhelper: ['name'=>..,'value'=>..] */
+function ppha_build_carp_option_nodes() {
+    $list = [];
+    $vips = config_get_path('virtualip/vip', []);
+    if (is_array($vips)) {
+        foreach ($vips as $idx => $vip) {
+            if (($vip['mode'] ?? '') !== 'carp') {
+                continue;
+            }
+            $vhid    = $vip['vhid'] ?? '?';
+            $subnet  = $vip['subnet'] ?? '';
+            $iface   = $vip['interface'] ?? '';
+            $ifdescr = convert_real_interface_to_friendly_descr($iface) ?: $iface;
+            $label   = sprintf('VHID %s @ %s (%s)', $vhid, $subnet, $ifdescr);
+            $list[]  = ['name' => $label, 'value' => (string)$idx];
+        }
+    }
+    if (!$list) {
+        $list[] = ['name' => '-- no CARP VIPs found --', 'value' => ''];
+    }
+    return $list;
+}
+
+/* Build assigned interface options (filter to PPPoE if you like) */
+function ppha_build_iface_option_nodes($pppoe_only = true) {
+    $list = [];
+    $friendly = get_configured_interface_with_descr(); // e.g. ['wan'=>'WAN', 'opt1'=>'Foo']
+    foreach ($friendly as $fname => $descr) {
+        $ifcfg = config_get_path("interfaces/{$fname}", []);
+        $real  = get_real_interface($fname);
+        $suffix = $real ? " ($real)" : "";
+
+        $is_pppoe = false;
+        if (!empty($ifcfg)) {
+            if (!empty($ifcfg['if']) && preg_match('/^pppoe\d+$/', $ifcfg['if'])) {
+                $is_pppoe = true;
+            } elseif (($ifcfg['ipaddr'] ?? '') === 'pppoe') {
+                $is_pppoe = true;
+            }
+        }
+        if (!$is_pppoe && $real && preg_match('/^pppoe\d+$/', $real)) {
+            $is_pppoe = true;
+        }
+
+        if ($pppoe_only && !$is_pppoe) {
+            continue;
+        }
+
+        $list[] = ['name' => $descr . $suffix, 'value' => $fname];
+    }
+    if (!$list) {
+        $list[] = ['name' => $pppoe_only ? '-- no PPPoE interfaces found --' : '-- no interfaces found --', 'value' => ''];
+    }
+    return $list;
+}
+
+/* Inject options for both selects inside the rowhelper */
+function ppha_before_form_pppoe_ha(&$pkg) {
+    if (empty($pkg['fields']['field'])) {
+        return;
+    }
+    if (!empty($_REQUEST['ppha_reconcile'])) {
+        ppha_run_reconcile_now();
+    }
+    // normalize singletons
+    if (isset($pkg['fields']['field']['type'])) {
+        $pkg['fields']['field'] = [ $pkg['fields']['field'] ];
+    }
+
+    $vip_opts   = ppha_build_carp_option_nodes();
+    $iface_opts = ppha_build_iface_option_nodes(true);
+
+    foreach ($pkg['fields']['field'] as &$field) {
+        if (($field['type'] ?? '') !== 'rowhelper') {
+            continue;
+        }
+        if (empty($field['rowhelper']['rowhelperfield'])) {
+            continue;
+        }
+        if (isset($field['rowhelper']['rowhelperfield']['type'])) {
+            $field['rowhelper']['rowhelperfield'] = [ $field['rowhelper']['rowhelperfield'] ];
+        }
+
+        foreach ($field['rowhelper']['rowhelperfield'] as &$rhf) {
+            // CARP VIP select
+            if (($rhf['fieldname'] ?? '') === 'vipref' && ($rhf['type'] ?? '') === 'select') {
+                $rhf['options'] = ['option' => $vip_opts];
+            }
+            // PPPoE iface select (fieldname 'iface')
+            if (($rhf['fieldname'] ?? '') === 'iface' && ($rhf['type'] ?? '') === 'select') {
+                $rhf['options'] = ['option' => $iface_opts];
+            }
+        }
+        unset($rhf);
+    }
+    unset($field);
+}
+
+/** Run a one-shot reconcile and surface a GUI message */
+function ppha_run_reconcile_now() {
+    $rc = 0;
+    // Fire and forget; logs will appear under tag 'pppoe-ha'
+    mwexec('/usr/local/sbin/pppoe_ha_event reconcile', $rc);
+    // Tell the GUI something happened
+    $msg = $rc === 0
+        ? 'PPPoE HA: Reconcile executed. See Status → System Logs (tag "pppoe-ha") for details.'
+        : 'PPPoE HA: Reconcile attempted, but the helper returned a non-zero status. Check logs.';
+    // pkg_edit.php will render $savemsg if set
+    $GLOBALS['savemsg'] = $msg;
+}
+
+/* Validation (optional) */
+function ppha_validate_form_pppoe_ha($post, &$input_errors) {
+    // Add checks here if needed (e.g., require enabled rows to have both fields)
+}
+
+/* Resync (ensures node exists; no daemon action yet) */
+function ppha_resync_package_pppoe_ha() {
+    $rows = ppha_get_rows();
+    ppha_set_rows(is_array($rows) ? $rows : []);
+    write_config('PPPoE HA: resync');
+}

--- a/www/Kontrol-pkg-pppoeHA/files/usr/local/pkg/pppoe_ha.xml
+++ b/www/Kontrol-pkg-pppoeHA/files/usr/local/pkg/pppoe_ha.xml
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE packagegui SYSTEM "./schema/packages.dtd">
+<?xml-stylesheet type="text/xsl" href="./xsl/package.xsl"?>
+<packagegui>
+    <copyright>
+	<![CDATA[
+/*
+ * frr.xml
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2012-2024 Rubicon Communications, LLC (Netgate)
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+	]]>
+	</copyright>
+    <title>Services/PPPoE High Availability</title>
+    <name>pppoe_ha</name>
+    <version>%%PKGVERSION%%</version>
+    <include_file>/usr/local/pkg/pppoe_ha.inc</include_file>
+
+    <menu>
+        <name>PPPoE High Availability</name>
+        <tooltiptext>Enable/disable PPPoE by CARP state</tooltiptext>
+        <section>Services</section>
+        <configfile>pppoe_ha.xml</configfile>
+        <url>/pkg_edit.php?xml=pppoe_ha.xml&amp;id=0</url>
+    </menu>
+
+    <!-- no <service> yet; we’ll add backend/rc/devd later -->
+
+    <fields>
+        <field>
+            <name>Overview</name>
+            <type>listtopic</type>
+        </field>
+
+        <field>
+            <name>How it works</name>
+            <type>info</type>
+            <description><![CDATA[
+        Map an <strong>assigned PPPoE interface</strong> to a <strong>CARP VIP</strong>. When the VIP
+        is MASTER, the PPPoE interface will be enabled; when BACKUP, it will be disabled.
+        
+      ]]></description>
+        </field>
+
+        <field>
+            <name>Mappings</name>
+            <type>listtopic</type>
+        </field>
+
+        <!-- dynamic row table: one mapping per row -->
+        <field>
+            <fielddescr><![CDATA[PPPoE ↔ CARP VIP 
+      ]]></fielddescr>
+            <fieldname>none</fieldname>
+            <type>rowhelper</type>
+            <rowhelper>
+                <rowhelperfield>
+                    <fielddescr>Enabled</fielddescr>
+                    <fieldname>enabled</fieldname>
+                    <type>checkbox</type>
+                    <size>50</size>
+                </rowhelperfield>
+
+
+                <rowhelperfield>
+                    <fielddescr>PPPoE Interface</fielddescr>
+                    <fieldname>iface</fieldname>
+                    <type>select</type>
+                    <options>
+                        <option>
+                            <name>Loading…</name>
+                            <value></value>
+                        </option>
+                    </options>
+                    <size>30</size>
+                    <required />
+                </rowhelperfield>
+
+                <rowhelperfield>
+                    <fielddescr>CARP VIP</fielddescr>
+                    <fieldname>vipref</fieldname>
+                    <type>select</type>
+                    <!-- options will be filled dynamically by before_form hook -->
+                    <options>
+                        <!-- placeholder; will be replaced in before_form -->
+                        <option>
+                            <name>Loading…</name>
+                            <value></value>
+                        </option>
+                    </options>
+                    <size>30</size>
+                    <required />
+                </rowhelperfield>
+            </rowhelper>
+        </field>
+		    <!-- Manual reconcile UI -->
+    <field>
+      <name>Manual Reconcile</name>
+      <type>listtopic</type>
+    </field>
+
+    <field>
+      <name>About Reconcile</name>
+      <type>info</type>
+      <description><![CDATA[
+        <p>
+          <strong>No automatic reconcile is performed after saving changes.</strong>
+          This is intentional to avoid race conditions and to reduce the risk of accidentally
+          locking yourself out or briefly breaking Internet connectivity while CARP/PPPoE are
+          transitioning.
+        </p>
+        <p>
+          If you changed mappings and want to immediately align PPPoE interface state with the
+          current CARP state, you can run a manual reconcile now.
+        </p>
+        <p>
+          <a class="btn btn-sm btn-primary"
+             href="/pkg_edit.php?xml=pppoe_ha.xml&amp;id=0&amp;ppha_reconcile=1">
+             Run Reconcile Now
+          </a>
+        </p>
+      ]]></description>
+    </field>
+
+    </fields>
+
+    <!-- hooks implemented in /usr/local/pkg/pppoe_ha.inc -->
+    <custom_php_command_before_form>
+        ppha_before_form_pppoe_ha($pkg);
+    </custom_php_command_before_form>
+
+    <custom_php_validation_command>
+        ppha_validate_form_pppoe_ha($_POST, $input_errors);
+    </custom_php_validation_command>
+
+    <custom_php_resync_config_command>
+        ppha_resync_package_pppoe_ha();
+    </custom_php_resync_config_command>
+
+</packagegui>

--- a/www/Kontrol-pkg-pppoeHA/files/usr/local/sbin/pppoe_ha_event
+++ b/www/Kontrol-pkg-pppoeHA/files/usr/local/sbin/pppoe_ha_event
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /usr/local/bin/php -q /usr/local/sbin/pppoe_ha_event.php "$@"

--- a/www/Kontrol-pkg-pppoeHA/files/usr/local/sbin/pppoe_ha_event.php
+++ b/www/Kontrol-pkg-pppoeHA/files/usr/local/sbin/pppoe_ha_event.php
@@ -1,0 +1,275 @@
+<?php
+/*
+ * pppoe_ha_event.php — CARP event handler + reconcile
+ * Usage from devd:
+ *   /usr/local/sbin/pppoe_ha_event carp <subsystem> <MASTER|BACKUP|INIT>
+ * Usage manual:
+ *   /usr/local/sbin/pppoe_ha_event reconcile
+ */
+
+require_once("util.inc");
+require_once("config.inc");
+require_once("interfaces.inc");
+require_once("/usr/local/pkg/pppoe_ha.inc");
+
+//function ha_log($msg) { log_error("[pppoe-ha] " . $msg); }
+function ha_log($msg, $prio = LOG_NOTICE) {
+    static $opened = false;
+    if (!$opened) {
+        // LOG_USER lands in the main System log; LOG_PID adds [pid]
+        openlog('pppoe-ha', LOG_PID, LOG_USER);
+        $opened = true;
+        register_shutdown_function(function() { closelog(); });
+    }
+    syslog($prio, $msg);
+}
+
+//function ha_log($msg) { log_error("[pppoe-ha] " . $msg); }
+function ha_log_debug($msg) {
+   ha_log($msg, LOG_DEBUG);
+}
+
+// devd may pass '$19@vtnet0.510' and '$BACKUP' when action uses '$subsystem' '$type'
+function ppha_sanitize_token($s) {
+    $s = trim((string)$s);
+    if ($s !== '' && $s[0] === '$') {
+        $s = substr($s, 1);
+    }
+    return $s;
+}
+
+function ppha_build_targets($only_vhid = null) {
+    $rows = ppha_get_rows();
+    $vips = config_get_path('virtualip/vip', []);
+    $targets = [];
+
+    if (!is_array($rows) || !is_array($vips)) {
+        return [];
+    }
+
+    foreach ($rows as $i => $row) {
+        // normalize; allow vipref '0'
+        $enabled = isset($row['enabled']) && strcasecmp((string)$row['enabled'], 'ON') === 0;
+        $vipref  = array_key_exists('vipref', $row) ? (string)$row['vipref'] : '';
+        $iface   = array_key_exists('iface',  $row) ? (string)$row['iface']  : '';
+
+        if (!$enabled || $vipref === '' || $iface === '') {
+            ha_log_debug("row[$i] skipped (enabled/vipref/iface missing or off)");
+            continue;
+        }
+
+        // resolve VIP + VHID
+        $vip = $vips[$vipref] ?? null;
+        if (!$vip || ($vip['mode'] ?? '') !== 'carp') {
+            ha_log_debug("row[$i] skipped (vipref {$vipref} not CARP or missing)");
+            continue;
+        }
+        $vhid = (int)($vip['vhid'] ?? -1);
+        if ($vhid < 0) {
+            ha_log_debug("row[$i] skipped (vipref {$vipref} has invalid VHID)");
+            continue;
+        }
+
+        if ($only_vhid !== null && (int)$only_vhid !== $vhid) {
+            continue;
+        }
+
+        // resolve interface
+        $real = get_real_interface($iface);
+        if (empty($real)) {
+            ha_log("row[$i] {$iface}/vipref={$vipref} - real interface not found; skipping");
+            continue;
+        }
+
+        $targets[] = [
+            'idx'            => (int)$i,
+            'iface_friendly' => $iface,
+            'iface_real'     => $real,
+            'vipref'         => $vipref,
+            'vhid'           => $vhid,
+        ];
+    }
+
+    return $targets;
+}
+
+
+/** Apply the CARP-derived state for a single target. */
+function ppha_apply_target_state(array $t, string $state) {
+    $iface = $t['iface_friendly'];
+    $real  = $t['iface_real'];
+    $vhid  = $t['vhid'];
+
+    if (!is_pppoe_real($real)) {
+        ha_log("warning: {$real} does not look like pppoeX; continuing anyway");
+    }
+
+    switch ($state) {
+        case 'MASTER':
+            ha_log("VHID {$vhid} MASTER - UP {$iface} ({$real})");
+            //Call iface_up with $iface as it is using pfSctl internally!
+            iface_up($iface);
+            break;
+        case 'BACKUP':
+        case 'INIT':
+            ha_log("VHID {$vhid} {$state} - DOWN {$iface} ({$real})");
+            iface_down($real);
+            break;
+        default:
+            ha_log("VHID {$vhid} {$state} - no action");
+    }
+}
+
+
+/** Parse devd CARP “subsystem” (e.g. "5@igb0", "carp1", "5") */
+function parse_carp_subsystem($subsys) {
+    $subsys = trim((string)$subsys);
+    if ($subsys !== '' && $subsys[0] === '$') {
+        $subsys = substr($subsys, 1);
+    }
+    $subsys = trim((string)$subsys);
+    if (preg_match('/^(\d+)\@([A-Za-z0-9_.:\-]+)$/', $subsys, $m)) {
+        return ['vhid'=>(int)$m[1], 'real'=>$m[2], 'carpif'=>null];
+    }
+    if (preg_match('/^(carp\d+)$/', $subsys, $m)) {
+        $carpif = $m[1];
+        $out=[]; @exec("/sbin/ifconfig ".escapeshellarg($carpif)." 2>/dev/null",$out);
+        $vhid=null; foreach ($out as $line) {
+            if (preg_match('/\bvhid\s+(\d+)/', $line, $mm)) { $vhid=(int)$mm[1]; break; }
+        }
+        return ['vhid'=>$vhid, 'real'=>null, 'carpif'=>$carpif];
+    }
+    if (preg_match('/^\d+$/', $subsys)) { return ['vhid'=>(int)$subsys, 'real'=>null, 'carpif'=>null]; }
+    return ['vhid'=>null, 'real'=>null, 'carpif'=>null];
+}
+
+/**
+ * Return CARP state (MASTER|BACKUP|INIT) for a given VHID, or null if not found.
+ * Works whether CARP appears under carpX: or under a real interface block.
+ */
+function get_carp_state_for_vhid($vhid) {
+    $vhid = (int)$vhid;
+    $out = [];
+    $rc  = 0;
+    @exec('/sbin/ifconfig -a', $out, $rc);
+    if ($rc !== 0 || empty($out)) {
+        return null;
+    }
+    foreach ($out as $line) {
+        // Look for a line like: "carp: MASTER vhid 19 ..." (order can vary)
+        if (preg_match('/\bcarp:\s*(MASTER|BACKUP|INIT)\b.*\bvhid\s+(\d+)/i', $line, $m)) {
+            if ((int)$m[2] === $vhid) {
+                return strtoupper($m[1]);
+            }
+        }
+    }
+    return null;
+}
+
+function get_pppoe_status($real) {
+    $out = [];
+    @exec("/sbin/ifconfig " . escapeshellarg($real) . " 2>&1", $out);
+
+    $has_v4_p2p = false;
+    $has_v6_global = false;
+
+    foreach ($out as $line) {
+        // IPv4 PPPoE shows: inet <local> --> <peer>
+        if (preg_match('/^\s*inet\s+\S+\s+-->\s+\S+/', $line)) {
+            $has_v4_p2p = true;
+            continue;
+        }
+        // IPv6 global (exclude link-local fe80:: and exclude 'tentative')
+        if (preg_match('/^\s*inet6\s+([0-9a-f:]+)/i', $line, $m)) {
+            $addr = strtolower($m[1]);
+            if (strpos($addr, 'fe80:') !== 0 && stripos($line, 'tentative') === false) {
+                $has_v6_global = true;
+            }
+        }
+    }
+
+    return [
+        'active'       => ($has_v4_p2p || $has_v6_global),
+        'has_ipv4_p2p' => $has_v4_p2p,
+        'has_v6_global'=> $has_v6_global,
+    ];
+}
+
+function is_pppoe_real($ifname){ return (bool)preg_match('/^pppoe\d+$/', (string)$ifname); }
+
+
+// iface_up needs to use pfSctl and needs to be called with the iface name instead of the real interface!
+function iface_up($iface){ mwexec("/usr/local/sbin/pfSctl -c 'interface reload ".escapeshellarg($iface)."'"); }
+function iface_down($real){ mwexec("/sbin/ifconfig ".escapeshellarg($real)." down"); }
+
+
+
+function handle_carp_state_change($vhid, $state) {
+    ha_log_debug("carp change: vhid={$vhid} state={$state}");
+
+    $targets = ppha_build_targets($vhid);
+    if (!$targets) {
+        ha_log("no mappings for VHID {$vhid}; ignoring");
+        return;
+    }
+    foreach ($targets as $t) {
+        ppha_apply_target_state($t, $state);
+    }
+}
+
+function reconcile_all() {
+    $targets = ppha_build_targets(); // all mappings
+    if (!$targets) {
+        ha_log("Reconcile: no mappings configured");
+        return;
+    }
+    ha_log("Reconcile: evaluating " . count($targets) . " mapping(s)");
+    foreach ($targets as $t) {
+        $state = get_carp_state_for_vhid($t['vhid']) ?? 'INIT';
+        $desired_up = ($state === 'MASTER');
+
+        // Do not reload a PPPoE interface if it is already up and if the desired state also is up
+        if (is_pppoe_real($t['iface_real'])) {
+            $st = get_pppoe_status($t['iface_real']);
+            if ($desired_up && $st['active']) {
+                ha_log("Reconcile: VHID {$t['vhid']} target=UP but {$t['iface_friendly']} ({$t['iface_real']}) already UP - skip");
+                continue;
+            }
+        }
+
+        // Non-PPPoE (or PPPoE not active) - proceed as usual
+        ppha_apply_target_state($t, $state);
+    }
+}
+
+
+/* entry */
+
+$argv0 = array_shift($argv);           // script path
+$cmd   = strtoupper($argv[0] ?? '');
+
+if ($cmd === 'CARP') {
+    //ha_log("Handling CARP command");
+    $subsys = ppha_sanitize_token($argv[1] ?? '');
+    $state  = strtoupper(ppha_sanitize_token($argv[2] ?? ''));
+    $info   = parse_carp_subsystem(ppha_sanitize_token($subsys));
+    $vhid   = $info['vhid'];
+    //echo "CMD CARP subsys $subsy state $state info $info vhid $vhid";
+    ha_log("Handle CARP command for $subsys - $state");
+    if ($vhid === null || !in_array($state, ['MASTER','BACKUP','INIT'], true)) {
+        ha_log("Invalid CARP args: subsystem={$subsys} parsed_vhid=".var_export($vhid,true)." state={$state}");
+        exit(1);
+    }
+    handle_carp_state_change($vhid, $state);
+    exit(0);
+}
+if ($cmd === 'RECONCILE') {
+    reconcile_all();
+    exit(0);
+}
+
+/* help */
+echo "Usage:\n";
+echo "  pppoe_ha_event carp <vhid|carpX|vhid@realif> <MASTER|BACKUP|INIT>\n";
+echo "  pppoe_ha_event reconcile\n";
+exit(1);

--- a/www/Kontrol-pkg-pppoeHA/files/usr/local/share/Kontrol-pkg-pppoeHA/info.xml
+++ b/www/Kontrol-pkg-pppoeHA/files/usr/local/share/Kontrol-pkg-pppoeHA/info.xml
@@ -1,0 +1,8 @@
+<pfsensepkgs>
+    <package>
+        <name>pppoe_ha</name>
+        <descr><![CDATA[PPPoE High Availability – GUI + devd/rc handling]]></descr>
+        <version>%%PKGVERSION%%</version>
+        <configurationfile>pppoe_ha.xml</configurationfile>
+    </package>
+</pfsensepkgs>

--- a/www/Kontrol-pkg-pppoeHA/pkg-descr
+++ b/www/Kontrol-pkg-pppoeHA/pkg-descr
@@ -1,0 +1,5 @@
+Kontrol PPPoE High Availability package for pfSense/Kontrol environments.
+
+Provides GUI, devd hooks, and reconcile logic to tie PPPoE interface up/down
+state to CARP MASTER/BACKUP transitions, avoiding duplicate PPPoE sessions in
+HA deployments.

--- a/www/Kontrol-pkg-pppoeHA/pkg-plist
+++ b/www/Kontrol-pkg-pppoeHA/pkg-plist
@@ -1,0 +1,7 @@
+pkg/pppoe_ha.xml
+pkg/pppoe_ha.inc
+sbin/pppoe_ha_event
+sbin/pppoe_ha_event.php
+etc/rc.d/pppoe_ha
+etc/devd/pppoe_ha.conf
+share/Kontrol-pkg-pppoeHA/info.xml

--- a/www/Makefile
+++ b/www/Makefile
@@ -301,6 +301,7 @@
     SUBDIR += joomla4
     SUBDIR += joomla5
     SUBDIR += jwt-cli
+    SUBDIR += Kontrol-pkg-pppoeHA
     SUBDIR += kanboard
     SUBDIR += kannel
     SUBDIR += kannel-sqlbox


### PR DESCRIPTION
### Motivation
- Bring the upstream pfSense PPPoE High Availability package into the Kontrol ports tree as a native Kontrol-style port and rebrand it from `pfSense` to `Kontrol`. 
- Make the package installable via the ports `package` workflow (create a proper `Makefile`, `pkg-plist` and install/deinstall hooks) so it can be managed like other Kontrol ports.

### Description
- Added a new port at `www/Kontrol-pkg-pppoeHA` containing a `Makefile`, `pkg-plist`, `pkg-descr`, `files/pkg-install.in` and `files/pkg-deinstall.in` to build the package from the upstream payload. 
- Imported upstream payload files into `files/usr/local/...` for the GUI (`pppoe_ha.xml`, `pppoe_ha.inc`), event handler (`pppoe_ha_event`, `pppoe_ha_event.php`), `rc.d` helper and `devd` rule, and added `info.xml` under `share/`.
- Rebranded metadata and runtime references from `pfSense-pkg-pppoe-ha` to `Kontrol-pkg-pppoeHA` and added `%%PKGVERSION%%` substitution points in `info.xml`/GUI XML to match ports packaging conventions. 
- Registered the new port in `www/Makefile` by adding `SUBDIR += Kontrol-pkg-pppoeHA` so it appears in the `www/` category.

### Testing
- `git clone --branch main --depth 1 https://github.com/perrin-1/pfSense-pppoe-ha.git` succeeded and upstream files were inspected with `sed`/`find` to identify package payload and scripts. (succeeded)
- Files were copied into `www/Kontrol-pkg-pppoeHA/files/...` and adjusted with `sed` to replace version/name tokens, and these operations completed successfully. (succeeded)
- Repository changes were committed with `git commit` and the port directory was added to `www/Makefile`; the commit succeeded. (succeeded)
- Attempted a ports `stage` with `make -C www/Kontrol-pkg-pppoeHA stage NO_DEPENDS=yes`, but it failed in this environment because the Linux `make` and missing BSD ports infrastructure (`bsd.port.mk` / native FreeBSD make environment) prevented a proper `make` run. (failed due to environment limitations)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15de874ad0832eb375b2036ff21877)