### PR TITLE
Harden blacklist extraction: validation, locking, temp dirs, and rollback; add smoke tests

### DIFF
--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/www/e2guardian.php
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/www/e2guardian.php
@@ -41,122 +41,245 @@ if (!defined('E2GUARDIAN_DIR')) {
 }
 require_once(E2GUARDIAN_DIR . "/pkg/e2guardian.inc");
 
+function e2g_blacklist_notice($message) {
+        $error = null;
+        file_notice("E2guardian", $error, "E2guardian - " . gettext($message), "");
+}
+
+function e2g_blacklist_lock() {
+        $lock_handle = @fopen('/tmp/e2guardian-blacklist.lock', 'c');
+        if ($lock_handle === false || !@flock($lock_handle, LOCK_EX | LOCK_NB)) {
+                if (is_resource($lock_handle)) {
+                        @fclose($lock_handle);
+                }
+                e2g_blacklist_notice("A blacklist update is already running.");
+                return false;
+        }
+        return $lock_handle;
+}
+
+function e2g_blacklist_unlock($lock_handle) {
+        if (is_resource($lock_handle)) {
+                @flock($lock_handle, LOCK_UN);
+                @fclose($lock_handle);
+        }
+}
+
+function e2g_blacklist_remove_temp_dir($temp_dir) {
+        $temp_prefix = rtrim(sys_get_temp_dir(), '/') . '/e2guardian-blacklist-';
+        if (is_string($temp_dir) && strpos($temp_dir, $temp_prefix) === 0 && is_dir($temp_dir)) {
+                e2g_delTree($temp_dir);
+        }
+}
+
+function e2g_blacklist_validate_archive($blacklist_file) {
+        $entries = array();
+        exec('/usr/bin/tar -tzPf ' . escapeshellarg($blacklist_file) . ' 2>&1', $entries, $return);
+        if ($return !== 0 || empty($entries)) {
+                return false;
+        }
+        foreach ($entries as $entry) {
+                $entry = str_replace('\\', '/', trim($entry));
+                if ($entry === '' || $entry === '.' || substr($entry, 0, 1) === '/') {
+                        return false;
+                }
+                foreach (explode('/', $entry) as $component) {
+                        if ($component === '..') {
+                                return false;
+                        }
+                }
+        }
+
+        $verbose_entries = array();
+        exec('/usr/bin/tar -tvzPf ' . escapeshellarg($blacklist_file) . ' 2>&1', $verbose_entries, $return);
+        if ($return !== 0) {
+                return false;
+        }
+        foreach ($verbose_entries as $entry) {
+                if (!preg_match('/^[-d]/', $entry)) {
+                        return false;
+                }
+        }
+        return true;
+}
+
+function e2g_blacklist_create_temp_dir() {
+        $temp_dir = @tempnam(sys_get_temp_dir(), 'e2guardian-blacklist-');
+        if ($temp_dir === false) {
+                return false;
+        }
+        @unlink($temp_dir);
+        if (!@mkdir($temp_dir, 0700)) {
+                return false;
+        }
+        return $temp_dir;
+}
+
+function e2g_blacklist_prepare_tree($temp_dir) {
+        $entries = array_values(array_diff(scandir($temp_dir), array('.', '..')));
+        if (empty($entries)) {
+                return false;
+        }
+        if (count($entries) === 1 && $entries[0] === 'blacklists' && is_dir($temp_dir . '/blacklists')) {
+                return $temp_dir . '/blacklists';
+        }
+        if (count($entries) === 1 && is_dir($temp_dir . '/' . $entries[0])) {
+                return $temp_dir . '/' . $entries[0];
+        }
+
+        $prepared_dir = $temp_dir . '/.prepared-blacklists';
+        if (!@mkdir($prepared_dir, 0700)) {
+                return false;
+        }
+        foreach ($entries as $entry) {
+                if (!@rename($temp_dir . '/' . $entry, $prepared_dir . '/' . $entry)) {
+                        return false;
+                }
+        }
+        return $prepared_dir;
+}
+
 function fetch_blacklist($log_notice = true, $install_process = false) {
         global $config, $g;
-        $blacklist_file = E2GUARDIAN_PKGDIR . "/blacklist.tgz";
-        if (is_array($config['installedpackages']['e2guardianblacklist']) && is_array($config['installedpackages']['e2guardianblacklist']['config'])) {
-                $url = $config['installedpackages']['e2guardianblacklist']['config'][0]['url'];
-                $uw = "Found a previous install, checking Blacklist config...";
-        } else {
-                $uw = "Found a clean install, reading default access lists...";
-	}
-	if ($install_process == true) {
-		update_output_window($uw);
-	}
-	if (isset($url) && is_url($url)) {
-		if ($log_notice == true) {
-			print "file download start..";
-                        unlink_if_exists($blacklist_file);
-                        exec("/usr/bin/fetch -o " . escapeshellarg($blacklist_file) . " " . escapeshellarg($url), $output, $return);
+        $lock_handle = e2g_blacklist_lock();
+        if ($lock_handle === false) {
+                return false;
+        }
+        try {
+                $blacklist_file = E2GUARDIAN_PKGDIR . "/blacklist.tgz";
+                if (is_array($config['installedpackages']['e2guardianblacklist']) && is_array($config['installedpackages']['e2guardianblacklist']['config'])) {
+                        $url = $config['installedpackages']['e2guardianblacklist']['config'][0]['url'];
+                        $uw = "Found a previous install, checking Blacklist config...";
                 } else {
-                        //install process
-                        if (file_exists($blacklist_file)) {
-                                update_output_window("Found previous blacklist database, skipping download...");
-                                $return = 0;
+                        $uw = "Found a clean install, reading default access lists...";
+                }
+                if ($install_process == true) {
+                        update_output_window($uw);
+                }
+                if (isset($url) && is_url($url)) {
+                        if ($log_notice == true) {
+                                print "file download start..";
+                                unlink_if_exists($blacklist_file);
+                                exec("/usr/bin/fetch -o " . escapeshellarg($blacklist_file) . " " . escapeshellarg($url), $output, $return);
                         } else {
-                                update_output_window("Fetching blacklist");
-                                if (function_exists('download_file_with_progress_bar')) {
-                                        download_file_with_progress_bar($url, $blacklist_file);
-                                } else {
-                                        exec("/usr/bin/fetch -o " . escapeshellarg($blacklist_file) . " " . escapeshellarg($url), $output, $return);
-                                }
+                                //install process
                                 if (file_exists($blacklist_file)) {
+                                        update_output_window("Found previous blacklist database, skipping download...");
                                         $return = 0;
+                                } else {
+                                        update_output_window("Fetching blacklist");
+                                        if (function_exists('download_file_with_progress_bar')) {
+                                                download_file_with_progress_bar($url, $blacklist_file);
+                                        } else {
+                                                exec("/usr/bin/fetch -o " . escapeshellarg($blacklist_file) . " " . escapeshellarg($url), $output, $return);
+                                        }
+                                        if (file_exists($blacklist_file)) {
+                                                $return = 0;
+                                        }
                                 }
                         }
-                }
-                if ($return == 0) {
-			extract_black_list($log_notice);
-		} else {
-			file_notice("E2guardian",$error,"E2guardian" . gettext("Could not fetch blacklists from url"), "");
-		}
-	} else {
-		if ($install_process == true) {
-			read_lists(false, $uw);
-		} elseif (!empty($url)) {
-			file_notice("E2guardian",$error,"E2guardian" . gettext("Blacklist url is invalid."), "");
-		}
-	}
-}
-function extract_black_list($log_notice=true) {
-        $blacklist_file = E2GUARDIAN_PKGDIR . "/blacklist.tgz";
-        if (!file_exists($blacklist_file)) {
-                file_notice("E2guardian", $error, "E2guardian" . gettext("Downloaded blacklists not found"), "");
-                return;
-        }
-
-        $lists_dir = E2GUARDIAN_ETCDIR . "/lists";
-        if (!is_dir($lists_dir)) {
-                @mkdir($lists_dir, 0755, true);
-        }
-
-        $cwd = getcwd();
-        chdir($lists_dir);
-
-        if (is_dir('blacklists.old')) {
-                e2g_delTree($lists_dir . '/blacklists.old');
-        }
-        if (is_dir('blacklists')) {
-                @rename('blacklists', 'blacklists.old');
-        }
-
-        exec('/usr/bin/tar -xzf ' . escapeshellarg($blacklist_file) . ' 2>&1', $output, $return);
-        if ($return !== 0) {
-                if (is_dir('blacklists.old')) {
-                        @rename('blacklists.old', 'blacklists');
-                }
-                if (isset($cwd)) {
-                        chdir($cwd);
-                }
-                file_notice("E2guardian", $error, "E2guardian - " . gettext("Could not extract blacklist archive."), "");
-                return;
-        }
-
-        $entries = array_diff(scandir('.'), array('.', '..', 'blacklists', 'blacklists.old'));
-        $dirs = array();
-        foreach ($entries as $entry) {
-                if (is_dir($entry)) {
-                        $dirs[] = $entry;
-                }
-        }
-
-        if (!is_dir('blacklists')) {
-                if (count($dirs) === 1) {
-                        @rename($dirs[0], 'blacklists');
+                        if ($return == 0) {
+                                return extract_black_list($log_notice, $lock_handle);
+                        }
+                        file_notice("E2guardian", $error, "E2guardian" . gettext("Could not fetch blacklists from url"), "");
                 } else {
-                        @mkdir('blacklists', 0755, true);
-                        foreach ($entries as $entry) {
-                                @rename($entry, 'blacklists/' . $entry);
+                        if ($install_process == true) {
+                                read_lists(false, $uw);
+                        } elseif (!empty($url)) {
+                                file_notice("E2guardian", $error, "E2guardian" . gettext("Blacklist url is invalid."), "");
                         }
                 }
+        } finally {
+                e2g_blacklist_unlock($lock_handle);
+        }
+        return false;
+}
+
+function extract_black_list($log_notice = true, $lock_handle = null, $options = array()) {
+        $owns_lock = false;
+        if (!is_resource($lock_handle)) {
+                $lock_handle = e2g_blacklist_lock();
+                if ($lock_handle === false) {
+                        return false;
+                }
+                $owns_lock = true;
         }
 
-        if (!is_dir('blacklists')) {
-                if (is_dir('blacklists.old')) {
-                        @rename('blacklists.old', 'blacklists');
+        $temp_dir = false;
+        try {
+                if (!empty($options['hold_lock_seconds'])) {
+                        sleep((int)$options['hold_lock_seconds']);
                 }
-                if (isset($cwd)) {
-                        chdir($cwd);
+                $blacklist_file = $options['blacklist_file'] ?? E2GUARDIAN_PKGDIR . "/blacklist.tgz";
+                if (!file_exists($blacklist_file)) {
+                        e2g_blacklist_notice("Downloaded blacklists not found.");
+                        return false;
                 }
-                file_notice("E2guardian", $error, "E2guardian - " . gettext("Could not determine Blacklist extract dir. Categories not updated"), "");
-                return;
-        }
+                if (!e2g_blacklist_validate_archive($blacklist_file)) {
+                        e2g_blacklist_notice("Blacklist archive is invalid, empty, or contains unsafe paths or links.");
+                        return false;
+                }
 
-        read_lists($log_notice);
-        e2g_delTree($lists_dir . '/blacklists.old');
+                $lists_dir = $options['lists_dir'] ?? E2GUARDIAN_ETCDIR . "/lists";
+                $blacklists_dir = $lists_dir . '/blacklists';
+                $blacklists_old_dir = $lists_dir . '/blacklists.old';
+                if (!is_dir($lists_dir) && !@mkdir($lists_dir, 0755, true)) {
+                        e2g_blacklist_notice("Could not create the E2guardian lists directory.");
+                        return false;
+                }
 
-        if (isset($cwd)) {
-                chdir($cwd);
+                $temp_dir = e2g_blacklist_create_temp_dir();
+                if ($temp_dir === false) {
+                        e2g_blacklist_notice("Could not create a temporary blacklist extraction directory.");
+                        return false;
+                }
+                exec('/usr/bin/tar -xzf ' . escapeshellarg($blacklist_file) . ' -C ' . escapeshellarg($temp_dir) . ' 2>&1', $output, $return);
+                if ($return !== 0) {
+                        e2g_blacklist_notice("Could not extract blacklist archive.");
+                        return false;
+                }
+
+                $prepared_dir = e2g_blacklist_prepare_tree($temp_dir);
+                if ($prepared_dir === false || !is_dir($prepared_dir)) {
+                        e2g_blacklist_notice("Could not determine Blacklist extract dir. Categories not updated.");
+                        return false;
+                }
+
+                if (is_dir($blacklists_old_dir)) {
+                        if (!is_dir($blacklists_dir)) {
+                                if (!@rename($blacklists_old_dir, $blacklists_dir)) {
+                                        e2g_blacklist_notice("Could not restore the previous blacklist tree.");
+                                        return false;
+                                }
+                        } else {
+                                e2g_delTree($blacklists_old_dir);
+                        }
+                }
+                if (is_dir($blacklists_dir) && !@rename($blacklists_dir, $blacklists_old_dir)) {
+                        e2g_blacklist_notice("Could not preserve the previous blacklist tree.");
+                        return false;
+                }
+                $simulate_install_failure = !empty($options['simulate_install_failure']);
+                if ($simulate_install_failure || !@rename($prepared_dir, $blacklists_dir)) {
+                        if (!is_dir($blacklists_dir) && is_dir($blacklists_old_dir)) {
+                                @rename($blacklists_old_dir, $blacklists_dir);
+                        }
+                        e2g_blacklist_notice("Could not install the new blacklist tree; the previous tree was restored.");
+                        return false;
+                }
+
+                if (empty($options['skip_read_lists'])) {
+                        read_lists($log_notice);
+                }
+                if (is_dir($blacklists_old_dir)) {
+                        e2g_delTree($blacklists_old_dir);
+                }
+                return true;
+        } finally {
+                e2g_blacklist_remove_temp_dir($temp_dir);
+                if ($owns_lock) {
+                        e2g_blacklist_unlock($lock_handle);
+                }
         }
 }
 

--- a/www/Kontrol-pkg-E2guardian54/tests/blacklist_extract_smoke.php
+++ b/www/Kontrol-pkg-E2guardian54/tests/blacklist_extract_smoke.php
@@ -1,0 +1,185 @@
+#!/usr/bin/env php
+<?php
+if (!function_exists('gettext')) {
+        function gettext($message) {
+                return $message;
+        }
+}
+function fail($message) {
+        fwrite(STDERR, "FAIL: {$message}\n");
+        exit(1);
+}
+function assert_true($condition, $message) {
+        if (!$condition) {
+                fail($message);
+        }
+}
+function e2g_delTree($dir) {
+        if (!is_dir($dir)) {
+                return false;
+        }
+        foreach (array_diff(scandir($dir), array('.', '..')) as $entry) {
+                $path = $dir . '/' . $entry;
+                is_dir($path) && !is_link($path) ? e2g_delTree($path) : unlink($path);
+        }
+        return rmdir($dir);
+}
+function file_notice($package, $error, $message, $url) {
+        $GLOBALS['notices'][] = $message;
+}
+
+$source = file_get_contents(__DIR__ . '/../files/usr/local/www/e2guardian.php');
+$start = strpos($source, 'function e2g_blacklist_notice(');
+$end = strpos($source, 'function read_lists(');
+assert_true($start !== false && $end !== false, 'could not load blacklist implementation');
+eval(substr($source, $start, $end - $start));
+
+function make_tree($base) {
+        mkdir($base . '/lists/authplugins', 0777, true);
+        mkdir($base . '/lists/blacklists/old-category', 0777, true);
+        foreach (array(
+                'authplugins/ipgroups',
+                'authplugins/ipgroups.sample',
+                'authexceptionurllist',
+                'authexceptionurllist.sample',
+                'bannedurllist.g_Default',
+                'another-package-managed-list.sample',
+                'blacklists/old-category/domains'
+        ) as $file) {
+                file_put_contents($base . '/lists/' . $file, "fixture\n");
+        }
+}
+function create_archive($base, $name, $entries) {
+        $archive_root = $base . '/archive-' . $name;
+        mkdir($archive_root, 0777, true);
+        foreach ($entries as $file) {
+                $path = $archive_root . '/' . $file;
+                if (!is_dir(dirname($path))) {
+                        mkdir(dirname($path), 0777, true);
+                }
+                file_put_contents($path, "fixture\n");
+        }
+        $archive = $base . '/' . $name . '.tgz';
+        exec('/usr/bin/tar -czf ' . escapeshellarg($archive) . ' -C ' . escapeshellarg($archive_root) . ' .', $output, $return);
+        assert_true($return === 0, "could not create {$name} archive");
+        return $archive;
+}
+function assert_preserved($lists) {
+        foreach (array(
+                'authplugins/ipgroups',
+                'authplugins/ipgroups.sample',
+                'authexceptionurllist',
+                'authexceptionurllist.sample',
+                'bannedurllist.g_Default',
+                'another-package-managed-list.sample'
+        ) as $file) {
+                assert_true(is_file($lists . '/' . $file), "managed list moved or removed: {$file}");
+                assert_true(!file_exists($lists . '/blacklists/' . $file), "managed list incorrectly nested: {$file}");
+        }
+}
+function update_with($base, $archive, $extra = array()) {
+        return extract_black_list(false, null, $extra + array(
+                'blacklist_file' => $archive,
+                'lists_dir' => $base . '/lists',
+                'skip_read_lists' => true
+        ));
+}
+
+$root = sys_get_temp_dir() . '/e2guardian-smoke-' . getmypid();
+mkdir($root, 0777, true);
+try {
+        foreach (array(
+                'blacklists-root' => array('blacklists/new-category/domains', 'blacklists/new-category/urls'),
+                'BL-root' => array('BL/new-category/domains', 'BL/new-category/urls'),
+                'direct-categories' => array('new-category/domains', 'new-category/urls', 'second-category/domains')
+        ) as $scenario => $entries) {
+                $base = $root . '/' . $scenario;
+                make_tree($base);
+                assert_true(update_with($base, create_archive($base, $scenario, $entries)), "{$scenario} update failed");
+                assert_preserved($base . '/lists');
+                assert_true(is_file($base . '/lists/blacklists/new-category/domains'), "{$scenario} domains missing");
+                assert_true(is_file($base . '/lists/blacklists/new-category/urls'), "{$scenario} urls missing");
+        }
+
+        $base = $root . '/corrupt';
+        make_tree($base);
+        $archive = $base . '/corrupt.tgz';
+        file_put_contents($archive, "not a tarball\n");
+        assert_true(!update_with($base, $archive), 'corrupt archive unexpectedly accepted');
+        assert_true(is_file($base . '/lists/blacklists/old-category/domains'), 'corrupt archive replaced old blacklist');
+        assert_preserved($base . '/lists');
+
+        $base = $root . '/empty';
+        make_tree($base);
+        $archive = $base . '/empty.tgz';
+        exec('/usr/bin/tar -czf ' . escapeshellarg($archive) . ' --files-from /dev/null', $output, $return);
+        assert_true($return === 0, 'could not create empty archive');
+        assert_true(!update_with($base, $archive), 'empty archive unexpectedly accepted');
+        assert_true(is_file($base . '/lists/blacklists/old-category/domains'), 'empty archive replaced old blacklist');
+        assert_preserved($base . '/lists');
+
+        $base = $root . '/traversal';
+        make_tree($base);
+        mkdir($base . '/payload', 0777, true);
+        file_put_contents($base . '/payload/file', "fixture\n");
+        $archive = $base . '/traversal.tgz';
+        exec('/usr/bin/tar -czf ' . escapeshellarg($archive) . ' -C ' . escapeshellarg($base . '/payload') . ' --transform=' . escapeshellarg('s|file|../outside|') . ' file', $output, $return);
+        assert_true($return === 0, 'could not create traversal archive');
+        assert_true(!update_with($base, $archive), 'traversal archive unexpectedly accepted');
+        assert_true(!file_exists($base . '/outside'), 'traversal wrote outside extraction directory');
+        assert_preserved($base . '/lists');
+
+        $base = $root . '/absolute';
+        make_tree($base);
+        mkdir($base . '/payload', 0777, true);
+        file_put_contents($base . '/payload/file', "fixture\n");
+        $archive = $base . '/absolute.tgz';
+        exec('/usr/bin/tar -czPf ' . escapeshellarg($archive) . ' -C ' . escapeshellarg($base . '/payload') . ' --transform=' . escapeshellarg('s|file|/tmp/e2guardian-absolute-smoke|') . ' file', $output, $return);
+        assert_true($return === 0, 'could not create absolute-path archive');
+        assert_true(!update_with($base, $archive), 'absolute-path archive unexpectedly accepted');
+        assert_true(!file_exists('/tmp/e2guardian-absolute-smoke'), 'absolute path wrote outside extraction directory');
+        assert_preserved($base . '/lists');
+
+        $base = $root . '/symlink';
+        make_tree($base);
+        mkdir($base . '/payload/BL', 0777, true);
+        symlink('/tmp', $base . '/payload/BL/link');
+        $archive = $base . '/symlink.tgz';
+        exec('/usr/bin/tar -czf ' . escapeshellarg($archive) . ' -C ' . escapeshellarg($base . '/payload') . ' BL', $output, $return);
+        assert_true($return === 0, 'could not create symlink archive');
+        assert_true(!update_with($base, $archive), 'symlink archive unexpectedly accepted');
+        assert_preserved($base . '/lists');
+
+        $base = $root . '/interrupted-rollback';
+        make_tree($base);
+        rename($base . '/lists/blacklists', $base . '/lists/blacklists.old');
+        $archive = create_archive($base, 'interrupted-rollback', array('BL/new-category/domains'));
+        assert_true(update_with($base, $archive), 'update did not recover interrupted rollback');
+        assert_true(is_file($base . '/lists/blacklists/new-category/domains'), 'recovered update did not install new blacklist');
+        assert_preserved($base . '/lists');
+
+        $base = $root . '/rollback';
+        make_tree($base);
+        $archive = create_archive($base, 'rollback', array('BL/new-category/domains'));
+        assert_true(!update_with($base, $archive, array('simulate_install_failure' => true)), 'simulated install failure unexpectedly succeeded');
+        assert_true(is_file($base . '/lists/blacklists/old-category/domains'), 'rollback did not restore previous blacklist');
+        assert_true(!is_dir($base . '/lists/blacklists.old'), 'rollback left blacklists.old behind');
+        assert_preserved($base . '/lists');
+
+        $base = $root . '/concurrency';
+        make_tree($base);
+        $archive = create_archive($base, 'concurrency', array('BL/new-category/domains'));
+        $pid = pcntl_fork();
+        assert_true($pid !== -1, 'could not fork concurrency worker');
+        if ($pid === 0) {
+                exit(update_with($base, $archive, array('hold_lock_seconds' => 2)) ? 0 : 1);
+        }
+        usleep(300000);
+        assert_true(!update_with($base, $archive), 'concurrent update unexpectedly acquired the lock');
+        pcntl_waitpid($pid, $status);
+        assert_true(pcntl_wexitstatus($status) === 0, 'lock-holding update failed');
+
+        echo "PASS: blacklist extraction smoke tests\n";
+} finally {
+        e2g_delTree($root);
+}


### PR DESCRIPTION
### Motivation
- Prevent unsafe or partial blacklist installs by validating archives, isolating extraction, and providing safe rollback behavior.
- Avoid concurrent blacklist updates and race conditions by introducing an exclusive lock for the update flow.
- Improve maintainability by refactoring the extraction logic into smaller, testable helper functions.

### Description
- Refactored and hardened blacklist update flow by adding `e2g_blacklist_notice`, `e2g_blacklist_lock`, `e2g_blacklist_unlock`, `e2g_blacklist_create_temp_dir`, `e2g_blacklist_remove_temp_dir`, `e2g_blacklist_validate_archive`, and `e2g_blacklist_prepare_tree` helper functions and using them from `fetch_blacklist` and `extract_black_list`.
- Rewrote `extract_black_list` to extract archives into a secure temporary directory, validate archive entries (reject absolute paths, traversal components, symlinks, and malformed archives), atomically swap `blacklists` with `blacklists.old`, and restore the previous tree on failure; added options such as `simulate_install_failure`, `skip_read_lists`, and overridable `blacklist_file`/`lists_dir` for testing.
- Updated `fetch_blacklist` to acquire a lock before operating and to call the new extraction implementation, and added better notices and cleanup behavior.
- Added a comprehensive smoke test script `tests/blacklist_extract_smoke.php` that covers normal installs, different archive-root layouts, corrupt/empty archives, path traversal, absolute paths, symlink entries, interrupted rollbacks, simulated install failures, and concurrency locking.

### Testing
- Executed the new smoke test `tests/blacklist_extract_smoke.php`, which runs multiple archive scenarios and concurrency assertions, and it passed all checks.
- No other automated test suites were modified or required for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1db8ba3a24832e9c7478b01dd53a28)