### PR TITLE
Fix E2guardian blacklist extraction path and bump port to 6.6.19

### DIFF
--- a/www/Kontrol-pkg-E2guardian54/Makefile
+++ b/www/Kontrol-pkg-E2guardian54/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	Kontrol-pkg-E2guardian54
-PORTVERSION=	6.6.18
+PORTVERSION=	6.6.19
 PORTREVISION=	# empty
 CATEGORIES=	www
 MASTER_SITES=	# empty

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/www/e2guardian.php
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/www/e2guardian.php
@@ -115,26 +115,75 @@ function e2g_blacklist_create_temp_dir() {
         return $temp_dir;
 }
 
-function e2g_blacklist_prepare_tree($temp_dir) {
-        $entries = array_values(array_diff(scandir($temp_dir), array('.', '..')));
-        if (empty($entries)) {
+function e2g_blacklist_tree_has_lists($dir) {
+        if (!is_dir($dir)) {
                 return false;
         }
-        if (count($entries) === 1 && $entries[0] === 'blacklists' && is_dir($temp_dir . '/blacklists')) {
-                return $temp_dir . '/blacklists';
+        if (is_file($dir . '/global_usage')) {
+                return true;
         }
-        if (count($entries) === 1 && is_dir($temp_dir . '/' . $entries[0])) {
-                return $temp_dir . '/' . $entries[0];
+        foreach (array_diff(scandir($dir), array('.', '..')) as $entry) {
+                $path = $dir . '/' . $entry;
+                if (is_file($path) && in_array($entry, array('domains', 'urls'), true)) {
+                        return true;
+                }
+                if (is_dir($path) && e2g_blacklist_tree_has_lists($path)) {
+                        return true;
+                }
+        }
+        return false;
+}
+
+function e2g_blacklist_find_source_dir($temp_dir) {
+        $candidates = array(
+                $temp_dir . '/BL',
+                $temp_dir . '/blacklists/BL',
+                $temp_dir . '/blacklists'
+        );
+        foreach ($candidates as $candidate) {
+                if (e2g_blacklist_tree_has_lists($candidate)) {
+                        return $candidate;
+                }
         }
 
+        $dirs = array();
+        foreach (array_diff(scandir($temp_dir), array('.', '..')) as $entry) {
+                $path = $temp_dir . '/' . $entry;
+                if (is_dir($path)) {
+                        $dirs[] = $path;
+                }
+        }
+        if (count($dirs) === 1 && e2g_blacklist_tree_has_lists($dirs[0])) {
+                return $dirs[0];
+        }
+        if (e2g_blacklist_tree_has_lists($temp_dir)) {
+                return $temp_dir;
+        }
+        return false;
+}
+
+function e2g_blacklist_prepare_tree($temp_dir) {
+        $source_dir = e2g_blacklist_find_source_dir($temp_dir);
+        if ($source_dir === false || !is_dir($source_dir)) {
+                return false;
+        }
         $prepared_dir = $temp_dir . '/.prepared-blacklists';
         if (!@mkdir($prepared_dir, 0700)) {
                 return false;
         }
-        foreach ($entries as $entry) {
-                if (!@rename($temp_dir . '/' . $entry, $prepared_dir . '/' . $entry)) {
+        if ($source_dir === $temp_dir) {
+                if (!@mkdir($prepared_dir . '/BL', 0700)) {
                         return false;
                 }
+                foreach (array_diff(scandir($temp_dir), array('.', '..', '.prepared-blacklists')) as $entry) {
+                        if (!@rename($temp_dir . '/' . $entry, $prepared_dir . '/BL/' . $entry)) {
+                                return false;
+                        }
+                }
+                return $prepared_dir;
+        }
+        if (!@rename($source_dir, $prepared_dir . '/BL')) {
+                return false;
         }
         return $prepared_dir;
 }
@@ -223,8 +272,14 @@ function extract_black_list($log_notice = true, $lock_handle = null, $options = 
                 $lists_dir = $options['lists_dir'] ?? E2GUARDIAN_ETCDIR . "/lists";
                 $blacklists_dir = $lists_dir . '/blacklists';
                 $blacklists_old_dir = $lists_dir . '/blacklists.old';
+                $target_bl_dir = $blacklists_dir . '/BL';
+                $backup_bl_dir = $blacklists_dir . '/BL.old.' . getmypid();
                 if (!is_dir($lists_dir) && !@mkdir($lists_dir, 0755, true)) {
                         e2g_blacklist_notice("Could not create the E2guardian lists directory.");
+                        return false;
+                }
+                if (!is_dir($blacklists_dir) && !@mkdir($blacklists_dir, 0755, true)) {
+                        e2g_blacklist_notice("Could not create the E2guardian blacklist directory.");
                         return false;
                 }
 
@@ -245,24 +300,23 @@ function extract_black_list($log_notice = true, $lock_handle = null, $options = 
                         return false;
                 }
 
-                if (is_dir($blacklists_old_dir)) {
-                        if (!is_dir($blacklists_dir)) {
-                                if (!@rename($blacklists_old_dir, $blacklists_dir)) {
-                                        e2g_blacklist_notice("Could not restore the previous blacklist tree.");
-                                        return false;
-                                }
-                        } else {
-                                e2g_delTree($blacklists_old_dir);
+                if (is_dir($blacklists_old_dir) && !is_dir($target_bl_dir)) {
+                        if (!@rename($blacklists_old_dir, $target_bl_dir)) {
+                                e2g_blacklist_notice("Could not restore the previous blacklist tree.");
+                                return false;
                         }
+                } elseif (is_dir($blacklists_old_dir)) {
+                        e2g_delTree($blacklists_old_dir);
                 }
-                if (is_dir($blacklists_dir) && !@rename($blacklists_dir, $blacklists_old_dir)) {
+                e2g_delTree($backup_bl_dir);
+                if (is_dir($target_bl_dir) && !@rename($target_bl_dir, $backup_bl_dir)) {
                         e2g_blacklist_notice("Could not preserve the previous blacklist tree.");
                         return false;
                 }
                 $simulate_install_failure = !empty($options['simulate_install_failure']);
-                if ($simulate_install_failure || !@rename($prepared_dir, $blacklists_dir)) {
-                        if (!is_dir($blacklists_dir) && is_dir($blacklists_old_dir)) {
-                                @rename($blacklists_old_dir, $blacklists_dir);
+                if ($simulate_install_failure || !@rename($prepared_dir . '/BL', $target_bl_dir)) {
+                        if (!is_dir($target_bl_dir) && is_dir($backup_bl_dir)) {
+                                @rename($backup_bl_dir, $target_bl_dir);
                         }
                         e2g_blacklist_notice("Could not install the new blacklist tree; the previous tree was restored.");
                         return false;
@@ -271,8 +325,8 @@ function extract_black_list($log_notice = true, $lock_handle = null, $options = 
                 if (empty($options['skip_read_lists'])) {
                         read_lists($log_notice);
                 }
-                if (is_dir($blacklists_old_dir)) {
-                        e2g_delTree($blacklists_old_dir);
+                if (is_dir($backup_bl_dir)) {
+                        e2g_delTree($backup_bl_dir);
                 }
                 return true;
         } finally {
@@ -289,7 +343,8 @@ function read_lists($log_notice=true, $uw="") {
         $dir = E2GUARDIAN_ETCDIR . "/lists";
         $groups = array("phraselists", "blacklists", "whitelists");
         $liston = $config['installedpackages']['e2guardianblacklist']['config'][0]['liston'] ?? 'banned';
-        $metadata = e2g_parse_blacklist_metadata($dir . '/blacklists');
+        $blacklist_root = (is_dir($dir . '/blacklists/BL') ? $dir . '/blacklists/BL' : $dir . '/blacklists');
+        $metadata = e2g_parse_blacklist_metadata($blacklist_root);
 
         foreach ($config['installedpackages'] as $key => $values) {
                 if (preg_match("/e2guardian(phrase|black|white)lists/", $key)) {
@@ -309,11 +364,16 @@ function read_lists($log_notice=true, $uw="") {
                         continue;
                 }
 
-                $lists = array_diff(scandir($group_dir), array('.', '..'));
+                $scan_dir = $group_dir;
+                if ($group === 'blacklists' && is_dir($group_dir . '/BL')) {
+                        $scan_dir = $group_dir . '/BL';
+                }
+
+                $lists = array_diff(scandir($scan_dir), array('.', '..'));
                 foreach ($lists as $list) {
-                        $path = $group_dir . '/' . $list;
+                        $path = $scan_dir . '/' . $list;
                         if (is_dir($path)) {
-                                e2g_collect_category($collection, $group_dir, $group, array($list), $liston, $metadata);
+                                e2g_collect_category($collection, $scan_dir, $group, array($list), $liston, $metadata);
                         } else {
                                 e2g_register_list_file($collection, $group, array($list), $path, $list, $liston, $metadata);
                         }

--- a/www/Kontrol-pkg-E2guardian54/tests/blacklist_extract_smoke.php
+++ b/www/Kontrol-pkg-E2guardian54/tests/blacklist_extract_smoke.php
@@ -97,8 +97,8 @@ try {
                 make_tree($base);
                 assert_true(update_with($base, create_archive($base, $scenario, $entries)), "{$scenario} update failed");
                 assert_preserved($base . '/lists');
-                assert_true(is_file($base . '/lists/blacklists/new-category/domains'), "{$scenario} domains missing");
-                assert_true(is_file($base . '/lists/blacklists/new-category/urls'), "{$scenario} urls missing");
+                assert_true(is_file($base . '/lists/blacklists/BL/new-category/domains'), "{$scenario} domains missing");
+                assert_true(is_file($base . '/lists/blacklists/BL/new-category/urls'), "{$scenario} urls missing");
         }
 
         $base = $root . '/corrupt';
@@ -155,14 +155,14 @@ try {
         rename($base . '/lists/blacklists', $base . '/lists/blacklists.old');
         $archive = create_archive($base, 'interrupted-rollback', array('BL/new-category/domains'));
         assert_true(update_with($base, $archive), 'update did not recover interrupted rollback');
-        assert_true(is_file($base . '/lists/blacklists/new-category/domains'), 'recovered update did not install new blacklist');
+        assert_true(is_file($base . '/lists/blacklists/BL/new-category/domains'), 'recovered update did not install new blacklist');
         assert_preserved($base . '/lists');
 
         $base = $root . '/rollback';
         make_tree($base);
         $archive = create_archive($base, 'rollback', array('BL/new-category/domains'));
         assert_true(!update_with($base, $archive, array('simulate_install_failure' => true)), 'simulated install failure unexpectedly succeeded');
-        assert_true(is_file($base . '/lists/blacklists/old-category/domains'), 'rollback did not restore previous blacklist');
+        assert_true(is_file($base . '/lists/blacklists/old-category/domains'), 'rollback did not preserve previous legacy blacklist');
         assert_true(!is_dir($base . '/lists/blacklists.old'), 'rollback left blacklists.old behind');
         assert_preserved($base . '/lists');
 


### PR DESCRIPTION
### Motivation
- Backport and adapt the RELENG_2_7_2 fix that resolves a critical blacklist update/extraction path problem so downloaded blacklists are staged and installed consistently without corrupting existing managed lists. 
- Ensure new behavior normalizes incoming archive contents into a single `BL` tree while preserving legacy layouts and safe rollback semantics.

### Description
- Added `e2g_blacklist_tree_has_lists` and `e2g_blacklist_find_source_dir` to detect safe blacklist content layouts and locate the correct source directory inside extracted archives.
- Reworked `e2g_blacklist_prepare_tree` to stage archive content under a `.prepared-blacklists/BL` directory and to handle archives that already contain `BL`, `blacklists/BL`, `blacklists`, or direct category trees.
- Updated `extract_black_list` to create and use `lists/blacklists/BL`, backup the previous `BL` into `BL.old.<pid>`, and restore on failure, while avoiding moving other managed files; added safer temp/backup cleanup.
- Updated `read_lists` to prefer `lists/blacklists/BL` when present (with fallback to legacy `lists/blacklists`) and adjusted category discovery to scan the normalized `BL` subtree.
- Bumped the port `PORTVERSION` from `6.6.18` to `6.6.19` in `Makefile` to allow rebuilds.
- Updated the smoke test `tests/blacklist_extract_smoke.php` to assert the new `BL` staging/installation path and refined a rollback assertion message.

### Testing
- Ran the extraction smoke test `php www/Kontrol-pkg-E2guardian54/tests/blacklist_extract_smoke.php`, which reported `PASS: blacklist extraction smoke tests`.
- Performed PHP syntax checks with `php -l` on `www/Kontrol-pkg-E2guardian54/files/usr/local/www/e2guardian.php` and on the test script, both returning no syntax errors.
- Ran `git diff --check` to ensure no whitespace/cleanup issues were introduced; no problems found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a386107bc60832e99f033c808d13680)