### PR TITLE
Fix E2guardian blacklist update sequencing

### DIFF
--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc
@@ -2206,16 +2206,17 @@ EOF;
 	file_put_contents("/root/e2guardian_custom.script", base64_decode($e2guardian_blacklist['custom_script']), LOCK_EX);
 	if ($_POST["force_download"]) {
 		log_error("Blacklist update process started");
-		file_notice("E2guardian",$error,"E2guardian - " . gettext("Blacklist update process started"), "");
+		file_notice("E2guardian", $error, "E2guardian - " . gettext("Blacklist update process started"), "");
 		if ($e2guardian_blacklist['enable_custom_script']) {
 			mwexec_bg("/root/e2guardian_custom.script");
-                } else {
-                        mwexec_bg(E2GUARDIAN_BINDIR . "/php " . E2GUARDIAN_WWWDIR . "/e2guardian.php fetch_blacklist");
-                }
+		} else {
+			require_once(E2GUARDIAN_WWWDIR . "/e2guardian.php");
+			fetch_blacklist();
+		}
 	}
 
 	//Update blacklist categories on Acls
-	if ($_POST["force_update"] || $_POST["liston"]) {
+	if (!$_POST["force_download"] && ($_POST["force_update"] || $_POST["liston"])) {
 		require_once(E2GUARDIAN_WWWDIR . "/e2guardian.php");
 		extract_black_list();
 	}
@@ -2918,12 +2919,12 @@ function isValidXmlElementName($elementName)
 }
 
 function e2guardian_php_install_command() {
-	sync_package_e2guardian("no", true);
 	echo "Checking Blacklist...\n";
 	require_once(E2GUARDIAN_WWWDIR . "/e2guardian.php");
 
 	fetch_blacklist(false, true);
-        echo "Blacklist check done, continuing package config sync.\n";
+	echo "Blacklist check done, continuing package config sync.\n";
+	sync_package_e2guardian("no", true);
 	clear_subsystem_dirty('e2guardian');
 }
 

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/www/e2guardian.php
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/www/e2guardian.php
@@ -65,6 +65,13 @@ function e2g_blacklist_unlock($lock_handle) {
         }
 }
 
+function e2g_blacklist_reload_service() {
+        if (function_exists('e2guardian_start') && is_process_running('e2guardian')) {
+                e2g_log_info("E2guardian - reloading service after blacklist update.");
+                e2guardian_start("no", false, true);
+        }
+}
+
 function e2g_blacklist_remove_temp_dir($temp_dir) {
         if (!is_string($temp_dir) || !is_dir($temp_dir)) {
                 return;
@@ -317,6 +324,9 @@ function extract_black_list($log_notice = true, $lock_handle = null, $options = 
 
                 if (empty($options['skip_read_lists'])) {
                         read_lists($log_notice);
+                        if (empty($options['skip_reload'])) {
+                                e2g_blacklist_reload_service();
+                        }
                 }
                 if (is_dir($backup_bl_dir)) {
                         e2g_delTree($backup_bl_dir);


### PR DESCRIPTION
### Motivation
- The GUI `Download BlackList` path could start a background fetch and then immediately re-apply/update lists in the same request, producing misleading messages like `Downloaded blacklists not found` and `A blacklist update is already running` and leaving E2guardian running against an empty/stale tree.
- After a successful blacklist extraction the running e2guardian process was not automatically reloaded, forcing a manual service restart for new categories to take effect.
- During package install the service could be started before a downloaded blacklist was applied, risking an empty lists tree at startup.

### Description
- Make the GUI `force_download` flow call the built-in `fetch_blacklist()` synchronously instead of launching a background `mwexec_bg` fetch, so the save request waits for download/extract to complete (`www/.../e2guardian.inc`).
- Prevent re-applying categories during the same POST that triggered `force_download` by skipping `extract_black_list()` when `force_download` is present, avoiding overlapping update paths (`www/.../e2guardian.inc`).
- Add `e2g_blacklist_reload_service()` and call it after `read_lists()` inside `extract_black_list()` unless `skip_reload` is set, so the daemon is soft-restarted and new categories are applied without a manual restart (`www/.../e2guardian.php`).
- During package install, run `fetch_blacklist()` before calling `sync_package_e2guardian()` so the package sync/start sequence sees the populated blacklist tree (`www/.../e2guardian.inc`).
- Modified files: `files/usr/local/www/e2guardian.php` and `files/usr/local/pkg/e2guardian.inc`.

### Testing
- Linted PHP files with `php -l www/Kontrol-pkg-E2guardian54/files/usr/local/www/e2guardian.php` and `php -l www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc`, both returned no syntax errors.
- Ran the smoke extraction test `www/Kontrol-pkg-E2guardian54/tests/blacklist_extract_smoke.php` and it passed.
- Verified the updated control flows in the modified files (sanity checks) and ensured the changes do not introduce syntax issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c943faadc832e92db9fe0c345c93b)