### PR TITLE
Call fetch_blacklist() inline, reload e2guardian after blacklist update, and adjust install flow

### DIFF
--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc
@@ -2206,16 +2206,17 @@ EOF;
 	file_put_contents("/root/e2guardian_custom.script", base64_decode($e2guardian_blacklist['custom_script']), LOCK_EX);
 	if ($_POST["force_download"]) {
 		log_error("Blacklist update process started");
-		file_notice("E2guardian",$error,"E2guardian - " . gettext("Blacklist update process started"), "");
+		file_notice("E2guardian", $error, "E2guardian - " . gettext("Blacklist update process started"), "");
 		if ($e2guardian_blacklist['enable_custom_script']) {
 			mwexec_bg("/root/e2guardian_custom.script");
-                } else {
-                        mwexec_bg(E2GUARDIAN_BINDIR . "/php " . E2GUARDIAN_WWWDIR . "/e2guardian.php fetch_blacklist");
-                }
+		} else {
+			require_once(E2GUARDIAN_WWWDIR . "/e2guardian.php");
+			fetch_blacklist();
+		}
 	}
 
 	//Update blacklist categories on Acls
-	if ($_POST["force_update"] || $_POST["liston"]) {
+	if (!$_POST["force_download"] && ($_POST["force_update"] || $_POST["liston"])) {
 		require_once(E2GUARDIAN_WWWDIR . "/e2guardian.php");
 		extract_black_list();
 	}
@@ -2918,12 +2919,12 @@ function isValidXmlElementName($elementName)
 }
 
 function e2guardian_php_install_command() {
-	sync_package_e2guardian("no", true);
 	echo "Checking Blacklist...\n";
 	require_once(E2GUARDIAN_WWWDIR . "/e2guardian.php");
 
 	fetch_blacklist(false, true);
-        echo "Blacklist check done, continuing package config sync.\n";
+	echo "Blacklist check done, continuing package config sync.\n";
+	sync_package_e2guardian("no", true);
 	clear_subsystem_dirty('e2guardian');
 }
 

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/www/e2guardian.php
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/www/e2guardian.php
@@ -65,6 +65,26 @@ function e2g_blacklist_unlock($lock_handle) {
         }
 }
 
+function e2g_blacklist_reload_service() {
+        if (!function_exists('is_process_running') || !is_process_running('e2guardian')) {
+                return;
+        }
+
+        e2g_log_info("E2guardian - restarting service after blacklist update.");
+        if (function_exists('e2g_stop_watchdog_processes')) {
+                e2g_stop_watchdog_processes();
+        }
+
+        $script = E2GUARDIAN_RCDIR . '/e2guardian.sh';
+        if (file_exists($script)) {
+                mwexec($script . ' stop');
+                sleep(2);
+                mwexec_bg($script . ' start');
+        } elseif (function_exists('e2guardian_start')) {
+                e2guardian_start("no", false, true);
+        }
+}
+
 function e2g_blacklist_remove_temp_dir($temp_dir) {
         if (!is_string($temp_dir) || !is_dir($temp_dir)) {
                 return;
@@ -317,6 +337,9 @@ function extract_black_list($log_notice = true, $lock_handle = null, $options = 
 
                 if (empty($options['skip_read_lists'])) {
                         read_lists($log_notice);
+                        if (empty($options['skip_reload'])) {
+                                e2g_blacklist_reload_service();
+                        }
                 }
                 if (is_dir($backup_bl_dir)) {
                         e2g_delTree($backup_bl_dir);


### PR DESCRIPTION
### Motivation

- Replace background PHP invocation for blacklist fetching with an inline call to avoid spawning extra processes and to allow better control of the update flow.
- Ensure the e2guardian service is restarted after installing a new blacklist so changes take effect immediately.
- Move package config sync to run after blacklist verification to prevent race conditions during install.

### Description

- Replaced the `mwexec_bg` invocation of the PHP blacklist fetch with `require_once(E2GUARDIAN_WWWDIR . "/e2guardian.php"); fetch_blacklist();` to run the fetch inline.
- Added `e2g_blacklist_reload_service()` to restart the e2guardian service (stops watchdog processes, stops and starts the rc script, or calls `e2guardian_start`) after blacklist installation.
- Updated `extract_black_list()` to call `e2g_blacklist_reload_service()` after `read_lists()` unless the `skip_reload` option is set.
- Prevented redundant `extract_black_list()` execution when a forced download is in progress by adding a guard around the update call in the package management flow (`if (!$_POST["force_download"] && (...) )`).
- Moved the `sync_package_e2guardian("no", true)` call to run after `fetch_blacklist()` in `e2guardian_php_install_command()` so blacklist checking completes before syncing configuration.
- Minor formatting and spacing adjustments to improve code readability.

### Testing

- Ran `php -l` syntax checks on the modified files and observed no parse errors.
- Executed `fetch_blacklist()` in a test environment to verify the inline fetch path completes without spawning background PHP processes and completed successfully.
- Performed an install flow test invoking `e2guardian_php_install_command()` to confirm the blacklist check runs then `sync_package_e2guardian()` and that no fatal errors occurred.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c943faadc832e92db9fe0c345c93b)