### PR TITLE
sysutils/pfSense-upgrade: install pfSense-repo-setup into ${PREFIX}/sbin

### DIFF
--- a/sysutils/pfSense-upgrade/Makefile
+++ b/sysutils/pfSense-upgrade/Makefile
@@ -35,5 +35,7 @@ do-install:
 		${STAGEDIR}${PREFIX}/sbin
 	${INSTALL_SCRIPT} ${WRKSRC}/install-boot.sh \
 		${STAGEDIR}${PREFIX}/libexec
+	${INSTALL_SCRIPT} ${WRKSRC}/pfSense-repo-setup \
+		${STAGEDIR}${PREFIX}/sbin
 
 .include <bsd.port.mk>


### PR DESCRIPTION
### Motivation
- Ensure the file declared in `PLIST_FILES` (`sbin/pfSense-repo-setup`) is actually installed into `${PREFIX}/sbin` during `do-install` to avoid package build failures (pkg-static unable to access the repo setup script).

### Description
- Add installation of `pfSense-repo-setup` from `${WRKSRC}` into `${STAGEDIR}${PREFIX}/sbin` in `sysutils/pfSense-upgrade/Makefile`'s `do-install` target so the packaged file exists at package build time.

### Testing
- Ran `git diff --check` and verified that `sbin/pfSense-repo-setup` appears in `PLIST_FILES` and a matching install line exists in `do-install`, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a63e61117d4832e95c884b2b880fd26)