### PR TITLE
devel/py-maturin: honor upstream Rust MSRV

### DIFF
--- a/devel/py-maturin/Makefile
+++ b/devel/py-maturin/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	maturin
 DISTVERSION=	1.12.6
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	devel python
 MASTER_SITES=	PYPI
 PKGNAMEPREFIX=	${PYTHON_PKGNAMEPREFIX}
@@ -19,7 +19,8 @@ LICENSE_FILE_MIT=	${WRKSRC}/license-mit
 BUILD_DEPENDS=	${PY_SETUPTOOLS} \
 		${PYTHON_PKGNAMEPREFIX}setuptools-rust>=1.4.0:devel/py-setuptools-rust@${PY_FLAVOR} \
 		${PY_TOMLI} \
-		${PYTHON_PKGNAMEPREFIX}wheel>=0.36.2:devel/py-wheel@${PY_FLAVOR}
+		${PYTHON_PKGNAMEPREFIX}wheel>=0.36.2:devel/py-wheel@${PY_FLAVOR} \
+		${RUST_DEFAULT}>=1.88.0:lang/${RUST_DEFAULT}
 LIB_DEPENDS=	libzstd.so:archivers/zstd
 RUN_DEPENDS=	${PY_TOMLI}
 
@@ -27,6 +28,9 @@ USES=		cargo python
 USE_PYTHON=	autoplist concurrent pep517
 
 CARGO_BUILD=	no
+# Keep the dependency aligned with maturin's declared MSRV instead of the
+# newer blanket minimum from cargo.mk.
+CARGO_BUILDDEP=	no
 CARGO_INSTALL=	no
 CARGO_TARGET_DIR=	${WRKSRC}/target
 MAKE_ENV=	${CARGO_ENV}


### PR DESCRIPTION
### Motivation
- The port failed during `build-depends` because `Mk/Uses/cargo.mk` enforces a blanket `rust>=1.94.0` while upstream `maturin` 1.12.6 declares `rust-version = "1.88"`, making the blanket requirement unnecessarily strict.

### Description
- Update `devel/py-maturin/Makefile` to add an explicit build dependency `rust>=1.88.0` so the port follows maturin's declared MSRV.
- Add `CARGO_BUILDDEP=no` in the port to disable the blanket Rust 1.94 requirement applied by `cargo.mk` for this port only and document the rationale inline.
- Increment `PORTREVISION` to `2` to reflect the dependency change.
- No other ports or global `cargo.mk` were changed; this is a targeted exception for `devel/py-maturin`.

### Testing
- Ran `rustup toolchain install 1.89.0 --profile minimal` and `cargo +1.89.0 --version` and `rustc +1.89.0 --version`, all of which completed successfully.
- Performed `cargo +1.89.0 check --locked` against the upstream `maturin-1.12.6` source and the check completed successfully, indicating compatibility with Rust 1.89.
- Ran `git diff --check` and basic repository checks which showed no local formatting errors.
- A full FreeBSD ports `bmake` build could not be executed in this environment because `bmake`/native ports toolchain was not available here, so the native ports build was not run (Cargo-level verification succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a64dadcc118832e8cace7ba9ce8daa2)