### PR TITLE
Relax Rust build-dependency minimum from 1.94.0 to 1.89.0 in cargo.mk

### DIFF
--- a/Mk/Uses/cargo.mk
+++ b/Mk/Uses/cargo.mk
@@ -109,7 +109,7 @@ WRKSRC_crate_${_crate}=	${WRKDIR}/${_wrksrc}
 
 CARGO_BUILDDEP?=	yes
 .  if ${CARGO_BUILDDEP:tl} == "yes"
-BUILD_DEPENDS+=	${RUST_DEFAULT}>=1.94.0:lang/${RUST_DEFAULT}
+BUILD_DEPENDS+=	${RUST_DEFAULT}>=1.89.0:lang/${RUST_DEFAULT}
 .  elif ${CARGO_BUILDDEP:tl} == "any-version"
 BUILD_DEPENDS+=	${RUST_DEFAULT}>=0:lang/${RUST_DEFAULT}
 .  endif


### PR DESCRIPTION
### Motivation
- Allow packages using the Cargo support to build with older Rust toolchains by lowering the minimum required `lang/${RUST_DEFAULT}` from `1.94.0` to `1.89.0` to increase compatibility with available toolchains.

### Description
- Updated the build-dependency requirement in `Mk/Uses/cargo.mk` so `BUILD_DEPENDS+= ${RUST_DEFAULT}>=1.89.0:lang/${RUST_DEFAULT}` replaces the previous `>=1.94.0` constraint.

### Testing
- No automated test suite was executed for this Makefile change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a64dadcc118832e8cace7ba9ce8daa2)