### PR TITLE
sysutils/pfSense-upgrade: remove obsolete pfSense runtime dependencies

### DIFF
--- a/sysutils/pfSense-upgrade/Makefile
+++ b/sysutils/pfSense-upgrade/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	Kontrol-upgrade
 PORTVERSION=	2.9.0
+PORTREVISION=	1
 CATEGORIES=	sysutils
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/sysutils/pfSense-upgrade/files/Kontrol-upgrade
+++ b/sysutils/pfSense-upgrade/files/Kontrol-upgrade
@@ -771,16 +771,6 @@ pkg_upgrade() {
 		fi
 
 		local _meta_pkg=$(get_meta_pkg_name)
-		if [ "${platform}" = "nanobsd" ]; then
-			_echo "**** WARNING ****"
-			_echo ""
-			_echo "NanoBSD platform is no longer supported."
-			_echo ""
-			_echo "You can find instructions on how to convert it"
-			    "to Full Installation at http://bit.ly/2wDinm8"
-			_exit 1
-		fi
-
 		# ZFS panics with reroot, do not use it in this case
 		# https://redmine.pfsense.org/issues/6045
 		if ! kldstat -qm zfs; then
@@ -1402,7 +1392,6 @@ export product=$(php -n /usr/local/sbin/read_global_var product_name Kontrol)
 export product_label=$(php -n /usr/local/sbin/read_global_var product_label Kontrol)
 export pkg_prefix=$(php -n /usr/local/sbin/read_global_var pkg_prefix \
     Kontrol-pkg-)
-export platform=$(cat /etc/platform)
 
 USE_MFS_TMPVAR=$(read_xml_tag.sh boolean system/use_mfs_tmpvar)
 if [ "${USE_MFS_TMPVAR}" = "true" -a ! -e /conf/ram_disks_failed ]; then
@@ -1411,13 +1400,9 @@ if [ "${USE_MFS_TMPVAR}" = "true" -a ! -e /conf/ram_disks_failed ]; then
 fi
 
 product_version=$(cat /etc/version)
-do_not_send_uniqueid=$(read_xml_tag.sh boolean system/do_not_send_uniqueid)
-if [ "${do_not_send_uniqueid}" != "true" ]; then
-	uniqueid=$(gnid)
-	export HTTP_USER_AGENT="${product}/${product_version}:${uniqueid}"
-else
-	export HTTP_USER_AGENT="${product}/${product_version}"
-fi
+# Keep a stable user agent without coupling update checks to the proprietary
+# pfSense unique-identifier executable, which is not shipped by Kontrol.
+export HTTP_USER_AGENT="${product}/${product_version}"
 
 validate_repo_conf
 


### PR DESCRIPTION
### Motivation
- The Kontrol port used pfSense-specific runtime artifacts that are not present in Kontrol images, causing upgrade detection failures and runtime errors.
- Remove references to missing files and proprietary binaries so the port works on Kontrol installations and can be adapted for the 2.9.0 release.
- Bump the package revision so already-installed Kontrol 2.9.0 users will receive the corrected package.

### Description
- Increment `PORTREVISION` to `1` in `sysutils/pfSense-upgrade/Makefile` so fixed installs are picked up by package managers.
- Remove reading of `/etc/platform` and the NanoBSD-specific guard from `files/Kontrol-upgrade` because Kontrol does not ship `/etc/platform` and NanoBSD checks are not applicable.
- Remove invocation of the proprietary `gnid` executable and always export a stable `HTTP_USER_AGENT` as `"${product}/${product_version}"` to avoid depending on pfSense-only tooling.
- Minor cleanup to ensure the upgrade script no longer references `/etc/platform` or `gnid` anywhere in the port files.

### Testing
- Ran shell syntax checks with `sh -n sysutils/pfSense-upgrade/files/Kontrol-upgrade sysutils/pfSense-upgrade/files/Kontrol-upgrade.wrapper sysutils/pfSense-upgrade/files/Kontrol-repo-setup` and it completed without syntax errors (success).
- Ran `git diff --check` to validate the patch formatting and found no whitespace or patch issues (success).
- Searched for removed proprietary references with `rg -n 'gnid|/etc/platform' sysutils/pfSense-upgrade` and confirmed there are no remaining references (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a675df58b14832e82fe9d4296526ebf)