### PR TITLE
security/pfSense: avoid kernel ABI package suffix

### DIFF
--- a/security/pfSense/Makefile
+++ b/security/pfSense/Makefile
@@ -82,7 +82,7 @@ RUN_DEPENDS=	bind-tools>=0:dns/bind-tools \
 
 LIB_DEPENDS=	libltdl.so:devel/libltdl
 
-USES=		kmod php:flavors
+USES=		php:flavors
 
 IGNORE_WITH_PHP=	72 73 74 80 81 82
 USE_PHP=	bz2 bcmath ctype curl dom filter gettext gmp intl json mbstring \


### PR DESCRIPTION
### Motivation
- O `USES=kmod` ativava `Mk/Uses/kmod.mk`, que acrescenta `.${OSVERSION}` ao `PKGVERSION` e gerava nomes de pacote como `Kontrol-2.9.0.1600014.pkg` em vez de `Kontrol-2.9.0.pkg`.

### Description
- Removido `kmod` de `USES` em `security/pfSense/Makefile`, deixando `USES= php:flavors`, já que o port tem `NO_BUILD=yes` e não instala módulos de kernel.

### Testing
- Executados `git diff --check`, verificação do conteúdo de `security/pfSense/Makefile`, `rg` para confirmar ausência de `kmod`, `git status` e o commit foi aplicado com sucesso; a tentativa de usar `make -C security/pfSense -V PKGNAME -V PKGVERSION -V _OS_SUFX` foi ignorada por não ser possível executar o `make` do FreeBSD neste ambiente Linux.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6766b86e30832ebce7d6a925b1bda8)