### PR TITLE
www/e2guardian54: atualizar RUN_DEPENDS para security/openssl e incrementar PORTREVISION

### DIFF
--- a/www/e2guardian54/Makefile
+++ b/www/e2guardian54/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	e2guardian
 PORTVERSION=	5.4.18
-PORTREVISION=   # empty
+PORTREVISION=   1
 DISTVERSIONPREFIX=	v
 CATEGORIES=	www
 GH_ACCOUNT=    kontrol-br
@@ -14,7 +14,7 @@ WWW=		https://e2guardian.org
 
 LICENSE=	GPLv2
 
-RUN_DEPENDS+=   openssl111>=1.1.1w_2:security/openssl111
+RUN_DEPENDS+=   openssl>=1.1.1w_2:security/openssl
 
 LIB_DEPENDS=	libpcre.so:devel/pcre
 


### PR DESCRIPTION
### Motivation
- O port referenciava `security/openssl111` que está listado em `MOVED` como movido para `security/openssl`, o que provoca remoção/recompilação recorrente em builds incrementais do Poudriere.
- Atualizar a origem da dependência para a origem atual evita a remoção de pacotes existentes e estabiliza a resolução de dependências.

### Description
- Substituído `RUN_DEPENDS+=   openssl111>=1.1.1w_2:security/openssl111` por `RUN_DEPENDS+=   openssl>=1.1.1w_2:security/openssl` no `www/e2guardian54/Makefile` mantendo a restrição de versão mínima `>=1.1.1w_2`.
- Incrementado `PORTREVISION` de vazio para `1` devido à alteração dos metadados de dependência.
- Verificado o `security/openssl/Makefile`, que declara `PORTNAME=openssl` e `PORTVERSION=1.1.1w`, confirmando que o nome do pacote usado à esquerda de `RUN_DEPENDS` é `openssl`.
- Confirmado que não restam referências ativas a `security/openssl111` em `www/e2guardian54` (apenas menção descritiva em `BROKEN_SSL_REASON` permanece).

### Testing
- Executado `git diff --check` e não foram encontrados erros de formatação ou espaços em branco; comando sucedeu.
- Verificada a ausência de referências ativas com `rg -n '^[[:space:]]*(RUN|BUILD|LIB|TEST|FETCH|PATCH)_DEPENDS.*security/openssl111' www/e2guardian54`, que retornou nada (sucesso).
- Inspecionado o diff final com `git diff -- www/e2guardian54/Makefile`, que contém apenas a alteração de `RUN_DEPENDS` e o incremento de `PORTREVISION` (sucesso).
- Tentativas de avaliar variáveis do framework com `bmake -m ... -C ... -V PKGNAME` e `bmake -C ... -V` foram feitas, porém a avaliação completa do framework falhou neste ambiente Linux porque o FreeBSD ports framework requer um host FreeBSD (observado como falha/limitação do ambiente); `portlint` também não está instalado neste ambiente (não executado).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6bb46e30e8832e9d26ecc051ebc5fc)