### PR TITLE
www/Kontrol-pkg-E2guardian54: describe package configuration writes

### DIFF
--- a/www/Kontrol-pkg-E2guardian54/Makefile
+++ b/www/Kontrol-pkg-E2guardian54/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	Kontrol-pkg-E2guardian54
 PORTVERSION=	6.6.26
-PORTREVISION=	# empty
+PORTREVISION=	1
 CATEGORIES=	www
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.xml
@@ -32,6 +32,8 @@
 	<name>e2guardian</name>
 	<version>0.9.2</version>
 	<title>Services: E2guardian</title>
+	<delete_string>E2guardian: removed a configuration item.</delete_string>
+	<addedit_string>E2guardian: changed settings.</addedit_string>
 	<include_file>/usr/local/pkg/e2guardian.inc</include_file>
 	<menu>
 		<name>E2guardian Proxy</name>

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_antivirus_acl.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_antivirus_acl.xml
@@ -31,6 +31,8 @@
 	<name>e2guardianantivirusacl</name>
 	<version>1.0</version>
 	<title>Services: E2guardian - Access Lists</title>
+	<delete_string>E2guardian: removed a configuration item.</delete_string>
+	<addedit_string>E2guardian: changed settings.</addedit_string>
 	<include_file>/usr/local/pkg/e2guardian.inc</include_file>
 	<tabs>
 		<tab>

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_blacklist.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_blacklist.xml
@@ -32,6 +32,8 @@
 	<name>e2guardianblacklist</name>
 	<version>1.0</version>
 	<title>Services: E2guardian</title>
+	<delete_string>E2guardian: removed a configuration item.</delete_string>
+	<addedit_string>E2guardian: changed settings.</addedit_string>
 	<include_file>/usr/local/pkg/e2guardian.inc</include_file>
 	<tabs>
 		<tab>

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_config.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_config.xml
@@ -32,6 +32,8 @@
 	<name>e2guardianconfig</name>
 	<version>1.0</version>
 	<title>Services: E2guardian</title>
+	<delete_string>E2guardian: removed a configuration item.</delete_string>
+	<addedit_string>E2guardian: changed settings.</addedit_string>
 	<include_file>/usr/local/pkg/e2guardian.inc</include_file>
 	<tabs>
 		<tab>

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_content_acl.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_content_acl.xml
@@ -31,6 +31,8 @@
 	<name>e2guardiancontentacl</name>
 	<version>1.0</version>
 	<title>Services: E2guardian - Access Lists</title>
+	<delete_string>E2guardian: removed a configuration item.</delete_string>
+	<addedit_string>E2guardian: changed settings.</addedit_string>
 	<include_file>/usr/local/pkg/e2guardian.inc</include_file>
 	<tabs>
 		<tab>

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_file_acl.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_file_acl.xml
@@ -31,6 +31,8 @@
 	<name>e2guardianfileacl</name>
 	<version>1.0</version>
 	<title>Services: E2guardian - Access Lists</title>
+	<delete_string>E2guardian: removed a configuration item.</delete_string>
+	<addedit_string>E2guardian: changed settings.</addedit_string>
 	<include_file>/usr/local/pkg/e2guardian.inc</include_file>
 	<tabs>
 		<tab>

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_groups.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_groups.xml
@@ -31,6 +31,8 @@
 	<name>e2guardiangroups</name>
 	<version>1.0</version>
 	<title>Services: E2guardian</title>
+	<delete_string>E2guardian: removed a configuration item.</delete_string>
+	<addedit_string>E2guardian: changed settings.</addedit_string>
 	<include_file>/usr/local/pkg/e2guardian.inc</include_file>
 	<tabs>
 		<tab>

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_header_acl.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_header_acl.xml
@@ -31,6 +31,8 @@
 	<name>e2guardianheaderacl</name>
 	<version>1.0</version>
 	<title>Services: E2guardian - Access Lists</title>
+	<delete_string>E2guardian: removed a configuration item.</delete_string>
+	<addedit_string>E2guardian: changed settings.</addedit_string>
 	<include_file>/usr/local/pkg/e2guardian.inc</include_file>
 	<tabs>
 		<tab>

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_ips.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_ips.xml
@@ -32,6 +32,8 @@
 	<name>e2guardianips</name>
 	<version>1.0</version>
 	<title>Services: E2guardian</title>
+	<delete_string>E2guardian: removed a configuration item.</delete_string>
+	<addedit_string>E2guardian: changed settings.</addedit_string>
 	<include_file>/usr/local/pkg/e2guardian.inc</include_file>
 	<tabs>
 		<tab>

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_ldap.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_ldap.xml
@@ -31,6 +31,8 @@
 	<name>e2guardianldap</name>
 	<version>1.0</version>
 	<title>Services: E2guardian</title>
+	<delete_string>E2guardian: removed a configuration item.</delete_string>
+	<addedit_string>E2guardian: changed settings.</addedit_string>
 	<include_file>/usr/local/pkg/e2guardian.inc</include_file>
 	<tabs>
 		<tab>

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_limits.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_limits.xml
@@ -32,6 +32,8 @@
 	<name>e2guardianlimits</name>
 	<version>1.0</version>
 	<title>Services: E2guardian</title>
+	<delete_string>E2guardian: removed a configuration item.</delete_string>
+	<addedit_string>E2guardian: changed settings.</addedit_string>
 	<include_file>/usr/local/pkg/e2guardian.inc</include_file>
 	<tabs>
 		<tab>

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_log.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_log.xml
@@ -32,6 +32,8 @@
 	<name>e2guardianlog</name>
 	<version>1.0</version>
 	<title>Services: E2guardian</title>
+	<delete_string>E2guardian: removed a configuration item.</delete_string>
+	<addedit_string>E2guardian: changed settings.</addedit_string>
 	<include_file>/usr/local/pkg/e2guardian.inc</include_file>
 	<tabs>
 		<tab>

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_phrase_acl.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_phrase_acl.xml
@@ -31,6 +31,8 @@
 	<name>e2guardianphraseacl</name>
 	<version>1.0</version>
 	<title>Services: E2guardian - Access Lists</title>
+	<delete_string>E2guardian: removed a configuration item.</delete_string>
+	<addedit_string>E2guardian: changed settings.</addedit_string>
 	<include_file>/usr/local/pkg/e2guardian.inc</include_file>
 	<tabs>
 		<tab>

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_search_acl.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_search_acl.xml
@@ -31,6 +31,8 @@
 	<name>e2guardiansearchacl</name>
 	<version>1.0</version>
 	<title>Services: E2guardian - Access Lists</title>
+	<delete_string>E2guardian: removed a configuration item.</delete_string>
+	<addedit_string>E2guardian: changed settings.</addedit_string>
 	<include_file>/usr/local/pkg/e2guardian.inc</include_file>
 	<tabs>
 		<tab>

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_site_acl.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_site_acl.xml
@@ -31,6 +31,8 @@
 	<name>e2guardiansiteacl</name>
 	<version>1.0</version>
 	<title>Services: E2guardian - Access Lists</title>
+	<delete_string>E2guardian: removed a configuration item.</delete_string>
+	<addedit_string>E2guardian: changed settings.</addedit_string>
 	<include_file>/usr/local/pkg/e2guardian.inc</include_file>
 	<tabs>
 		<tab>

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_sync.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_sync.xml
@@ -32,6 +32,8 @@
 	<name>e2guardiansync</name>
 	<version>1.0</version>
 	<title>Services: E2guardian</title>
+	<delete_string>E2guardian: removed a configuration item.</delete_string>
+	<addedit_string>E2guardian: changed settings.</addedit_string>
 	<include_file>/usr/local/pkg/e2guardian.inc</include_file>
 	<tabs>
 		<tab>

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_url_acl.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_url_acl.xml
@@ -31,6 +31,8 @@
 	<name>e2guardianurlacl</name>
 	<version>1.0</version>
 	<title>Services: E2guardian - Access Lists</title>
+	<delete_string>E2guardian: removed a configuration item.</delete_string>
+	<addedit_string>E2guardian: changed settings.</addedit_string>
 	<include_file>/usr/local/pkg/e2guardian.inc</include_file>
 	<tabs>
 		<tab>

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_users.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_users.xml
@@ -32,6 +32,8 @@
 	<name>e2guardianusers</name>
 	<version>1.0</version>
 	<title>Services: E2guardian</title>
+	<delete_string>E2guardian: removed a configuration item.</delete_string>
+	<addedit_string>E2guardian: changed settings.</addedit_string>
 	<include_file>/usr/local/pkg/e2guardian.inc</include_file>
 	<tabs>
 		<tab>


### PR DESCRIPTION
### Motivation

- Eliminar o aviso `write_config() was called without description` garantindo que o `write_config()` receba uma descrição sempre que configurações de pacote forem salvas ou removidas. 
- A correção precisava ser mínima e não alterar o comportamento em tempo de execução do pacote. 
- Entregar a correção como atualização do port através do incremento do `PORTREVISION`.

### Description

- Adicionei entradas não vazias `<addedit_string>` e `<delete_string>` em todos os 18 arquivos XML de GUI do pacote localizados em `files/usr/local/pkg` para fornecer descrições usadas ao chamar `write_config()`. 
- Atualizei o `Makefile` para `PORTREVISION=1` para que a mudança seja distribuída como atualização do port. 
- Nenhum código PHP/INC ou lógica do E2guardian foi alterado; a modificação é estritamente metadados (strings de descrição). 
- As descrições adicionadas são simples e genéricas (por exemplo, `E2guardian: changed settings.` e `E2guardian: removed a configuration item.`) para evitar impacto funcional.

### Testing

- Rodei `php -l` em todos os arquivos PHP/INC do pacote e não houve erros de sintaxe. 
- Parsei os 18 XMLs com Python (`xml.etree.ElementTree`) e verifiquei que `addedit_string` e `delete_string` estão presentes e não vazios em todos os `packagegui`. 
- Executei o teste de fumaça PHP `php www/Kontrol-pkg-E2guardian54/tests/blacklist_extract_smoke.php` e todos os cenários cobertos pelo teste passaram. 
- Rodei `git diff --check` para checar espaços/erros; `portlint` não estava disponível no ambiente e por isso foi ignorado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cdf069548832e887ddfea3832ad9d)