### PR TITLE
e2guardian54: bump port revision, tighten cron install args, add XML change strings

### DIFF
--- a/www/Kontrol-pkg-E2guardian54/Makefile
+++ b/www/Kontrol-pkg-E2guardian54/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	Kontrol-pkg-E2guardian54
 PORTVERSION=	6.6.26
-PORTREVISION=	# empty
+PORTREVISION=	1
 CATEGORIES=	www
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.inc
@@ -2432,11 +2432,11 @@ EOF;
 function e2g_check_cron($cron_cmd, $action, $min = "*", $hour = "*", $mday = "*", $month = "*", $wday = "*"){
 
 	//Remove current job
-	install_cron_job ($cron_cmd, false);
-	install_cron_job ($cron_cmd . ' > /dev/null', false);
+	install_cron_job($cron_cmd, false, "0", "*", "*", "*", "*", "root", false);
+	install_cron_job($cron_cmd . ' > /dev/null', false, "0", "*", "*", "*", "*", "root", false);
 	if ($action == "create") {
 		//Install a new job
-		install_cron_job ($cron_cmd . ' > /dev/null', true, $min, $hour, $mday, $month, $wday , "root");
+		install_cron_job($cron_cmd . ' > /dev/null', true, $min, $hour, $mday, $month, $wday, "root", false);
 	}
 }
 

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian.xml
@@ -32,6 +32,8 @@
 	<name>e2guardian</name>
 	<version>0.9.2</version>
 	<title>Services: E2guardian</title>
+	<delete_string>E2guardian: removed a configuration item.</delete_string>
+	<addedit_string>E2guardian: changed settings.</addedit_string>
 	<include_file>/usr/local/pkg/e2guardian.inc</include_file>
 	<menu>
 		<name>E2guardian Proxy</name>

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_antivirus_acl.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_antivirus_acl.xml
@@ -31,6 +31,8 @@
 	<name>e2guardianantivirusacl</name>
 	<version>1.0</version>
 	<title>Services: E2guardian - Access Lists</title>
+	<delete_string>E2guardian: removed a configuration item.</delete_string>
+	<addedit_string>E2guardian: changed settings.</addedit_string>
 	<include_file>/usr/local/pkg/e2guardian.inc</include_file>
 	<tabs>
 		<tab>

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_blacklist.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_blacklist.xml
@@ -32,6 +32,8 @@
 	<name>e2guardianblacklist</name>
 	<version>1.0</version>
 	<title>Services: E2guardian</title>
+	<delete_string>E2guardian: removed a configuration item.</delete_string>
+	<addedit_string>E2guardian: changed settings.</addedit_string>
 	<include_file>/usr/local/pkg/e2guardian.inc</include_file>
 	<tabs>
 		<tab>

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_config.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_config.xml
@@ -32,6 +32,8 @@
 	<name>e2guardianconfig</name>
 	<version>1.0</version>
 	<title>Services: E2guardian</title>
+	<delete_string>E2guardian: removed a configuration item.</delete_string>
+	<addedit_string>E2guardian: changed settings.</addedit_string>
 	<include_file>/usr/local/pkg/e2guardian.inc</include_file>
 	<tabs>
 		<tab>

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_content_acl.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_content_acl.xml
@@ -31,6 +31,8 @@
 	<name>e2guardiancontentacl</name>
 	<version>1.0</version>
 	<title>Services: E2guardian - Access Lists</title>
+	<delete_string>E2guardian: removed a configuration item.</delete_string>
+	<addedit_string>E2guardian: changed settings.</addedit_string>
 	<include_file>/usr/local/pkg/e2guardian.inc</include_file>
 	<tabs>
 		<tab>

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_file_acl.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_file_acl.xml
@@ -31,6 +31,8 @@
 	<name>e2guardianfileacl</name>
 	<version>1.0</version>
 	<title>Services: E2guardian - Access Lists</title>
+	<delete_string>E2guardian: removed a configuration item.</delete_string>
+	<addedit_string>E2guardian: changed settings.</addedit_string>
 	<include_file>/usr/local/pkg/e2guardian.inc</include_file>
 	<tabs>
 		<tab>

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_groups.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_groups.xml
@@ -31,6 +31,8 @@
 	<name>e2guardiangroups</name>
 	<version>1.0</version>
 	<title>Services: E2guardian</title>
+	<delete_string>E2guardian: removed a configuration item.</delete_string>
+	<addedit_string>E2guardian: changed settings.</addedit_string>
 	<include_file>/usr/local/pkg/e2guardian.inc</include_file>
 	<tabs>
 		<tab>

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_header_acl.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_header_acl.xml
@@ -31,6 +31,8 @@
 	<name>e2guardianheaderacl</name>
 	<version>1.0</version>
 	<title>Services: E2guardian - Access Lists</title>
+	<delete_string>E2guardian: removed a configuration item.</delete_string>
+	<addedit_string>E2guardian: changed settings.</addedit_string>
 	<include_file>/usr/local/pkg/e2guardian.inc</include_file>
 	<tabs>
 		<tab>

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_ips.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_ips.xml
@@ -32,6 +32,8 @@
 	<name>e2guardianips</name>
 	<version>1.0</version>
 	<title>Services: E2guardian</title>
+	<delete_string>E2guardian: removed a configuration item.</delete_string>
+	<addedit_string>E2guardian: changed settings.</addedit_string>
 	<include_file>/usr/local/pkg/e2guardian.inc</include_file>
 	<tabs>
 		<tab>

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_ldap.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_ldap.xml
@@ -31,6 +31,8 @@
 	<name>e2guardianldap</name>
 	<version>1.0</version>
 	<title>Services: E2guardian</title>
+	<delete_string>E2guardian: removed a configuration item.</delete_string>
+	<addedit_string>E2guardian: changed settings.</addedit_string>
 	<include_file>/usr/local/pkg/e2guardian.inc</include_file>
 	<tabs>
 		<tab>

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_limits.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_limits.xml
@@ -32,6 +32,8 @@
 	<name>e2guardianlimits</name>
 	<version>1.0</version>
 	<title>Services: E2guardian</title>
+	<delete_string>E2guardian: removed a configuration item.</delete_string>
+	<addedit_string>E2guardian: changed settings.</addedit_string>
 	<include_file>/usr/local/pkg/e2guardian.inc</include_file>
 	<tabs>
 		<tab>

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_log.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_log.xml
@@ -32,6 +32,8 @@
 	<name>e2guardianlog</name>
 	<version>1.0</version>
 	<title>Services: E2guardian</title>
+	<delete_string>E2guardian: removed a configuration item.</delete_string>
+	<addedit_string>E2guardian: changed settings.</addedit_string>
 	<include_file>/usr/local/pkg/e2guardian.inc</include_file>
 	<tabs>
 		<tab>

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_phrase_acl.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_phrase_acl.xml
@@ -31,6 +31,8 @@
 	<name>e2guardianphraseacl</name>
 	<version>1.0</version>
 	<title>Services: E2guardian - Access Lists</title>
+	<delete_string>E2guardian: removed a configuration item.</delete_string>
+	<addedit_string>E2guardian: changed settings.</addedit_string>
 	<include_file>/usr/local/pkg/e2guardian.inc</include_file>
 	<tabs>
 		<tab>

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_search_acl.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_search_acl.xml
@@ -31,6 +31,8 @@
 	<name>e2guardiansearchacl</name>
 	<version>1.0</version>
 	<title>Services: E2guardian - Access Lists</title>
+	<delete_string>E2guardian: removed a configuration item.</delete_string>
+	<addedit_string>E2guardian: changed settings.</addedit_string>
 	<include_file>/usr/local/pkg/e2guardian.inc</include_file>
 	<tabs>
 		<tab>

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_site_acl.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_site_acl.xml
@@ -31,6 +31,8 @@
 	<name>e2guardiansiteacl</name>
 	<version>1.0</version>
 	<title>Services: E2guardian - Access Lists</title>
+	<delete_string>E2guardian: removed a configuration item.</delete_string>
+	<addedit_string>E2guardian: changed settings.</addedit_string>
 	<include_file>/usr/local/pkg/e2guardian.inc</include_file>
 	<tabs>
 		<tab>

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_sync.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_sync.xml
@@ -32,6 +32,8 @@
 	<name>e2guardiansync</name>
 	<version>1.0</version>
 	<title>Services: E2guardian</title>
+	<delete_string>E2guardian: removed a configuration item.</delete_string>
+	<addedit_string>E2guardian: changed settings.</addedit_string>
 	<include_file>/usr/local/pkg/e2guardian.inc</include_file>
 	<tabs>
 		<tab>

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_url_acl.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_url_acl.xml
@@ -31,6 +31,8 @@
 	<name>e2guardianurlacl</name>
 	<version>1.0</version>
 	<title>Services: E2guardian - Access Lists</title>
+	<delete_string>E2guardian: removed a configuration item.</delete_string>
+	<addedit_string>E2guardian: changed settings.</addedit_string>
 	<include_file>/usr/local/pkg/e2guardian.inc</include_file>
 	<tabs>
 		<tab>

--- a/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_users.xml
+++ b/www/Kontrol-pkg-E2guardian54/files/usr/local/pkg/e2guardian_users.xml
@@ -32,6 +32,8 @@
 	<name>e2guardianusers</name>
 	<version>1.0</version>
 	<title>Services: E2guardian</title>
+	<delete_string>E2guardian: removed a configuration item.</delete_string>
+	<addedit_string>E2guardian: changed settings.</addedit_string>
 	<include_file>/usr/local/pkg/e2guardian.inc</include_file>
 	<tabs>
 		<tab>


### PR DESCRIPTION
### Motivation

- Ensure cron jobs are installed/removed with the explicit signature (user and flags) to avoid ambiguous behavior across environments. 
- Surface concise change messages in the package XMLs so UI notifications can show meaningful text when items are added/edited/removed. 
- Force a package revision bump to trigger rebuilds after the behavior and metadata changes. 

### Description

- Set `PORTREVISION` to `1` in `www/Kontrol-pkg-E2guardian54/Makefile` to bump the port revision. 
- Update `e2guardian.inc` `e2g_check_cron` function to call `install_cron_job` with explicit arguments including user `root` and final `false` flag when removing/creating jobs, and use `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cdf069548832e887ddfea3832ad9d)